### PR TITLE
Add multi-output support to StreamingCNN forward/backward tiling

### DIFF
--- a/examples/compare_grads_resnet.py
+++ b/examples/compare_grads_resnet.py
@@ -33,12 +33,9 @@ def _compare_grads(stream_grads: dict[str, torch.Tensor], normal_grads: dict[str
     print(f"Comparing {len(shared)} parameter gradients:")
     for name in shared:
         diff = (stream_grads[name] - normal_grads[name]).abs()
-        denom = normal_grads[name].abs().clamp_min(1e-12)
-        rel = diff / denom
         print(
             f"{name}: "
             f"mean abs diff={diff.mean().item():.6e}, max abs diff={diff.max().item():.6e}, "
-            f"mean rel diff={rel.mean().item():.6e}, max rel diff={rel.max().item():.6e}"
         )
 
 
@@ -63,6 +60,7 @@ def _compare_conv_weight_grads(
             f"{name}: "
             f"stream mean abs={stream_grad.abs().mean().item():.6e}, "
             f"normal mean abs={normal_grad.abs().mean().item():.6e}, "
+            f"mean abs diff={stream_grad.abs().mean().item() - normal_grad.abs().mean().item():.6e}, "
             f"max abs diff={diff.max().item():.6e}"
         )
 
@@ -77,6 +75,14 @@ def _parse_dtype(value: str) -> torch.dtype:
     if key not in mapping:
         raise ValueError(f"Unsupported dtype '{value}'. Choose from: {', '.join(mapping.keys())}")
     return mapping[key]
+
+
+def _freeze_batchnorm(module: nn.Module) -> None:
+    for submodule in module.modules():
+        if isinstance(submodule, nn.BatchNorm2d):
+            submodule.eval()
+            for param in submodule.parameters():
+                param.requires_grad = False
 
 
 def main() -> None:
@@ -94,47 +100,54 @@ def main() -> None:
     input_size = args.input_size
 
     img = torch.rand((1, 3, input_size, input_size), device=device, dtype=dtype)
+    target = torch.tensor(50., device=device, dtype=dtype)  # large value so we get larger gradients
+    criterion = torch.nn.MSELoss()
 
     network = StreamingResNet(
         "resnet18",
         tile_size,
-        additional_modules=torch.nn.MaxPool2d((2, 2)),
+        remove_last_block=False,
         mean=[0, 0, 0],
         std=[1, 1, 1],
         normalize_on_gpu=False,
-        tile_cache_path="/data/temporary/stephan/lightstream/examples/resnet18_vanilla_tile_cache_1_3_3200_3200"
-    )
-    network.to(device, dtype=dtype)
+        saliency=True,
+    ).to(device=device, dtype=dtype)
     network.stream_network.device = device
+    network.stream_network.dtype = dtype
     network.stream_network.mean = network.stream_network.mean.to(device=device, dtype=dtype)
     network.stream_network.std = network.stream_network.std.to(device=device, dtype=dtype)
-    network.eval()
-    #_zero_grads(network.stream_network.stream_module.parameters())
+    _freeze_batchnorm(network.stream_network.stream_module)
+
+    _zero_grads(network.stream_network.stream_module.parameters())
     stream_output = network(img)
-    # target_value = 50.0
-    # target = torch.full_like(stream_output, fill_value=target_value)
-    # stream_grad = 2 * (stream_output - target) / stream_output.numel()
-    # network.stream_network.backward(img, stream_grad)
-    # streaming_param_grads = _gather_param_grads(network.stream_network.stream_module)
+    stream_output.requires_grad = True
+    y_pred_streaming = torch.sigmoid(torch.mean(stream_output))
+    loss = criterion(y_pred_streaming, target)
+    loss.backward()
+    full_gradients = network.stream_network.backward(img, stream_output.grad)
+    streaming_param_grads = _gather_param_grads(network.stream_network.stream_module)
+
 
     network.stream_network.disable()
     normal_net = network.stream_network.stream_module
-    #_zero_grads(normal_net.parameters())
+    _freeze_batchnorm(normal_net)
+    _zero_grads(normal_net.parameters())
     img_normal = img.detach().clone().requires_grad_(True)
     normal_output = normal_net(img_normal)
     forward_diff = (stream_output - normal_output).abs()
     print(f"Forward output sum/max diff: {forward_diff.sum().item()}, {forward_diff.max().item()}")
 
-    #normal_loss = torch.nn.functional.mse_loss(normal_output, torch.full_like(normal_output, target_value))
-    #normal_loss.backward()
-    #normal_param_grads = _gather_param_grads(normal_net)
+    y_pred_normal=torch.sigmoid(torch.mean(normal_output))
+    normal_loss = criterion(y_pred_normal, target)
+    normal_loss.backward()
+    normal_param_grads = _gather_param_grads(normal_net)
 
-    #if img_normal.grad is not None:
-    #    input_grad_diff = img_normal.grad.detach().cpu().numpy() - network.stream_network.saliency_map[0].numpy()
-    #    print(f"Input gradient max diff: {input_grad_diff.max()}")
+    if img_normal.grad is not None:
+        input_grad_diff = img_normal.grad.detach().cpu().numpy() - network.stream_network.saliency_map[0].numpy()
+        print(f"Input gradient max diff: {input_grad_diff.max()}")
 
-    #_compare_grads(streaming_param_grads, normal_param_grads)
-    #_compare_conv_weight_grads(streaming_param_grads, normal_param_grads)
+    _compare_grads(streaming_param_grads, normal_param_grads)
+    _compare_conv_weight_grads(streaming_param_grads, normal_param_grads)
 
 
 if __name__ == "__main__":

--- a/examples/compare_grads_segment.py
+++ b/examples/compare_grads_segment.py
@@ -1,0 +1,240 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Callable, Iterable
+import argparse
+
+import torch
+import torch.nn as nn
+from torch.nn import Sequential
+from torchvision.models import resnet18, resnet34, resnet50
+
+from lightstream.modules.streaming import StreamingModule
+from lightstream.models.segment.model import WSS
+
+
+class StreamingWSS(StreamingModule):
+    def __init__(
+        self,
+        encoder: str,
+        tile_size: int,
+        additional_modules: nn.Module | None = None,
+        remove_last_block: bool = True,
+        verbose: bool = True,
+        deterministic: bool = True,
+        saliency: bool = False,
+        copy_to_gpu: bool = False,
+        statistics_on_cpu: bool = True,
+        normalize_on_gpu: bool = True,
+        mean: list | None = None,
+        std: list | None = None,
+        tile_cache_path: Path | None = None,
+    ):
+        model_choices = self.get_model_choices()
+
+        if encoder not in model_choices:
+            raise ValueError(f"Invalid model name '{encoder}'. Choose one of: {', '.join(model_choices.keys())}")
+
+        if additional_modules is not None:
+            stream_network = Sequential(
+                WSS(encoder=encoder, weights="default", remove_last_block=remove_last_block),
+                additional_modules,
+            )
+        else:
+            stream_network = WSS(encoder=encoder, weights="default", remove_last_block=remove_last_block)
+
+        if mean is None:
+            mean = [0.485, 0.456, 0.406]
+        if std is None:
+            std = [0.229, 0.224, 0.225]
+
+        if tile_cache_path is None:
+            tile_cache_path = Path.cwd() / Path(f"{encoder}_tile_cache_1_3_{str(tile_size)}_{str(tile_size)}")
+
+        super().__init__(
+            stream_network,
+            tile_size,
+            tile_cache_path,
+            verbose=verbose,
+            deterministic=deterministic,
+            saliency=saliency,
+            copy_to_gpu=copy_to_gpu,
+            statistics_on_cpu=statistics_on_cpu,
+            normalize_on_gpu=normalize_on_gpu,
+            mean=mean,
+            std=std,
+            add_keep_modules=[nn.BatchNorm2d],
+        )
+
+    @staticmethod
+    def get_model_choices() -> dict[str, Callable[..., nn.Module]]:
+        return {
+            "resnet18": resnet18,
+            "resnet34": resnet34,
+            "resnet50": resnet50,
+        }
+
+    @classmethod
+    def get_model_names(cls) -> list[str]:
+        return list(cls.get_model_choices().keys())
+
+
+def _gather_param_grads(model: nn.Module) -> dict[str, torch.Tensor]:
+    grads: dict[str, torch.Tensor] = {}
+    for name, param in model.named_parameters():
+        if param.grad is not None:
+            grads[name] = param.grad.detach().clone()
+    return grads
+
+
+def _zero_grads(parameters: Iterable[torch.nn.Parameter]) -> None:
+    for param in parameters:
+        if param.grad is not None:
+            param.grad.detach_()
+            param.grad.zero_()
+
+
+def _compare_grads(stream_grads: dict[str, torch.Tensor], normal_grads: dict[str, torch.Tensor]) -> None:
+    shared = sorted(set(stream_grads.keys()) & set(normal_grads.keys()))
+    if not shared:
+        print("No overlapping gradients found to compare.")
+        return
+
+    print(f"Comparing {len(shared)} parameter gradients:")
+    for name in shared:
+        diff = (stream_grads[name] - normal_grads[name]).abs()
+        print(
+            f"{name}: "
+            f"mean abs diff={diff.mean().item():.6e}, max abs diff={diff.max().item():.6e}, "
+        )
+
+
+def _compare_conv_weight_grads(
+    stream_grads: dict[str, torch.Tensor], normal_grads: dict[str, torch.Tensor]
+) -> None:
+    conv_names = sorted(
+        name
+        for name, grad in stream_grads.items()
+        if name in normal_grads and grad.ndim == 4 and "conv" in name
+    )
+    if not conv_names:
+        print("No convolution weight gradients found to compare.")
+        return
+
+    print("\nConvolution kernel gradient stats:")
+    for name in conv_names:
+        stream_grad = stream_grads[name]
+        normal_grad = normal_grads[name]
+        diff = (stream_grad - normal_grad).abs()
+        print(
+            f"{name}: "
+            f"stream mean abs={stream_grad.abs().mean().item():.6e}, "
+            f"normal mean abs={normal_grad.abs().mean().item():.6e}, "
+            f"mean abs diff={stream_grad.abs().mean().item() - normal_grad.abs().mean().item():.6e}, "
+            f"max abs diff={diff.max().item():.6e}"
+        )
+
+
+def _parse_dtype(value: str) -> torch.dtype:
+    mapping = {
+        "float16": torch.float16,
+        "float32": torch.float32,
+        "float64": torch.float64,
+    }
+    key = value.lower()
+    if key not in mapping:
+        raise ValueError(f"Unsupported dtype '{value}'. Choose from: {', '.join(mapping.keys())}")
+    return mapping[key]
+
+
+def _freeze_batchnorm(module: nn.Module) -> None:
+    for submodule in module.modules():
+        if isinstance(submodule, nn.BatchNorm2d):
+            submodule.eval()
+            for param in submodule.parameters():
+                param.requires_grad = False
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Compare streaming vs non-streaming backward gradients for WSS.")
+    parser.add_argument("--dtype", default="float64", help="float16, float32, or float64")
+    parser.add_argument("--tile-size", type=int, default=1920)
+    parser.add_argument("--input-size", type=int, default=2560)
+    args = parser.parse_args()
+
+    torch.manual_seed(0)
+
+    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    dtype = _parse_dtype(args.dtype)
+    tile_size = args.tile_size
+    input_size = args.input_size
+
+    img = torch.rand((1, 3, input_size, input_size), device=device, dtype=dtype)
+    target = torch.tensor(50.0, device=device, dtype=dtype)
+    criterion = torch.nn.MSELoss()
+
+    network = StreamingWSS(
+        "resnet18",
+        tile_size,
+        additional_modules=None,
+        mean=[0, 0, 0],
+        std=[1, 1, 1],
+        normalize_on_gpu=False,
+        saliency=True,
+    ).to(device=device, dtype=dtype)
+    network.stream_network.device = device
+    network.stream_network.dtype = dtype
+    network.stream_network.mean = network.stream_network.mean.to(device=device, dtype=dtype)
+    network.stream_network.std = network.stream_network.std.to(device=device, dtype=dtype)
+
+    # Valid StreamingCNN debug information
+    print("output_spec:", network.stream_network._output_spec)
+    print(
+        "output_stride_per_output:",
+        [tuple(int(x) for x in s.tolist()) for s in network.stream_network._output_stride_per_output],
+    )
+
+    _freeze_batchnorm(network.stream_network.stream_module)
+
+    _zero_grads(network.stream_network.stream_module.parameters())
+    stream_outputs = network(img)
+    for out in stream_outputs:
+        out.requires_grad = True
+        out.retain_grad()
+
+    y_pred_streaming = [torch.sigmoid(torch.mean(x)) for x in stream_outputs]
+    loss = [criterion(x, target) for x in y_pred_streaming]
+    total_loss = sum(loss)
+    total_loss.backward()
+    output_grads = tuple(out.grad for out in stream_outputs)
+    network.stream_network.backward(img, output_grads)
+
+    streaming_param_grads = _gather_param_grads(network.stream_network.stream_module)
+
+    network.stream_network.disable()
+    normal_net = network.stream_network.stream_module
+    _freeze_batchnorm(normal_net)
+    _zero_grads(normal_net.parameters())
+    img_normal = img.detach().clone().requires_grad_(True)
+    normal_outputs = normal_net(img_normal)
+
+    for stream_out, normal_out in zip(stream_outputs, normal_outputs):
+        diff = (stream_out - normal_out).abs()
+        print(f"Forward output sum/max diff: {diff.sum().item()}, {diff.max().item()}")
+
+    y_pred_normal = [torch.sigmoid(torch.mean(x)) for x in normal_outputs]
+    normal_loss = [criterion(x, target) for x in y_pred_normal]
+    total_loss = sum(normal_loss)
+    total_loss.backward()
+    normal_param_grads = _gather_param_grads(normal_net)
+
+    if img_normal.grad is not None:
+        input_grad_diff = img_normal.grad.detach().cpu().numpy() - network.stream_network.saliency_map[0].numpy()
+        print(f"Input gradient max diff: {input_grad_diff.max()}")
+
+    _compare_grads(streaming_param_grads, normal_param_grads)
+    _compare_conv_weight_grads(streaming_param_grads, normal_param_grads)
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/grad_compare_testnet.py
+++ b/examples/grad_compare_testnet.py
@@ -36,6 +36,7 @@ def _compare_grads(stream_grads: dict[str, torch.Tensor], normal_grads: dict[str
         print(
             f"{name}: "
             f"mean abs diff={diff.mean().item():.6e}, max abs diff={diff.max().item():.6e}, "
+
         )
 
 
@@ -45,7 +46,7 @@ def _compare_conv_weight_grads(
     conv_names = sorted(
         name
         for name, grad in stream_grads.items()
-        if name in normal_grads and grad.ndim == 4 and "conv" in name
+        if name in normal_grads
     )
     if not conv_names:
         print("No convolution weight gradients found to compare.")
@@ -60,6 +61,7 @@ def _compare_conv_weight_grads(
             f"{name}: "
             f"stream mean abs={stream_grad.abs().mean().item():.6e}, "
             f"normal mean abs={normal_grad.abs().mean().item():.6e}, "
+            f"mean abs diff={stream_grad.abs().mean().item() - normal_grad.abs().mean().item():.6e}, "
             f"max abs diff={diff.max().item():.6e}"
         )
 
@@ -78,9 +80,9 @@ def _parse_dtype(value: str) -> torch.dtype:
 
 def main() -> None:
     parser = argparse.ArgumentParser(description="Compare streaming vs non-streaming backward gradients for ResNet18.")
-    parser.add_argument("--dtype", default="float32", help="float16, float32, or float64")
-    parser.add_argument("--tile-size", type=int, default=3200)
-    parser.add_argument("--input-size", type=int, default=4800)
+    parser.add_argument("--dtype", default="float64", help="float16, float32, or float64")
+    parser.add_argument("--tile-size", type=int, default=512)
+    parser.add_argument("--input-size", type=int, default=1024)
     args = parser.parse_args()
 
     torch.manual_seed(0)
@@ -91,6 +93,8 @@ def main() -> None:
     input_size = args.input_size
 
     img = torch.rand((1, 3, input_size, input_size), device=device, dtype=dtype)
+    target = torch.tensor(50., device=device, dtype=dtype)  # large value so we get larger gradients
+    criterion = torch.nn.MSELoss()
 
     network = StreamingTestNet(
         tile_size,
@@ -100,26 +104,32 @@ def main() -> None:
         saliency=True,
     ).to(device=device, dtype=dtype)
     network.stream_network.device = device
+    network.stream_network.dtype = dtype
     network.stream_network.mean = network.stream_network.mean.to(device=device, dtype=dtype)
     network.stream_network.std = network.stream_network.std.to(device=device, dtype=dtype)
 
     _zero_grads(network.stream_network.stream_module.parameters())
     stream_output = network(img)
-    target_value = 50.0
-    target = torch.full_like(stream_output, fill_value=target_value)
-    stream_grad = 2 * (stream_output - target) / stream_output.numel()
-    network.stream_network.backward(img, stream_grad)
+    stream_output.requires_grad = True
+
+    y_pred_streaming = torch.sigmoid(torch.mean(stream_output))
+    loss = criterion(y_pred_streaming, target)
+    loss.backward()
+    full_gradients = network.stream_network.backward(img, stream_output.grad)
     streaming_param_grads = _gather_param_grads(network.stream_network.stream_module)
 
+
+    ## normal model
     network.stream_network.disable()
     normal_net = network.stream_network.stream_module
     _zero_grads(normal_net.parameters())
     img_normal = img.detach().clone().requires_grad_(True)
     normal_output = normal_net(img_normal)
+
     forward_diff = (stream_output - normal_output).sum().item()
     print(f"Forward output sum diff: {forward_diff}")
-
-    normal_loss = torch.nn.functional.mse_loss(normal_output, torch.full_like(normal_output, target_value))
+    y_pred_normal=torch.sigmoid(torch.mean(normal_output))
+    normal_loss = criterion(y_pred_normal, target)
     normal_loss.backward()
     normal_param_grads = _gather_param_grads(normal_net)
 
@@ -129,7 +139,6 @@ def main() -> None:
 
     _compare_grads(streaming_param_grads, normal_param_grads)
     _compare_conv_weight_grads(streaming_param_grads, normal_param_grads)
-
 
 if __name__ == "__main__":
     main()

--- a/lightstream/core/constructor.py
+++ b/lightstream/core/constructor.py
@@ -14,7 +14,7 @@ import torch
 import torch.nn as nn
 
 from copy import deepcopy
-from core.scnn.scnn import StreamingCNN
+from lightstream.core.scnn.scnn import StreamingCNN
 from typing import Callable, Optional, Any
 
 

--- a/lightstream/core/scnn/scnn.py
+++ b/lightstream/core/scnn/scnn.py
@@ -627,7 +627,44 @@ class StreamingCNN(torch.nn.Module):
         if grad_spec != self._output_spec:
             raise ValueError("Gradient output structure does not match streaming output structure")
 
-        if len(self._tile_output_shapes) > 1 and self._last_forward_tiles:
+        if len(self._tile_output_shapes) == 1:
+            grad_lost = self.tile_gradient_lost
+            output_height = self._tile_output_shape[H_DIM]
+            output_width = self._tile_output_shape[W_DIM]
+            valid_grad_height = (tile_height - grad_lost.top - grad_lost.bottom) // int(self.output_stride[1])
+            valid_grad_height *= int(self.output_stride[1])
+            valid_grad_width = (tile_width - grad_lost.left - grad_lost.right) // int(self.output_stride[2])
+            valid_grad_width *= int(self.output_stride[2])
+
+            n_rows = math.ceil(float(height - grad_lost.top - grad_lost.bottom) / float(valid_grad_height))
+            n_cols = math.ceil(float(width - grad_lost.left - grad_lost.right) / float(valid_grad_width))
+
+            if image.shape[W_DIM] <= tile_width:
+                n_cols = 1
+            if image.shape[H_DIM] <= tile_height:
+                n_rows = 1
+
+            base_grad = grad_tensors[0]
+            tile_iter = []
+            for row in range(n_rows):
+                for col in range(n_cols):
+                    output_y = row * valid_grad_height // int(self.output_stride[1])
+                    output_x = col * valid_grad_width // int(self.output_stride[2])
+
+                    sides_top = True if row == 0 else False
+                    sides_left = True if col == 0 else False
+                    sides_bottom = True if output_y + output_height >= base_grad.shape[H_DIM] else False
+                    sides_right = True if output_x + output_width >= base_grad.shape[W_DIM] else False
+
+                    if sides_bottom:
+                        output_y = max(base_grad.shape[H_DIM] - output_height, 0)
+                    if sides_right:
+                        output_x = max(base_grad.shape[W_DIM] - output_width, 0)
+
+                    input_y = output_y * int(self.output_stride[1])
+                    input_x = output_x * int(self.output_stride[2])
+                    tile_iter.append((int(input_y), int(input_x), Sides(sides_left, sides_top, sides_right, sides_bottom)))
+        elif self._last_forward_tiles:
             tile_iter = self._last_forward_tiles
         else:
             tile_iter = []

--- a/lightstream/core/scnn/scnn.py
+++ b/lightstream/core/scnn/scnn.py
@@ -187,16 +187,6 @@ class StreamingCNN(torch.nn.Module):
             else:
                 output_stride = torch.tensor([1, 1, 1])
 
-            # Some branches include upsampling layers that are intentionally not
-            # part of streaming statistics hooks. Infer effective spatial stride
-            # from tile/output shapes so multi-head decoders can share a common
-            # final output stride when appropriate.
-            effective_h = max(1, int(round(float(tile.shape[H_DIM]) / float(out.shape[H_DIM]))))
-            effective_w = max(1, int(round(float(tile.shape[W_DIM]) / float(out.shape[W_DIM]))))
-            output_stride = output_stride.clone()
-            output_stride[1] = min(int(output_stride[1]), effective_h)
-            output_stride[2] = min(int(output_stride[2]), effective_w)
-
             self._output_stride_per_output.append(output_stride)
 
         if len(self._output_stride_per_output) > 1:

--- a/lightstream/core/scnn/scnn.py
+++ b/lightstream/core/scnn/scnn.py
@@ -261,6 +261,32 @@ class StreamingCNN(torch.nn.Module):
             return values, index
         raise TypeError(f"Unsupported output spec kind: {kind}")
 
+    def _compute_multi_output_input_step(self, valid_output_heights, valid_output_widths):
+        step_candidates_h = [
+            valid_output_heights[idx] * int(self._output_stride_per_output[idx][1])
+            for idx in range(len(self._tile_output_shapes))
+        ]
+        step_candidates_w = [
+            valid_output_widths[idx] * int(self._output_stride_per_output[idx][2])
+            for idx in range(len(self._tile_output_shapes))
+        ]
+
+        # Extra safety from backward statistics (input gradient valid region)
+        grad_safe_h = self.tile_shape[H_DIM] - self.tile_gradient_lost.top - self.tile_gradient_lost.bottom
+        grad_safe_w = self.tile_shape[W_DIM] - self.tile_gradient_lost.left - self.tile_gradient_lost.right
+        step_candidates_h.append(int(grad_safe_h))
+        step_candidates_w.append(int(grad_safe_w))
+
+        align_h = 1
+        align_w = 1
+        for stride in self._output_stride_per_output:
+            align_h = math.lcm(align_h, int(stride[1]))
+            align_w = math.lcm(align_w, int(stride[2]))
+
+        valid_input_height = max(align_h, (min(step_candidates_h) // align_h) * align_h)
+        valid_input_width = max(align_w, (min(step_candidates_w) // align_w) * align_w)
+        return valid_input_height, valid_input_width
+
     def _convert_modules_for_streaming(self, module):
         mod = module
         if isinstance(module, torch.nn.Conv2d):
@@ -426,22 +452,20 @@ class StreamingCNN(torch.nn.Module):
         ]
         already_filled = [Box(0, 0, 0, 0, None) for _ in range(len(self._tile_output_shapes))]
 
-        step_candidates_h = [
-            valid_output_heights[idx] * int(self._output_stride_per_output[idx][1])
-            for idx in range(len(self._tile_output_shapes))
-        ]
-        step_candidates_w = [
-            valid_output_widths[idx] * int(self._output_stride_per_output[idx][2])
-            for idx in range(len(self._tile_output_shapes))
-        ]
-        align_h = 1
-        align_w = 1
-        for stride in self._output_stride_per_output:
-            align_h = math.lcm(align_h, int(stride[1]))
-            align_w = math.lcm(align_w, int(stride[2]))
-
-        valid_input_height = max(align_h, (min(step_candidates_h) // align_h) * align_h)
-        valid_input_width = max(align_w, (min(step_candidates_w) // align_w) * align_w)
+        if len(self._tile_output_shapes) > 1:
+            valid_input_height, valid_input_width = self._compute_multi_output_input_step(
+                valid_output_heights,
+                valid_output_widths,
+            )
+        else:
+            valid_input_height = max(
+                1,
+                valid_output_heights[0] * int(self._output_stride_per_output[0][1]),
+            )
+            valid_input_width = max(
+                1,
+                valid_output_widths[0] * int(self._output_stride_per_output[0][2]),
+            )
         n_rows = math.ceil(float(max(1, image.shape[H_DIM] - self.tile_shape[H_DIM])) / float(valid_input_height)) + 1
         n_cols = math.ceil(float(max(1, image.shape[W_DIM] - self.tile_shape[W_DIM])) / float(valid_input_width)) + 1
 
@@ -587,22 +611,20 @@ class StreamingCNN(torch.nn.Module):
         base_stride_h = int(self._base_output_stride[1])
         base_stride_w = int(self._base_output_stride[2])
 
-        step_candidates_h = [
-            valid_output_heights[idx] * int(self._output_stride_per_output[idx][1])
-            for idx in range(len(self._tile_output_shapes))
-        ]
-        step_candidates_w = [
-            valid_output_widths[idx] * int(self._output_stride_per_output[idx][2])
-            for idx in range(len(self._tile_output_shapes))
-        ]
-        align_h = 1
-        align_w = 1
-        for stride in self._output_stride_per_output:
-            align_h = math.lcm(align_h, int(stride[1]))
-            align_w = math.lcm(align_w, int(stride[2]))
-
-        valid_input_height = max(align_h, (min(step_candidates_h) // align_h) * align_h)
-        valid_input_width = max(align_w, (min(step_candidates_w) // align_w) * align_w)
+        if len(self._tile_output_shapes) > 1:
+            valid_input_height, valid_input_width = self._compute_multi_output_input_step(
+                valid_output_heights,
+                valid_output_widths,
+            )
+        else:
+            valid_input_height = max(
+                1,
+                valid_output_heights[0] * int(self._output_stride_per_output[0][1]),
+            )
+            valid_input_width = max(
+                1,
+                valid_output_widths[0] * int(self._output_stride_per_output[0][2]),
+            )
 
         n_rows = math.ceil(float(max(1, height - tile_height)) / float(valid_input_height)) + 1
         n_cols = math.ceil(float(max(1, width - tile_width)) / float(valid_input_width)) + 1

--- a/lightstream/core/scnn/scnn.py
+++ b/lightstream/core/scnn/scnn.py
@@ -627,7 +627,7 @@ class StreamingCNN(torch.nn.Module):
         if grad_spec != self._output_spec:
             raise ValueError("Gradient output structure does not match streaming output structure")
 
-        if self._last_forward_tiles:
+        if len(self._tile_output_shapes) > 1 and self._last_forward_tiles:
             tile_iter = self._last_forward_tiles
         else:
             tile_iter = []

--- a/lightstream/core/scnn/scnn.py
+++ b/lightstream/core/scnn/scnn.py
@@ -91,6 +91,10 @@ class StreamingCNN(torch.nn.Module):
         self.should_normalize = normalize_on_gpu
 
         self._tile_output_shape = None
+        self._tile_output_shapes = None
+        self._tile_output_lost = None
+        self._output_stride_per_output = None
+        self._output_spec = None
         self._module_stats = {}
         self._backward_seen_indices = {}
         self._saved_tensors = {}
@@ -158,26 +162,40 @@ class StreamingCNN(torch.nn.Module):
         # Forward pass with grads enabled
         torch.set_grad_enabled(True)
         output = self.stream_module(tile)
+        output_tensors, output_spec = self._flatten_output_structure(output)
+        self._output_spec = output_spec
 
         # Gather backward statistics
-        self._tile_output_shape = output.shape
-        gradient = torch.zeros(*output.shape, dtype=self.dtype, device=self.device)
-        gradient[
-            :,
-            :,
-            self.tile_output_lost.top : output.shape[H_DIM] - self.tile_output_lost.bottom,
-            self.tile_output_lost.left : output.shape[W_DIM] - self.tile_output_lost.right,
-        ] = 1
+        self._tile_output_shapes = [out.shape for out in output_tensors]
+        self._tile_output_shape = self._tile_output_shapes[0]
+        self._output_stride_per_output = []
+        gradients = []
+        for idx, out in enumerate(output_tensors):
+            lost = self._tile_output_lost[idx]
+            gradient = torch.zeros(*out.shape, dtype=self.dtype, device=self.device)
+            gradient[
+                :,
+                :,
+                lost.top : out.shape[H_DIM] - lost.bottom,
+                lost.left : out.shape[W_DIM] - lost.right,
+            ] = 1
+            gradients.append(gradient)
 
-        output.backward(gradient=gradient)
+            p_stats = self._prev_stats(out)
+            if p_stats:
+                output_stride = p_stats["output_stride"] * torch.tensor(p_stats["stride"])
+            else:
+                output_stride = torch.tensor([1, 1, 1])
+            self._output_stride_per_output.append(output_stride)
 
-        # Calculate the output stride of the whole stream_module
-        p_stats = self._prev_stats(output)
+        if len(self._output_stride_per_output) > 1:
+            reference_stride = self._output_stride_per_output[0]
+            for stride in self._output_stride_per_output[1:]:
+                if not torch.equal(stride, reference_stride):
+                    raise ValueError("StreamingCNN currently requires all outputs to have equal output strides")
 
-        if p_stats:
-            self.output_stride = p_stats["output_stride"] * torch.tensor(p_stats["stride"])
-        else:
-            self.output_stride = torch.tensor([1, 1, 1])
+        self.output_stride = self._output_stride_per_output[0]
+        torch.autograd.backward(output_tensors, gradients)
 
         # tiles can have -1, see backward_statistics_hook
         self.tile_gradient_lost = self._non_max_border_amount(tile.grad)
@@ -189,9 +207,59 @@ class StreamingCNN(torch.nn.Module):
     def _gather_forward_statistics(self, tile):
         torch.set_grad_enabled(False)
         output = self.stream_module(tile)
-        self.tile_output_lost = self._non_max_border_amount(output)
+        output_tensors, output_spec = self._flatten_output_structure(output)
+        self._output_spec = output_spec
+        self._tile_output_lost = [self._non_max_border_amount(out) for out in output_tensors]
+        self.tile_output_lost = self._tile_output_lost[0]
         if self.verbose:
-            print("\n", "Output lost", self.tile_output_lost)
+            print("\n", "Output lost", self._tile_output_lost)
+
+    def _flatten_output_structure(self, output):
+        if isinstance(output, torch.Tensor):
+            return [output], ("tensor", None)
+        if isinstance(output, tuple):
+            flat = []
+            children = []
+            for x in output:
+                child_flat, child_spec = self._flatten_output_structure(x)
+                flat.extend(child_flat)
+                children.append(child_spec)
+            return flat, ("tuple", children)
+        if isinstance(output, list):
+            flat = []
+            children = []
+            for x in output:
+                child_flat, child_spec = self._flatten_output_structure(x)
+                flat.extend(child_flat)
+                children.append(child_spec)
+            return flat, ("list", children)
+        if isinstance(output, dict):
+            flat = []
+            children = []
+            for key in sorted(output.keys()):
+                child_flat, child_spec = self._flatten_output_structure(output[key])
+                flat.extend(child_flat)
+                children.append((key, child_spec))
+            return flat, ("dict", children)
+        raise TypeError(f"Unsupported output type for streaming: {type(output)}")
+
+    def _unflatten_output_structure(self, flat, spec, index=0):
+        kind, payload = spec
+        if kind == "tensor":
+            return flat[index], index + 1
+        if kind in {"tuple", "list"}:
+            values = []
+            for child in payload:
+                value, index = self._unflatten_output_structure(flat, child, index)
+                values.append(value)
+            return (tuple(values) if kind == "tuple" else values), index
+        if kind == "dict":
+            values = {}
+            for key, child in payload:
+                value, index = self._unflatten_output_structure(flat, child, index)
+                values[key] = value
+            return values, index
+        raise TypeError(f"Unsupported output spec kind: {kind}")
 
     def _convert_modules_for_streaming(self, module):
         mod = module
@@ -324,32 +392,42 @@ class StreamingCNN(torch.nn.Module):
         tile_width, tile_height = self.tile_shape[W_DIM], self.tile_shape[H_DIM]
 
         # Size of valid output of a tile
-        valid_output_height = self._tile_output_shape[H_DIM] - self.tile_output_lost.top - self.tile_output_lost.bottom
-        valid_output_width = self._tile_output_shape[W_DIM] - self.tile_output_lost.left - self.tile_output_lost.right
-
-        # We will keep track which part of the output of the whole image we
-        # already filled with valid values from tile output.
-        already_filled = Box(0, 0, 0, 0, None)
+        valid_output_heights = [
+            self._tile_output_shapes[idx][H_DIM] - self._tile_output_lost[idx].top - self._tile_output_lost[idx].bottom
+            for idx in range(len(self._tile_output_shapes))
+        ]
+        valid_output_widths = [
+            self._tile_output_shapes[idx][W_DIM] - self._tile_output_lost[idx].left - self._tile_output_lost[idx].right
+            for idx in range(len(self._tile_output_shapes))
+        ]
 
         # Calculate size of output that we would get by inferencing the
         # whole image.
-        output_height = (image.shape[H_DIM] - self.tile_shape[H_DIM]) // self.output_stride[
-            1
-        ] + self._tile_output_shape[H_DIM]
-        output_width = (image.shape[W_DIM] - self.tile_shape[W_DIM]) // self.output_stride[2] + self._tile_output_shape[
-            W_DIM
+        output_heights = [
+            (image.shape[H_DIM] - self.tile_shape[H_DIM]) // self.output_stride[1] + tile_shape[H_DIM]
+            for tile_shape in self._tile_output_shapes
+        ]
+        output_widths = [
+            (image.shape[W_DIM] - self.tile_shape[W_DIM]) // self.output_stride[2] + tile_shape[W_DIM]
+            for tile_shape in self._tile_output_shapes
         ]
 
         if result_on_cpu:
             device = torch.device("cpu")
         else:
             device = self.device
-        output = torch.empty(
-            (image.shape[0], self._tile_output_shape[1], output_height, output_width), dtype=self.dtype, device=device
-        ).fill_(999)
+        outputs = [
+            torch.empty(
+                (image.shape[0], self._tile_output_shapes[idx][1], output_heights[idx], output_widths[idx]),
+                dtype=self.dtype,
+                device=device,
+            ).fill_(999)
+            for idx in range(len(self._tile_output_shapes))
+        ]
+        already_filled = [Box(0, 0, 0, 0, None) for _ in range(len(self._tile_output_shapes))]
 
-        n_rows = math.ceil(float(output_height) / float(valid_output_height))
-        n_cols = math.ceil(float(output_width) / float(valid_output_width))
+        n_rows = math.ceil(float(output_heights[0]) / float(valid_output_heights[0]))
+        n_cols = math.ceil(float(output_widths[0]) / float(valid_output_widths[0]))
 
         if image.shape[W_DIM] <= tile_width:
             n_cols = 1
@@ -370,8 +448,8 @@ class StreamingCNN(torch.nn.Module):
             for row in iterator:
                 for col in range(n_cols):
                     # Coordinates of the output w.r.t. the output of full image
-                    output_y = row * valid_output_height
-                    output_x = col * valid_output_width
+                    output_y = row * valid_output_heights[0]
+                    output_x = col * valid_output_widths[0]
 
                     # Check if we are at borders, since we can not create
                     # overlap here and should not crop values.
@@ -421,33 +499,39 @@ class StreamingCNN(torch.nn.Module):
                         tile = self._normalize_on_gpu(tile)
 
                     tile_output = self.stream_module(tile)
+                    tile_outputs, _ = self._flatten_output_structure(tile_output)
 
                     if torch.backends.cudnn.benchmark:
                         torch.cuda.empty_cache()
 
-                    trimmed_output = tile_output[
-                        :,
-                        :,
-                        lost.top : tile_output.shape[H_DIM] - lost.bottom,
-                        lost.left : tile_output.shape[W_DIM] - lost.right,
-                    ]
+                    for idx, head_output in enumerate(tile_outputs):
+                        lost = self._get_tile_lost_for_sides(sides, self._tile_output_lost[idx])
+                        output_loc = Box(output_y + lost.top, -1, output_x + lost.left, -1, sides)
+                        trimmed_output = head_output[
+                            :,
+                            :,
+                            lost.top : head_output.shape[H_DIM] - lost.bottom,
+                            lost.left : head_output.shape[W_DIM] - lost.right,
+                        ]
 
-                    new_output_box, updated_total_indices = _new_value_indices(trimmed_output.shape, output_loc, already_filled)
-                    already_filled = updated_total_indices
+                        new_output_box, updated_total_indices = _new_value_indices(
+                            trimmed_output.shape, output_loc, already_filled[idx]
+                        )
+                        already_filled[idx] = updated_total_indices
 
-                    relevant_output = trimmed_output[
-                        :,
-                        :,
-                        new_output_box.y : updated_total_indices.y + new_output_box.height,
-                        new_output_box.x : new_output_box.x + new_output_box.width,
-                    ]
+                        relevant_output = trimmed_output[
+                            :,
+                            :,
+                            new_output_box.y : updated_total_indices.y + new_output_box.height,
+                            new_output_box.x : new_output_box.x + new_output_box.width,
+                        ]
 
-                    output[
-                        :,
-                        :,
-                        int(updated_total_indices.y) : int(updated_total_indices.height),
-                        int(updated_total_indices.x - new_output_box.width) : int(updated_total_indices.x),
-                    ] = relevant_output
+                        outputs[idx][
+                            :,
+                            :,
+                            int(updated_total_indices.y) : int(updated_total_indices.height),
+                            int(updated_total_indices.x - new_output_box.width) : int(updated_total_indices.x),
+                        ] = relevant_output
 
                     del tile
 
@@ -457,7 +541,8 @@ class StreamingCNN(torch.nn.Module):
         del relevant_output  # type:ignore
         del image
         self._saved_tensors = {}
-
+        output, final_idx = self._unflatten_output_structure(outputs, self._output_spec)
+        assert final_idx == len(outputs)
         return output
 
     def backward(self, image, grad):
@@ -514,6 +599,10 @@ class StreamingCNN(torch.nn.Module):
         # else:
         iterator = range(n_rows)
 
+        grad_tensors, grad_spec = self._flatten_output_structure(grad)
+        if grad_spec != self._output_spec:
+            raise ValueError("Gradient output structure does not match streaming output structure")
+
         for row in iterator:
             for col in range(n_cols):
                 # Since we determine output (gradient) coordinates based on input
@@ -524,8 +613,9 @@ class StreamingCNN(torch.nn.Module):
                 sides_top = True if row == 0 else False
                 sides_left = True if col == 0 else False
 
-                sides_bottom = True if output_y + output_height >= grad.shape[H_DIM] else False
-                sides_right = True if output_x + output_width >= grad.shape[W_DIM] else False
+                base_grad = grad_tensors[0]
+                sides_bottom = True if output_y + output_height >= base_grad.shape[H_DIM] else False
+                sides_right = True if output_x + output_width >= base_grad.shape[W_DIM] else False
                 sides = Sides(sides_left, sides_top, sides_right, sides_bottom)
 
                 # We are doing a forward pass
@@ -536,9 +626,9 @@ class StreamingCNN(torch.nn.Module):
                 # over the border)
 
                 if sides_bottom:
-                    output_y = max(grad.shape[H_DIM] - output_height, 0)
+                    output_y = max(base_grad.shape[H_DIM] - output_height, 0)
                 if sides_right:
-                    output_x = max(grad.shape[W_DIM] - output_width, 0)
+                    output_x = max(base_grad.shape[W_DIM] - output_width, 0)
 
                 input_y = output_y * self.output_stride[1]
                 input_x = output_x * self.output_stride[2]
@@ -547,14 +637,7 @@ class StreamingCNN(torch.nn.Module):
 
                 tile = image[:, :, input_y : input_y + tile_height, input_x : input_x + tile_width]
 
-                gradient = grad[:, :, output_y : output_y + output_height, output_x : output_x + output_width]
-
                 self._saved_tensors = {}
-
-                # Trim output and gradient
-                trimmed_grad = gradient[
-                    :, :, lost.top : gradient.shape[H_DIM] - lost.bottom, lost.left : gradient.shape[W_DIM] - lost.right
-                ]
 
                 if not self.copy_to_gpu:
                     tile = tile.to(self.device, non_blocking=True)
@@ -574,34 +657,61 @@ class StreamingCNN(torch.nn.Module):
 
                 with torch.autocast(device_type="cuda", dtype=self.dtype):
                     tile_output = self.stream_module(tile)
+                tile_outputs, _ = self._flatten_output_structure(tile_output)
 
                 del tile  # memory management
 
-                trimmed_output = tile_output[
-                    :,
-                    :,
-                    lost.top : tile_output.shape[H_DIM] - lost.bottom,
-                    lost.left : tile_output.shape[W_DIM] - lost.right,
-                ]
+                trimmed_outputs = []
+                trimmed_grads = []
+                for idx, (head_output, head_grad) in enumerate(zip(tile_outputs, grad_tensors)):
+                    head_lost = self._get_tile_lost_for_sides(sides, self._tile_output_lost[idx])
+                    head_output_height = self._tile_output_shapes[idx][H_DIM]
+                    head_output_width = self._tile_output_shapes[idx][W_DIM]
+                    head_output_y = output_y
+                    head_output_x = output_x
 
-                # Do backward pass, fix gradient in hooks
-                trimmed_output = trimmed_output.to(self.device, non_blocking=True)
+                    if sides_bottom:
+                        head_output_y = max(head_grad.shape[H_DIM] - head_output_height, 0)
+                    if sides_right:
+                        head_output_x = max(head_grad.shape[W_DIM] - head_output_width, 0)
 
-                # Sometimes when training with variable input shapes,
-                # the gradient size is a bit too big
-                if (
-                    trimmed_grad.shape[H_DIM] != trimmed_output.shape[H_DIM]
-                    or trimmed_grad.shape[W_DIM] != trimmed_output.shape[W_DIM]
-                ):
-                    assert image.shape[H_DIM] < self.tile_shape[H_DIM] or image.shape[W_DIM] < self.tile_shape[W_DIM]
-                    trimmed_grad = trimmed_grad[:, :, 0 : trimmed_output.shape[H_DIM], 0 : trimmed_output.shape[W_DIM]]
+                    gradient = head_grad[
+                        :,
+                        :,
+                        head_output_y : head_output_y + head_output_height,
+                        head_output_x : head_output_x + head_output_width,
+                    ]
+                    trimmed_grad = gradient[
+                        :,
+                        :,
+                        head_lost.top : gradient.shape[H_DIM] - head_lost.bottom,
+                        head_lost.left : gradient.shape[W_DIM] - head_lost.right,
+                    ]
+                    trimmed_output = head_output[
+                        :,
+                        :,
+                        head_lost.top : head_output.shape[H_DIM] - head_lost.bottom,
+                        head_lost.left : head_output.shape[W_DIM] - head_lost.right,
+                    ]
 
-                trimmed_output.backward(trimmed_grad)
+                    trimmed_output = trimmed_output.to(self.device, non_blocking=True)
+
+                    if (
+                        trimmed_grad.shape[H_DIM] != trimmed_output.shape[H_DIM]
+                        or trimmed_grad.shape[W_DIM] != trimmed_output.shape[W_DIM]
+                    ):
+                        assert image.shape[H_DIM] < self.tile_shape[H_DIM] or image.shape[W_DIM] < self.tile_shape[W_DIM]
+                        trimmed_grad = trimmed_grad[:, :, 0 : trimmed_output.shape[H_DIM], 0 : trimmed_output.shape[W_DIM]]
+
+                    trimmed_outputs.append(trimmed_output)
+                    trimmed_grads.append(trimmed_grad)
+
+                torch.autograd.backward(trimmed_outputs, trimmed_grads)
 
                 # Memory management
                 del tile_output
-                del trimmed_grad
-                del trimmed_output
+                del trimmed_grads
+                del trimmed_outputs
 
         # Memory management
         self._saved_tensors = {}
@@ -614,11 +724,12 @@ class StreamingCNN(torch.nn.Module):
 
         assert sides_right and sides_bottom, "It seems like we could not reconstruct all output"  # type:ignore
 
-    def _get_tile_lost_for_sides(self, sides):
-        lost_top = self.tile_output_lost.top if not sides.top else 0
-        lost_bottom = self.tile_output_lost.bottom if not sides.bottom else 0
-        lost_left = self.tile_output_lost.left if not sides.left else 0
-        lost_right = self.tile_output_lost.right if not sides.right else 0
+    def _get_tile_lost_for_sides(self, sides, output_lost=None):
+        output_lost = self.tile_output_lost if output_lost is None else output_lost
+        lost_top = output_lost.top if not sides.top else 0
+        lost_bottom = output_lost.bottom if not sides.bottom else 0
+        lost_left = output_lost.left if not sides.left else 0
+        lost_right = output_lost.right if not sides.right else 0
         lost = Lost(lost_top, lost_left, lost_bottom, lost_right)
         return lost
 
@@ -903,8 +1014,12 @@ class StreamingCNN(torch.nn.Module):
                 named_stats["net_stats"][name] = self._module_stats[module]
         named_stats["output_stride"] = self.output_stride
         named_stats["tile_output_lost"] = self.tile_output_lost  # type:ignore
+        named_stats["tile_output_lost_all"] = self._tile_output_lost  # type:ignore
         named_stats["tile_gradient_lost"] = self.tile_gradient_lost  # type:ignore
         named_stats["tile_output_shape"] = self._tile_output_shape  # type:ignore
+        named_stats["tile_output_shapes"] = self._tile_output_shapes  # type:ignore
+        named_stats["output_stride_per_output"] = self._output_stride_per_output  # type:ignore
+        named_stats["output_spec"] = self._output_spec
         return named_stats
 
     def load_tile_cache(self, state):
@@ -912,8 +1027,12 @@ class StreamingCNN(torch.nn.Module):
 
         self.output_stride = state["output_stride"]
         self.tile_output_lost = state["tile_output_lost"]
+        self._tile_output_lost = state.get("tile_output_lost_all", [self.tile_output_lost])
         self.tile_gradient_lost = state["tile_gradient_lost"]
         self._tile_output_shape = state["tile_output_shape"]
+        self._tile_output_shapes = state.get("tile_output_shapes", [self._tile_output_shape])
+        self._output_stride_per_output = state.get("output_stride_per_output", [self.output_stride])
+        self._output_spec = state.get("output_spec", ("tensor", None))
 
         for name, module in self.stream_module.named_modules():
             if name in state["net_stats"]:

--- a/lightstream/core/scnn/scnn.py
+++ b/lightstream/core/scnn/scnn.py
@@ -426,20 +426,30 @@ class StreamingCNN(torch.nn.Module):
         ]
         already_filled = [Box(0, 0, 0, 0, None) for _ in range(len(self._tile_output_shapes))]
 
-        valid_input_height = max(
-            1,
-            min(
-                valid_output_heights[idx] * int(self._output_stride_per_output[idx][1])
-                for idx in range(len(self._tile_output_shapes))
-            ),
-        )
-        valid_input_width = max(
-            1,
-            min(
-                valid_output_widths[idx] * int(self._output_stride_per_output[idx][2])
-                for idx in range(len(self._tile_output_shapes))
-            ),
-        )
+        if len(self._tile_output_shapes) > 1:
+            base_stride_h = int(self._base_output_stride[1])
+            base_stride_w = int(self._base_output_stride[2])
+            valid_input_height = (self.tile_shape[H_DIM] - self.tile_gradient_lost.top - self.tile_gradient_lost.bottom)
+            valid_input_height = (valid_input_height // base_stride_h) * base_stride_h
+            valid_input_width = (self.tile_shape[W_DIM] - self.tile_gradient_lost.left - self.tile_gradient_lost.right)
+            valid_input_width = (valid_input_width // base_stride_w) * base_stride_w
+            valid_input_height = max(1, valid_input_height)
+            valid_input_width = max(1, valid_input_width)
+        else:
+            valid_input_height = max(
+                1,
+                min(
+                    valid_output_heights[idx] * int(self._output_stride_per_output[idx][1])
+                    for idx in range(len(self._tile_output_shapes))
+                ),
+            )
+            valid_input_width = max(
+                1,
+                min(
+                    valid_output_widths[idx] * int(self._output_stride_per_output[idx][2])
+                    for idx in range(len(self._tile_output_shapes))
+                ),
+            )
         n_rows = math.ceil(float(max(1, image.shape[H_DIM] - self.tile_shape[H_DIM])) / float(valid_input_height)) + 1
         n_cols = math.ceil(float(max(1, image.shape[W_DIM] - self.tile_shape[W_DIM])) / float(valid_input_width)) + 1
 
@@ -582,23 +592,31 @@ class StreamingCNN(torch.nn.Module):
             for idx in range(len(self._tile_output_shapes))
         ]
 
-        valid_input_height = max(
-            1,
-            min(
-                valid_output_heights[idx] * int(self._output_stride_per_output[idx][1])
-                for idx in range(len(self._tile_output_shapes))
-            ),
-        )
-        valid_input_width = max(
-            1,
-            min(
-                valid_output_widths[idx] * int(self._output_stride_per_output[idx][2])
-                for idx in range(len(self._tile_output_shapes))
-            ),
-        )
-
         base_stride_h = int(self._base_output_stride[1])
         base_stride_w = int(self._base_output_stride[2])
+
+        if len(self._tile_output_shapes) > 1:
+            valid_input_height = (tile_height - self.tile_gradient_lost.top - self.tile_gradient_lost.bottom)
+            valid_input_height = (valid_input_height // base_stride_h) * base_stride_h
+            valid_input_width = (tile_width - self.tile_gradient_lost.left - self.tile_gradient_lost.right)
+            valid_input_width = (valid_input_width // base_stride_w) * base_stride_w
+            valid_input_height = max(1, valid_input_height)
+            valid_input_width = max(1, valid_input_width)
+        else:
+            valid_input_height = max(
+                1,
+                min(
+                    valid_output_heights[idx] * int(self._output_stride_per_output[idx][1])
+                    for idx in range(len(self._tile_output_shapes))
+                ),
+            )
+            valid_input_width = max(
+                1,
+                min(
+                    valid_output_widths[idx] * int(self._output_stride_per_output[idx][2])
+                    for idx in range(len(self._tile_output_shapes))
+                ),
+            )
 
         n_rows = math.ceil(float(max(1, height - tile_height)) / float(valid_input_height)) + 1
         n_cols = math.ceil(float(max(1, width - tile_width)) / float(valid_input_width)) + 1

--- a/lightstream/core/scnn/scnn.py
+++ b/lightstream/core/scnn/scnn.py
@@ -186,13 +186,28 @@ class StreamingCNN(torch.nn.Module):
                 output_stride = p_stats["output_stride"] * torch.tensor(p_stats["stride"])
             else:
                 output_stride = torch.tensor([1, 1, 1])
+
+            # Some branches include upsampling layers that are intentionally not
+            # part of streaming statistics hooks. Infer effective spatial stride
+            # from tile/output shapes so multi-head decoders can share a common
+            # final output stride when appropriate.
+            effective_h = max(1, int(round(float(tile.shape[H_DIM]) / float(out.shape[H_DIM]))))
+            effective_w = max(1, int(round(float(tile.shape[W_DIM]) / float(out.shape[W_DIM]))))
+            output_stride = output_stride.clone()
+            output_stride[1] = min(int(output_stride[1]), effective_h)
+            output_stride[2] = min(int(output_stride[2]), effective_w)
+
             self._output_stride_per_output.append(output_stride)
 
         if len(self._output_stride_per_output) > 1:
             reference_stride = self._output_stride_per_output[0]
             for stride in self._output_stride_per_output[1:]:
                 if not torch.equal(stride, reference_stride):
-                    raise ValueError("StreamingCNN currently requires all outputs to have equal output strides")
+                    stride_values = [tuple(int(x) for x in s.tolist()) for s in self._output_stride_per_output]
+                    raise ValueError(
+                        "StreamingCNN currently requires all outputs to have equal output strides. "
+                        f"Found strides: {stride_values}"
+                    )
 
         self.output_stride = self._output_stride_per_output[0]
         torch.autograd.backward(output_tensors, gradients)

--- a/lightstream/core/scnn/scnn.py
+++ b/lightstream/core/scnn/scnn.py
@@ -426,30 +426,22 @@ class StreamingCNN(torch.nn.Module):
         ]
         already_filled = [Box(0, 0, 0, 0, None) for _ in range(len(self._tile_output_shapes))]
 
-        if len(self._tile_output_shapes) > 1:
-            base_stride_h = int(self._base_output_stride[1])
-            base_stride_w = int(self._base_output_stride[2])
-            valid_input_height = (self.tile_shape[H_DIM] - self.tile_gradient_lost.top - self.tile_gradient_lost.bottom)
-            valid_input_height = (valid_input_height // base_stride_h) * base_stride_h
-            valid_input_width = (self.tile_shape[W_DIM] - self.tile_gradient_lost.left - self.tile_gradient_lost.right)
-            valid_input_width = (valid_input_width // base_stride_w) * base_stride_w
-            valid_input_height = max(1, valid_input_height)
-            valid_input_width = max(1, valid_input_width)
-        else:
-            valid_input_height = max(
-                1,
-                min(
-                    valid_output_heights[idx] * int(self._output_stride_per_output[idx][1])
-                    for idx in range(len(self._tile_output_shapes))
-                ),
-            )
-            valid_input_width = max(
-                1,
-                min(
-                    valid_output_widths[idx] * int(self._output_stride_per_output[idx][2])
-                    for idx in range(len(self._tile_output_shapes))
-                ),
-            )
+        step_candidates_h = [
+            valid_output_heights[idx] * int(self._output_stride_per_output[idx][1])
+            for idx in range(len(self._tile_output_shapes))
+        ]
+        step_candidates_w = [
+            valid_output_widths[idx] * int(self._output_stride_per_output[idx][2])
+            for idx in range(len(self._tile_output_shapes))
+        ]
+        align_h = 1
+        align_w = 1
+        for stride in self._output_stride_per_output:
+            align_h = math.lcm(align_h, int(stride[1]))
+            align_w = math.lcm(align_w, int(stride[2]))
+
+        valid_input_height = max(align_h, (min(step_candidates_h) // align_h) * align_h)
+        valid_input_width = max(align_w, (min(step_candidates_w) // align_w) * align_w)
         n_rows = math.ceil(float(max(1, image.shape[H_DIM] - self.tile_shape[H_DIM])) / float(valid_input_height)) + 1
         n_cols = math.ceil(float(max(1, image.shape[W_DIM] - self.tile_shape[W_DIM])) / float(valid_input_width)) + 1
 
@@ -595,28 +587,22 @@ class StreamingCNN(torch.nn.Module):
         base_stride_h = int(self._base_output_stride[1])
         base_stride_w = int(self._base_output_stride[2])
 
-        if len(self._tile_output_shapes) > 1:
-            valid_input_height = (tile_height - self.tile_gradient_lost.top - self.tile_gradient_lost.bottom)
-            valid_input_height = (valid_input_height // base_stride_h) * base_stride_h
-            valid_input_width = (tile_width - self.tile_gradient_lost.left - self.tile_gradient_lost.right)
-            valid_input_width = (valid_input_width // base_stride_w) * base_stride_w
-            valid_input_height = max(1, valid_input_height)
-            valid_input_width = max(1, valid_input_width)
-        else:
-            valid_input_height = max(
-                1,
-                min(
-                    valid_output_heights[idx] * int(self._output_stride_per_output[idx][1])
-                    for idx in range(len(self._tile_output_shapes))
-                ),
-            )
-            valid_input_width = max(
-                1,
-                min(
-                    valid_output_widths[idx] * int(self._output_stride_per_output[idx][2])
-                    for idx in range(len(self._tile_output_shapes))
-                ),
-            )
+        step_candidates_h = [
+            valid_output_heights[idx] * int(self._output_stride_per_output[idx][1])
+            for idx in range(len(self._tile_output_shapes))
+        ]
+        step_candidates_w = [
+            valid_output_widths[idx] * int(self._output_stride_per_output[idx][2])
+            for idx in range(len(self._tile_output_shapes))
+        ]
+        align_h = 1
+        align_w = 1
+        for stride in self._output_stride_per_output:
+            align_h = math.lcm(align_h, int(stride[1]))
+            align_w = math.lcm(align_w, int(stride[2]))
+
+        valid_input_height = max(align_h, (min(step_candidates_h) // align_h) * align_h)
+        valid_input_width = max(align_w, (min(step_candidates_w) // align_w) * align_w)
 
         n_rows = math.ceil(float(max(1, height - tile_height)) / float(valid_input_height)) + 1
         n_cols = math.ceil(float(max(1, width - tile_width)) / float(valid_input_width)) + 1

--- a/lightstream/core/scnn/scnn.py
+++ b/lightstream/core/scnn/scnn.py
@@ -691,9 +691,9 @@ class StreamingCNN(torch.nn.Module):
                     head_output_y = input_y // int(head_stride[1])
                     head_output_x = input_x // int(head_stride[2])
 
-                    if sides_bottom:
+                    if sides.bottom:
                         head_output_y = max(head_grad.shape[H_DIM] - head_output_height, 0)
-                    if sides_right:
+                    if sides.right:
                         head_output_x = max(head_grad.shape[W_DIM] - head_output_width, 0)
 
                     gradient = head_grad[

--- a/lightstream/core/scnn/scnn.py
+++ b/lightstream/core/scnn/scnn.py
@@ -189,17 +189,11 @@ class StreamingCNN(torch.nn.Module):
 
             self._output_stride_per_output.append(output_stride)
 
-        if len(self._output_stride_per_output) > 1:
-            reference_stride = self._output_stride_per_output[0]
-            for stride in self._output_stride_per_output[1:]:
-                if not torch.equal(stride, reference_stride):
-                    stride_values = [tuple(int(x) for x in s.tolist()) for s in self._output_stride_per_output]
-                    raise ValueError(
-                        "StreamingCNN currently requires all outputs to have equal output strides. "
-                        f"Found strides: {stride_values}"
-                    )
-
         self.output_stride = self._output_stride_per_output[0]
+        self._base_output_stride = self._output_stride_per_output[0].clone()
+        for stride in self._output_stride_per_output[1:]:
+            self._base_output_stride[1] = min(int(self._base_output_stride[1]), int(stride[1]))
+            self._base_output_stride[2] = min(int(self._base_output_stride[2]), int(stride[2]))
         torch.autograd.backward(output_tensors, gradients)
 
         # tiles can have -1, see backward_statistics_hook
@@ -409,12 +403,12 @@ class StreamingCNN(torch.nn.Module):
         # Calculate size of output that we would get by inferencing the
         # whole image.
         output_heights = [
-            (image.shape[H_DIM] - self.tile_shape[H_DIM]) // self.output_stride[1] + tile_shape[H_DIM]
-            for tile_shape in self._tile_output_shapes
+            (image.shape[H_DIM] - self.tile_shape[H_DIM]) // int(self._output_stride_per_output[idx][1]) + tile_shape[H_DIM]
+            for idx, tile_shape in enumerate(self._tile_output_shapes)
         ]
         output_widths = [
-            (image.shape[W_DIM] - self.tile_shape[W_DIM]) // self.output_stride[2] + tile_shape[W_DIM]
-            for tile_shape in self._tile_output_shapes
+            (image.shape[W_DIM] - self.tile_shape[W_DIM]) // int(self._output_stride_per_output[idx][2]) + tile_shape[W_DIM]
+            for idx, tile_shape in enumerate(self._tile_output_shapes)
         ]
 
         if result_on_cpu:
@@ -431,8 +425,22 @@ class StreamingCNN(torch.nn.Module):
         ]
         already_filled = [Box(0, 0, 0, 0, None) for _ in range(len(self._tile_output_shapes))]
 
-        n_rows = math.ceil(float(output_heights[0]) / float(valid_output_heights[0]))
-        n_cols = math.ceil(float(output_widths[0]) / float(valid_output_widths[0]))
+        valid_input_height = max(
+            1,
+            min(
+                valid_output_heights[idx] * int(self._output_stride_per_output[idx][1])
+                for idx in range(len(self._tile_output_shapes))
+            ),
+        )
+        valid_input_width = max(
+            1,
+            min(
+                valid_output_widths[idx] * int(self._output_stride_per_output[idx][2])
+                for idx in range(len(self._tile_output_shapes))
+            ),
+        )
+        n_rows = math.ceil(float(max(1, image.shape[H_DIM] - self.tile_shape[H_DIM])) / float(valid_input_height)) + 1
+        n_cols = math.ceil(float(max(1, image.shape[W_DIM] - self.tile_shape[W_DIM])) / float(valid_input_width)) + 1
 
         if image.shape[W_DIM] <= tile_width:
             n_cols = 1
@@ -453,24 +461,16 @@ class StreamingCNN(torch.nn.Module):
             for row in iterator:
                 for col in range(n_cols):
                     # Coordinates of the output w.r.t. the output of full image
-                    output_y = row * valid_output_heights[0]
-                    output_x = col * valid_output_widths[0]
+                    tile_y = row * valid_input_height
+                    tile_x = col * valid_input_width
 
                     # Check if we are at borders, since we can not create
                     # overlap here and should not crop values.
                     sides_top = True if row == 0 else False
                     sides_left = True if col == 0 else False
 
-                    sides_bottom = (
-                        True
-                        if output_y * self.output_stride[1] + self.tile_shape[H_DIM] >= image.shape[H_DIM]
-                        else False
-                    )
-                    sides_right = (
-                        True
-                        if output_x * self.output_stride[2] + self.tile_shape[W_DIM] >= image.shape[W_DIM]
-                        else False
-                    )
+                    sides_bottom = True if tile_y + self.tile_shape[H_DIM] >= image.shape[H_DIM] else False
+                    sides_right = True if tile_x + self.tile_shape[W_DIM] >= image.shape[W_DIM] else False
                     sides = Sides(sides_left, sides_top, sides_right, sides_bottom)
 
                     # These values are used to crop invalid output values
@@ -480,17 +480,12 @@ class StreamingCNN(torch.nn.Module):
                     # need to keep that into account when we are at the bottom
                     # and right side of the output.
                     if sides_bottom:
-                        output_y = (image.shape[H_DIM] - self.tile_shape[H_DIM]) // self.output_stride[1]
+                        tile_y = max(image.shape[H_DIM] - self.tile_shape[H_DIM], 0)
                     if sides_right:
-                        output_x = (image.shape[W_DIM] - self.tile_shape[W_DIM]) // self.output_stride[2]
+                        tile_x = max(image.shape[W_DIM] - self.tile_shape[W_DIM], 0)
 
-                    output_y = output_y if not sides.top else 0
-                    output_x = output_x if not sides.left else 0
-                    output_loc = Box(output_y + lost.top, -1, output_x + lost.left, -1, sides)
-
-                    # Coordinates of the input w.r.t. the output of full image
-                    tile_y = output_y * self.output_stride[1]
-                    tile_x = output_x * self.output_stride[2]
+                    tile_y = tile_y if not sides.top else 0
+                    tile_x = tile_x if not sides.left else 0
 
                     # Extract tile and perform forward pass
                     tile = image[:, :, tile_y : tile_y + tile_height, tile_x : tile_x + tile_width]
@@ -511,6 +506,9 @@ class StreamingCNN(torch.nn.Module):
 
                     for idx, head_output in enumerate(tile_outputs):
                         lost = self._get_tile_lost_for_sides(sides, self._tile_output_lost[idx])
+                        head_stride = self._output_stride_per_output[idx]
+                        output_y = tile_y // int(head_stride[1])
+                        output_x = tile_x // int(head_stride[2])
                         output_loc = Box(output_y + lost.top, -1, output_x + lost.left, -1, sides)
                         trimmed_output = head_output[
                             :,
@@ -576,10 +574,12 @@ class StreamingCNN(torch.nn.Module):
         output_height = self._tile_output_shape[H_DIM]
         output_width = self._tile_output_shape[W_DIM]
 
-        valid_grad_height = (tile_height - grad_lost.top - grad_lost.bottom) // self.output_stride[1]
-        valid_grad_height *= self.output_stride[1]
-        valid_grad_width = (tile_width - grad_lost.left - grad_lost.right) // self.output_stride[2]
-        valid_grad_width *= self.output_stride[2]
+        base_stride_h = int(self._base_output_stride[1])
+        base_stride_w = int(self._base_output_stride[2])
+        valid_grad_height = (tile_height - grad_lost.top - grad_lost.bottom) // base_stride_h
+        valid_grad_height *= base_stride_h
+        valid_grad_width = (tile_width - grad_lost.left - grad_lost.right) // base_stride_w
+        valid_grad_width *= base_stride_w
 
         n_rows = math.ceil(float(height - grad_lost.top - grad_lost.bottom) / float(valid_grad_height))
         n_cols = math.ceil(float(width - grad_lost.left - grad_lost.right) / float(valid_grad_width))
@@ -612,15 +612,15 @@ class StreamingCNN(torch.nn.Module):
             for col in range(n_cols):
                 # Since we determine output (gradient) coordinates based on input
                 # coordinates. We need to divide by output stride.
-                output_y = row * valid_grad_height // self.output_stride[1]
-                output_x = col * valid_grad_width // self.output_stride[2]
+                output_y = row * valid_grad_height // base_stride_h
+                output_x = col * valid_grad_width // base_stride_w
 
                 sides_top = True if row == 0 else False
                 sides_left = True if col == 0 else False
 
                 base_grad = grad_tensors[0]
-                sides_bottom = True if output_y + output_height >= base_grad.shape[H_DIM] else False
-                sides_right = True if output_x + output_width >= base_grad.shape[W_DIM] else False
+                sides_bottom = True if (output_y * base_stride_h) + tile_height >= image.shape[H_DIM] else False
+                sides_right = True if (output_x * base_stride_w) + tile_width >= image.shape[W_DIM] else False
                 sides = Sides(sides_left, sides_top, sides_right, sides_bottom)
 
                 # We are doing a forward pass
@@ -631,12 +631,13 @@ class StreamingCNN(torch.nn.Module):
                 # over the border)
 
                 if sides_bottom:
-                    output_y = max(base_grad.shape[H_DIM] - output_height, 0)
+                    input_y = max(image.shape[H_DIM] - tile_height, 0)
+                else:
+                    input_y = output_y * base_stride_h
                 if sides_right:
-                    output_x = max(base_grad.shape[W_DIM] - output_width, 0)
-
-                input_y = output_y * self.output_stride[1]
-                input_x = output_x * self.output_stride[2]
+                    input_x = max(image.shape[W_DIM] - tile_width, 0)
+                else:
+                    input_x = output_x * base_stride_w
 
                 input_loc = Box(input_y, tile_height, input_x, tile_width, sides)
 
@@ -672,8 +673,9 @@ class StreamingCNN(torch.nn.Module):
                     head_lost = self._get_tile_lost_for_sides(sides, self._tile_output_lost[idx])
                     head_output_height = self._tile_output_shapes[idx][H_DIM]
                     head_output_width = self._tile_output_shapes[idx][W_DIM]
-                    head_output_y = output_y
-                    head_output_x = output_x
+                    head_stride = self._output_stride_per_output[idx]
+                    head_output_y = input_y // int(head_stride[1])
+                    head_output_x = input_x // int(head_stride[2])
 
                     if sides_bottom:
                         head_output_y = max(head_grad.shape[H_DIM] - head_output_height, 0)
@@ -1037,6 +1039,10 @@ class StreamingCNN(torch.nn.Module):
         self._tile_output_shape = state["tile_output_shape"]
         self._tile_output_shapes = state.get("tile_output_shapes", [self._tile_output_shape])
         self._output_stride_per_output = state.get("output_stride_per_output", [self.output_stride])
+        self._base_output_stride = self._output_stride_per_output[0].clone()
+        for stride in self._output_stride_per_output[1:]:
+            self._base_output_stride[1] = min(int(self._base_output_stride[1]), int(stride[1]))
+            self._base_output_stride[2] = min(int(self._base_output_stride[2]), int(stride[2]))
         self._output_spec = state.get("output_spec", ("tensor", None))
 
         for name, module in self.stream_module.named_modules():

--- a/lightstream/core/scnn/scnn.py
+++ b/lightstream/core/scnn/scnn.py
@@ -569,20 +569,36 @@ class StreamingCNN(torch.nn.Module):
 
         tile_height = self.tile_shape[H_DIM]
         tile_width = self.tile_shape[W_DIM]
-        grad_lost = self.tile_gradient_lost
 
-        output_height = self._tile_output_shape[H_DIM]
-        output_width = self._tile_output_shape[W_DIM]
+        valid_output_heights = [
+            self._tile_output_shapes[idx][H_DIM] - self._tile_output_lost[idx].top - self._tile_output_lost[idx].bottom
+            for idx in range(len(self._tile_output_shapes))
+        ]
+        valid_output_widths = [
+            self._tile_output_shapes[idx][W_DIM] - self._tile_output_lost[idx].left - self._tile_output_lost[idx].right
+            for idx in range(len(self._tile_output_shapes))
+        ]
+
+        valid_input_height = max(
+            1,
+            min(
+                valid_output_heights[idx] * int(self._output_stride_per_output[idx][1])
+                for idx in range(len(self._tile_output_shapes))
+            ),
+        )
+        valid_input_width = max(
+            1,
+            min(
+                valid_output_widths[idx] * int(self._output_stride_per_output[idx][2])
+                for idx in range(len(self._tile_output_shapes))
+            ),
+        )
 
         base_stride_h = int(self._base_output_stride[1])
         base_stride_w = int(self._base_output_stride[2])
-        valid_grad_height = (tile_height - grad_lost.top - grad_lost.bottom) // base_stride_h
-        valid_grad_height *= base_stride_h
-        valid_grad_width = (tile_width - grad_lost.left - grad_lost.right) // base_stride_w
-        valid_grad_width *= base_stride_w
 
-        n_rows = math.ceil(float(height - grad_lost.top - grad_lost.bottom) / float(valid_grad_height))
-        n_cols = math.ceil(float(width - grad_lost.left - grad_lost.right) / float(valid_grad_width))
+        n_rows = math.ceil(float(max(1, height - tile_height)) / float(valid_input_height)) + 1
+        n_cols = math.ceil(float(max(1, width - tile_width)) / float(valid_input_width)) + 1
 
         # if self.verbose:
         #    ideal_tile_size = height / float(n_rows) + grad_lost.top + grad_lost.bottom
@@ -610,17 +626,18 @@ class StreamingCNN(torch.nn.Module):
 
         for row in iterator:
             for col in range(n_cols):
-                # Since we determine output (gradient) coordinates based on input
-                # coordinates. We need to divide by output stride.
-                output_y = row * valid_grad_height // base_stride_h
-                output_x = col * valid_grad_width // base_stride_w
+                # traverse tiles in input space, same as forward
+                tile_y = row * valid_input_height
+                tile_x = col * valid_input_width
+                output_y = tile_y // base_stride_h
+                output_x = tile_x // base_stride_w
 
                 sides_top = True if row == 0 else False
                 sides_left = True if col == 0 else False
 
                 base_grad = grad_tensors[0]
-                sides_bottom = True if (output_y * base_stride_h) + tile_height >= image.shape[H_DIM] else False
-                sides_right = True if (output_x * base_stride_w) + tile_width >= image.shape[W_DIM] else False
+                sides_bottom = True if tile_y + tile_height >= image.shape[H_DIM] else False
+                sides_right = True if tile_x + tile_width >= image.shape[W_DIM] else False
                 sides = Sides(sides_left, sides_top, sides_right, sides_bottom)
 
                 # We are doing a forward pass
@@ -633,11 +650,11 @@ class StreamingCNN(torch.nn.Module):
                 if sides_bottom:
                     input_y = max(image.shape[H_DIM] - tile_height, 0)
                 else:
-                    input_y = output_y * base_stride_h
+                    input_y = tile_y
                 if sides_right:
                     input_x = max(image.shape[W_DIM] - tile_width, 0)
                 else:
-                    input_x = output_x * base_stride_w
+                    input_x = tile_x
 
                 input_loc = Box(input_y, tile_height, input_x, tile_width, sides)
 

--- a/lightstream/core/scnn/scnn.py
+++ b/lightstream/core/scnn/scnn.py
@@ -100,6 +100,7 @@ class StreamingCNN(torch.nn.Module):
         self._saved_tensors = {}
         self._current_tile_input_loc = None
         self._hooks = []
+        self._last_forward_tiles = []
 
         if state_dict is None:
             self._configure()
@@ -456,6 +457,7 @@ class StreamingCNN(torch.nn.Module):
         #    iterator = tqdm(range(n_rows))
         # else:
         iterator = range(n_rows)
+        self._last_forward_tiles = []
 
         with torch.no_grad():
             for row in iterator:
@@ -486,6 +488,7 @@ class StreamingCNN(torch.nn.Module):
 
                     tile_y = tile_y if not sides.top else 0
                     tile_x = tile_x if not sides.left else 0
+                    self._last_forward_tiles.append((int(tile_y), int(tile_x), sides))
 
                     # Extract tile and perform forward pass
                     tile = image[:, :, tile_y : tile_y + tile_height, tile_x : tile_x + tile_width]
@@ -624,37 +627,31 @@ class StreamingCNN(torch.nn.Module):
         if grad_spec != self._output_spec:
             raise ValueError("Gradient output structure does not match streaming output structure")
 
-        for row in iterator:
-            for col in range(n_cols):
-                # traverse tiles in input space, same as forward
-                tile_y = row * valid_input_height
-                tile_x = col * valid_input_width
-                output_y = tile_y // base_stride_h
-                output_x = tile_x // base_stride_w
+        if self._last_forward_tiles:
+            tile_iter = self._last_forward_tiles
+        else:
+            tile_iter = []
+            for row in iterator:
+                for col in range(n_cols):
+                    tile_y = row * valid_input_height
+                    tile_x = col * valid_input_width
+                    sides_top = True if row == 0 else False
+                    sides_left = True if col == 0 else False
+                    sides_bottom = True if tile_y + tile_height >= image.shape[H_DIM] else False
+                    sides_right = True if tile_x + tile_width >= image.shape[W_DIM] else False
+                    if sides_bottom:
+                        tile_y = max(image.shape[H_DIM] - tile_height, 0)
+                    if sides_right:
+                        tile_x = max(image.shape[W_DIM] - tile_width, 0)
+                    tile_y = tile_y if not sides_top else 0
+                    tile_x = tile_x if not sides_left else 0
+                    tile_iter.append((int(tile_y), int(tile_x), Sides(sides_left, sides_top, sides_right, sides_bottom)))
 
-                sides_top = True if row == 0 else False
-                sides_left = True if col == 0 else False
+        for input_y, input_x, sides in tile_iter:
+                output_y = input_y // base_stride_h
+                output_x = input_x // base_stride_w
 
-                base_grad = grad_tensors[0]
-                sides_bottom = True if tile_y + tile_height >= image.shape[H_DIM] else False
-                sides_right = True if tile_x + tile_width >= image.shape[W_DIM] else False
-                sides = Sides(sides_left, sides_top, sides_right, sides_bottom)
-
-                # We are doing a forward pass
                 lost = self._get_tile_lost_for_sides(sides)
-
-                # If the tile is at the bottom or right side of the input image
-                # than we need to shift back so that the tile fits (does not go
-                # over the border)
-
-                if sides_bottom:
-                    input_y = max(image.shape[H_DIM] - tile_height, 0)
-                else:
-                    input_y = tile_y
-                if sides_right:
-                    input_x = max(image.shape[W_DIM] - tile_width, 0)
-                else:
-                    input_x = tile_x
 
                 input_loc = Box(input_y, tile_height, input_x, tile_width, sides)
 

--- a/lightstream/core/scnn/scnn.py
+++ b/lightstream/core/scnn/scnn.py
@@ -702,7 +702,9 @@ class StreamingCNN(torch.nn.Module):
                     tile_x = tile_x if not sides_left else 0
                     tile_iter.append((int(tile_y), int(tile_x), Sides(sides_left, sides_top, sides_right, sides_bottom)))
 
+        last_sides = None
         for input_y, input_x, sides in tile_iter:
+                last_sides = sides
                 output_y = input_y // base_stride_h
                 output_x = input_x // base_stride_w
 
@@ -798,7 +800,9 @@ class StreamingCNN(torch.nn.Module):
                 mod.input_loc = None
                 mod.reset()
 
-        assert sides_right and sides_bottom, "It seems like we could not reconstruct all output"  # type:ignore
+        assert last_sides is not None and last_sides.right and last_sides.bottom, (
+            "It seems like we could not reconstruct all output"
+        )
 
     def _get_tile_lost_for_sides(self, sides, output_lost=None):
         output_lost = self.tile_output_lost if output_lost is None else output_lost

--- a/lightstream/models/segment/model.py
+++ b/lightstream/models/segment/model.py
@@ -18,17 +18,14 @@ class WSS(nn.Module):
         self.backbone, self.channels = make_resnet_backbone(encoder, weights=weights, include_layer4=not remove_last_block)
         self.decoder1 = nn.Sequential(
             nn.Conv2d(64, 1, 1),
-            nn.Upsample(scale_factor=4, mode="bilinear", align_corners=False),
             nn.Sigmoid()
         )
         self.decoder2 = nn.Sequential(
             nn.Conv2d(128, 1, 1),
-            nn.Upsample(scale_factor=8, mode="bilinear", align_corners=False),
             nn.Sigmoid()
         )
         self.decoder3 = nn.Sequential(
             nn.Conv2d(256, 1, 1),
-            nn.Upsample(scale_factor=16, mode="bilinear", align_corners=False),
             nn.Sigmoid()
         )
 
@@ -41,7 +38,6 @@ class WSS(nn.Module):
         y1 = self.decoder1(x1)
         y2 = self.decoder2(x2)
         y3 = self.decoder3(x3)
-
 
         return y1, y2, y3
 

--- a/lightstream/models/segment/model.py
+++ b/lightstream/models/segment/model.py
@@ -42,9 +42,8 @@ class WSS(nn.Module):
         y2 = self.decoder2(x2)
         y3 = self.decoder3(x3)
 
-        y = self.w[0] * y1 + self.w[1] * y2 + self.w[2] * y3
 
-        return y1, y2, y3, y
+        return y1, y2, y3
 
 if __name__ == "__main__":
     print(" is cuda available? ", torch.cuda.is_available())


### PR DESCRIPTION
### Motivation
- Enable StreamingCNN to correctly handle models that return structured multi-head outputs (tensor/tuple/list/dict) while preserving existing single-output behavior.
- Ensure tiled forward stitching and tiled backward gradient propagation work per-output so multi-branch networks reconstruct outputs and propagate grads correctly.
- Persist per-output metadata so tile cache and statistics remain compatible with structured outputs.

### Description
- Added per-output state fields (`_tile_output_shapes`, `_tile_output_lost`, `_output_stride_per_output`, `_output_spec`) and used them during stats gathering and runtime to track each head.
- Implemented `_flatten_output_structure` and `_unflatten_output_structure` to support arbitrary nested output structures and to restore the original shape after tiling.
- Refactored `forward` to stitch each output head independently into per-head tensors and then unflatten the collection back into the original structured output.
- Refactored `backward` and statistics gathering to accept structured gradients, crop per-head gradients/outputs, enforce compatible output strides across heads, and call a single `torch.autograd.backward` per tile across heads; extended tile-cache serialization to include per-output fields while keeping legacy single-output compatibility.

### Testing
- Compiled the modified module with `python -m compileall lightstream/core/scnn/scnn.py lightstream/core/scnn/streamingconv.py` which completed successfully.
- Recompiled and sanity-checked references with `python -m compileall lightstream/core/scnn/scnn.py` and verified multi-output-related occurrences via `rg`, all checks succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699b45ea571483309f978e7a42f78f7e)