### PR TITLE
Add StreamingUpsample2d and handle Upsample during streaming conversion

### DIFF
--- a/lightstream/core/constructor.py
+++ b/lightstream/core/constructor.py
@@ -64,6 +64,7 @@ class StreamingConstructor:
             torch.nn.MaxPool1d,
             torch.nn.MaxPool2d,
             torch.nn.MaxPool3d,
+            torch.nn.Upsample,
         ]
 
         if add_keep_modules is not None:

--- a/lightstream/core/scnn/scnn.py
+++ b/lightstream/core/scnn/scnn.py
@@ -14,6 +14,7 @@ import torch.nn.functional
 
 from lightstream.core.scnn.utils import Sides, Box, Lost, _ntuple, _new_value_indices, B_DIM, C_DIM, H_DIM, W_DIM
 from lightstream.core.scnn.streamingconv import StreamingConv2d
+from lightstream.core.scnn.streamingupsample import StreamingUpsample2d
 
 
 _triple = _ntuple(3)
@@ -313,6 +314,13 @@ class StreamingCNN(torch.nn.Module):
                 mod.output_stride = self._module_stats[module]["output_stride"]
                 self._module_stats[mod] = self._module_stats[module]
                 del self._module_stats[module]
+        elif isinstance(module, torch.nn.Upsample):
+            mod = StreamingUpsample2d(
+                size=module.size,
+                scale_factor=module.scale_factor,
+                mode=module.mode,
+                align_corners=module.align_corners,
+            )
         for name, child in module.named_children():
             mod.add_module(name, self._convert_modules_for_streaming(child))
         del module
@@ -347,6 +355,13 @@ class StreamingCNN(torch.nn.Module):
             else:
                 self._module_stats[mod] = self._module_stats[module]
                 del self._module_stats[module]
+        elif isinstance(module, StreamingUpsample2d):
+            mod = torch.nn.Upsample(
+                size=module.size,
+                scale_factor=module.scale_factor,
+                mode=module.mode,
+                align_corners=module.align_corners,
+            )
         for name, child in module.named_children():
             mod.add_module(name, self._reset_converted_modules(child))
         del module

--- a/lightstream/core/scnn/streamingupsample.py
+++ b/lightstream/core/scnn/streamingupsample.py
@@ -1,0 +1,39 @@
+import torch
+import torch.nn.functional as F
+
+
+class StreamingUpsample2d(torch.nn.Module):
+    def __init__(self, size=None, scale_factor=None, mode="bilinear", align_corners=None):
+        super().__init__()
+
+        if size is not None and scale_factor is not None:
+            raise ValueError("StreamingUpsample2d expects either size or scale_factor, not both.")
+        if size is None and scale_factor is None:
+            raise ValueError("StreamingUpsample2d requires either size or scale_factor.")
+
+        supported_modes = {"bilinear", "nearest"}
+        if mode not in supported_modes:
+            raise ValueError(f"Unsupported upsample mode '{mode}'. Supported modes: {sorted(supported_modes)}")
+
+        if align_corners is True:
+            raise ValueError("StreamingUpsample2d does not support align_corners=True.")
+
+        if mode == "bilinear" and align_corners not in (None, False):
+            raise ValueError("StreamingUpsample2d only supports align_corners=None or False for bilinear mode.")
+
+        if mode == "nearest" and align_corners is not None:
+            raise ValueError("align_corners is only valid for bilinear mode.")
+
+        self.size = size
+        self.scale_factor = scale_factor
+        self.mode = mode
+        self.align_corners = align_corners
+
+    def forward(self, inpt):
+        return F.interpolate(
+            inpt,
+            size=self.size,
+            scale_factor=self.scale_factor,
+            mode=self.mode,
+            align_corners=self.align_corners,
+        )


### PR DESCRIPTION
### Motivation
- Preserve and correctly handle `torch.nn.Upsample` layers during streaming preparation so statistics discovery and streaming conversion treat upsample operations explicitly instead of removing them. 
- Provide a safe, minimal runtime representation of upsampling that enforces supported configurations and fails early for unsupported or ambiguous arguments.

### Description
- Add `StreamingUpsample2d` in `lightstream/core/scnn/streamingupsample.py` which wraps `torch.nn.functional.interpolate` and enforces that exactly one of `size` or `scale_factor` is provided, only `bilinear` and `nearest` modes are allowed, and `align_corners=True` is rejected (with additional align_corners checks per mode). 
- Import and wire `StreamingUpsample2d` into `lightstream/core/scnn/scnn.py` and extend `_convert_modules_for_streaming` to replace `torch.nn.Upsample` with `StreamingUpsample2d`, and extend `_reset_converted_modules` to convert `StreamingUpsample2d` back to `torch.nn.Upsample`. 
- Add `torch.nn.Upsample` to `StreamingConstructor.keep_modules` in `lightstream/core/constructor.py` so upsample layers are kept during statistics discovery instead of being turned into `nn.Identity`.

### Testing
- Ran `python -m compileall lightstream/core/scnn/streamingupsample.py lightstream/core/scnn/scnn.py lightstream/core/constructor.py` and compilation succeeded. 
- Executed an isolated import and validation script via `importlib` that instantiated `StreamingUpsample2d` with valid cases and confirmed invalid combinations raised `ValueError`, and the checks passed. 
- Attempted a higher-level import-based smoke test which failed in this environment due to a missing optional dependency (`lightning`), which is unrelated to the new upsample logic.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699ca2ce76188330a81502bdfbe25da6)