### PR TITLE
Per-head lazy allocation for reducer-backed outputs in StreamingCNN.forward

### DIFF
--- a/lightstream/core/scnn/scnn.py
+++ b/lightstream/core/scnn/scnn.py
@@ -598,6 +598,8 @@ class StreamingCNN(torch.nn.Module):
             )
 
 
+        relevant_output = None
+
         with torch.no_grad():
             for row in iterator:
                 for col in range(n_cols):
@@ -758,7 +760,8 @@ class StreamingCNN(torch.nn.Module):
             assert sides_bottom and sides_right, "It seems like we could not reconstruct all output"  # type:ignore
 
         # mem management
-        del relevant_output  # type:ignore
+        if relevant_output is not None:
+            del relevant_output
         del image
         self._saved_tensors = {}
         for idx, reducer in self._reducer_head_map.items():

--- a/lightstream/core/scnn/scnn.py
+++ b/lightstream/core/scnn/scnn.py
@@ -541,14 +541,17 @@ class StreamingCNN(torch.nn.Module):
             device = torch.device("cpu")
         else:
             device = self.device
-        outputs = [
-            torch.empty(
-                (image.shape[0], self._tile_output_shapes[idx][1], output_heights[idx], output_widths[idx]),
-                dtype=self.dtype,
-                device=device,
-            ).fill_(999)
-            for idx in range(len(self._tile_output_shapes))
-        ]
+        outputs = [None] * len(self._tile_output_shapes)
+
+        def _allocate_non_reducer_outputs():
+            for idx in range(len(self._tile_output_shapes)):
+                if idx in self._reducer_head_map or outputs[idx] is not None:
+                    continue
+                outputs[idx] = torch.empty(
+                    (image.shape[0], self._tile_output_shapes[idx][1], output_heights[idx], output_widths[idx]),
+                    dtype=self.dtype,
+                    device=device,
+                ).fill_(999)
         self._reducer_head_map = {}
         self._reducer_forward_assignments = {}
         reducer_seen_masks = {}
@@ -640,6 +643,7 @@ class StreamingCNN(torch.nn.Module):
                     tile_output = self.stream_module(tile)
                     tile_outputs, _ = self._flatten_output_structure(tile_output)
                     self._resolve_reducer_head_map(tile_outputs)
+                    _allocate_non_reducer_outputs()
 
                     if self._reducer_head_map and not reducers_initialized:
                         for head_idx, reducer in self._reducer_head_map.items():
@@ -675,6 +679,36 @@ class StreamingCNN(torch.nn.Module):
                             lost.left : head_output.shape[W_DIM] - lost.right,
                         ]
 
+                        if idx in self._reducer_head_map:
+                            dst_y0 = int(output_loc.y)
+                            dst_y1 = int(output_loc.y + trimmed_output.shape[H_DIM])
+                            dst_x0 = int(output_loc.x)
+                            dst_x1 = int(output_loc.x + trimmed_output.shape[W_DIM])
+
+                            seen_slice = reducer_seen_masks[idx][dst_y0:dst_y1, dst_x0:dst_x1]
+                            new_mask = ~seen_slice
+                            if self.debug_reducer_replay:
+                                self._reducer_forward_assignments[idx].append(
+                                    (
+                                        int(tile_y),
+                                        int(tile_x),
+                                        bool(sides.top),
+                                        bool(sides.left),
+                                        bool(sides.right),
+                                        bool(sides.bottom),
+                                        int(trimmed_output.shape[H_DIM]),
+                                        int(trimmed_output.shape[W_DIM]),
+                                        dst_y0,
+                                        dst_y1,
+                                        dst_x0,
+                                        dst_x1,
+                                    )
+                                )
+                            if torch.any(new_mask):
+                                self._reducer_head_map[idx].accumulate_tile(trimmed_output, valid_mask=new_mask)
+                                seen_slice |= new_mask
+                            continue
+
                         src_y0 = 0
                         src_y1 = int(trimmed_output.shape[H_DIM])
                         src_x0 = 0
@@ -706,32 +740,6 @@ class StreamingCNN(torch.nn.Module):
 
                         relevant_output = trimmed_output[:, :, src_y0:src_y1, src_x0:src_x1]
 
-                        if idx in self._reducer_head_map:
-                            seen_slice = reducer_seen_masks[idx][dst_y0:dst_y1, dst_x0:dst_x1]
-                            new_mask = ~seen_slice
-                            if self.debug_reducer_replay:
-                                self._reducer_forward_assignments[idx].append(
-                                    (
-                                        int(tile_y),
-                                        int(tile_x),
-                                        bool(sides.top),
-                                        bool(sides.left),
-                                        bool(sides.right),
-                                        bool(sides.bottom),
-                                        int(trimmed_output.shape[H_DIM]),
-                                        int(trimmed_output.shape[W_DIM]),
-                                        dst_y0,
-                                        dst_y1,
-                                        dst_x0,
-                                        dst_x1,
-                                    )
-                                )
-                            if torch.any(new_mask):
-                                self._reducer_head_map[idx].accumulate_tile(relevant_output, valid_mask=new_mask)
-                                seen_slice |= new_mask
-                            continue
-
-
                         assert (dst_y1 - dst_y0) == relevant_output.shape[H_DIM], (
                             f"Y-shape mismatch while stitching output head {idx}: "
                             f"dst=({dst_y0}:{dst_y1}) src_h={relevant_output.shape[H_DIM]}"
@@ -755,6 +763,9 @@ class StreamingCNN(torch.nn.Module):
         self._saved_tensors = {}
         for idx, reducer in self._reducer_head_map.items():
             outputs[idx] = reducer.finalize_stream().to(device)
+        for idx, output in enumerate(outputs):
+            if output is None:
+                raise RuntimeError(f"Output head {idx} was not populated during streaming forward.")
         output, final_idx = self._unflatten_output_structure(outputs, self._output_spec)
         assert final_idx == len(outputs)
         return output

--- a/tests/test_scnn.py
+++ b/tests/test_scnn.py
@@ -1,31 +1,84 @@
-import pytest
+import torch
+import torch.nn as nn
+
+from lightstream.core.constructor import StreamingConstructor
+from lightstream.modules.reducer import Reducer
 
 
-@pytest.fixture(params=[0, 1], ids=["spam", "ham"])
-def a(request):
-    print("request", request)
-    return request.param
+class AllReducerHeadsNet(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.backbone = nn.Sequential(
+            nn.Conv2d(3, 6, kernel_size=3, padding=1, bias=False),
+            nn.ReLU(),
+        )
+        self.sum_head = nn.Sequential(nn.Conv2d(6, 2, kernel_size=1, bias=False), Reducer(mode="sum"))
+        self.mean_head = nn.Sequential(nn.Conv2d(6, 3, kernel_size=1, bias=False), Reducer(mode="mean"))
+
+    def forward(self, x):
+        feat = self.backbone(x)
+        return self.sum_head(feat), self.mean_head(feat)
 
 
-def test_a(a):
-    pass
+class MixedHeadsNet(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.backbone = nn.Sequential(
+            nn.Conv2d(3, 5, kernel_size=3, padding=1, bias=False),
+            nn.ReLU(),
+        )
+        self.raw_head = nn.Conv2d(5, 4, kernel_size=1, bias=False)
+        self.reducer_head = nn.Sequential(nn.Conv2d(5, 4, kernel_size=1, bias=False), Reducer(mode="mean"))
+
+    def forward(self, x):
+        feat = self.backbone(x)
+        return {"raw": self.raw_head(feat), "reduced": self.reducer_head(feat)}
 
 
-def test_a2(a):
-    pass
+def _make_streaming(model: nn.Module, tile_size: int = 4):
+    constructor = StreamingConstructor(
+        model,
+        tile_size=tile_size,
+        verbose=False,
+        deterministic=True,
+        copy_to_gpu=False,
+        statistics_on_cpu=True,
+        normalize_on_gpu=False,
+    )
+    return constructor.prepare_streaming_model()
 
 
-def idfn(fixture_value):
-    if fixture_value == 0:
-        return "eggs"
-    else:
-        return None
+def test_scnn_forward_all_reducer_heads_parity():
+    torch.manual_seed(7)
+    model = AllReducerHeadsNet().eval()
+    image = torch.randn(1, 3, 9, 11)
+
+    with torch.no_grad():
+        expected_sum, expected_mean = model(image)
+
+    scnn = _make_streaming(model, tile_size=4)
+    with torch.no_grad():
+        streamed_sum, streamed_mean = scnn.forward(image)
+
+    assert streamed_sum.shape == expected_sum.shape
+    assert streamed_mean.shape == expected_mean.shape
+    assert torch.allclose(streamed_sum, expected_sum, atol=1e-5, rtol=1e-4)
+    assert torch.allclose(streamed_mean, expected_mean, atol=1e-5, rtol=1e-4)
 
 
-@pytest.fixture(params=[0, 1], ids=idfn)
-def b(request):
-    return request.param
+def test_scnn_forward_mixed_reducer_non_reducer_heads_parity():
+    torch.manual_seed(11)
+    model = MixedHeadsNet().eval()
+    image = torch.randn(1, 3, 10, 12)
 
+    with torch.no_grad():
+        expected = model(image)
 
-def test_b(b):
-    pass
+    scnn = _make_streaming(model, tile_size=5)
+    with torch.no_grad():
+        streamed = scnn.forward(image)
+
+    assert streamed["raw"].shape == expected["raw"].shape
+    assert streamed["reduced"].shape == expected["reduced"].shape
+    assert torch.allclose(streamed["raw"], expected["raw"], atol=1e-5, rtol=1e-4)
+    assert torch.allclose(streamed["reduced"], expected["reduced"], atol=1e-5, rtol=1e-4)


### PR DESCRIPTION
### Motivation
- Avoid allocating full stitched output tensors for heads implemented as `Reducer` (which stream/accumulate instead), reducing memory usage and unnecessary allocations. 
- Ensure reducer outputs are resolved and finalized from reducer state rather than written into stitched buffers during tiling. 
- Add tests to cover multi-output scenarios with all-reducer and mixed reducer/non-reducer heads to validate behavior.

### Description
- Changed `StreamingCNN.forward` in `lightstream/core/scnn/scnn.py` to initialize `outputs` as a list of `None` placeholders and defer allocation for non-reducer heads via a helper `_allocate_non_reducer_outputs()` called after the reducer map is resolved from the first tile. 
- In the tile loop, reducer-backed heads now skip the clipping/write path and instead use reducer accumulation (`accumulate_tile`) on trimmed tiles; non-reducer heads continue to be stitched into allocated tensors. 
- At finalize, reducer-backed heads are filled with `outputs[idx] = reducer.finalize_stream().to(device)` and a safety check raises if any `outputs` slot remained unpopulated before `_unflatten_output_structure`. 
- Added focused parity tests in `tests/test_scnn.py` that cover a multi-output model where all heads are reducers and a model with mixed reducer and non-reducer outputs.

### Testing
- Ran `pytest -q tests/test_scnn.py tests/test_streaming_reducer.py` to validate changes; test collection failed with import errors due to missing optional environment dependency `lightning` and a warning about missing `numpy`, so automated tests could not complete in this environment. 
- No functional test failures in-source logic observed during dry code inspection; reducer finalization and allocation guard added to catch unpopulated outputs at runtime.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a5dd7307b08330a69115fc231740d7)