### PR TITLE
Add tile-local streaming reducer autograd op and integrate with SCNN tile loop

### DIFF
--- a/lightstream/core/scnn/scnn.py
+++ b/lightstream/core/scnn/scnn.py
@@ -978,7 +978,8 @@ class StreamingCNN(torch.nn.Module):
                 del trimmed_grads
                 del trimmed_outputs
 
-        self._validate_reducer_replay_consumed(reducer_assignment_cursors)
+        if self.debug_reducer_replay:
+            StreamingReducer.validate_replay_consumed(self._reducer_forward_assignments, reducer_assignment_cursors)
 
         # Memory management
         self._saved_tensors = {}
@@ -1089,94 +1090,30 @@ class StreamingCNN(torch.nn.Module):
         sides,
         reducer_assignment_cursors,
     ):
-        expected_h = int(trimmed_output.shape[H_DIM])
-        expected_w = int(trimmed_output.shape[W_DIM])
-
-        if self.debug_reducer_replay:
-            self._validate_reducer_replay_assignment(
-                idx=idx,
-                expected_h=expected_h,
-                expected_w=expected_w,
-                input_y=input_y,
-                input_x=input_x,
-                sides=sides,
-                reducer_assignment_cursors=reducer_assignment_cursors,
-            )
-
         reducer = self._reducer_head_map[idx]
-        normalization = reducer.running_count if reducer.mode == "mean" else None
-        reduced_output = reducer.reduce_tile(trimmed_output, normalization=normalization)
-        return reduced_output, gradient
 
-    def _validate_reducer_replay_assignment(
-        self,
-        idx,
-        expected_h,
-        expected_w,
-        input_y,
-        input_x,
-        sides,
-        reducer_assignment_cursors,
-    ):
-        assignments = self._reducer_forward_assignments.get(idx)
-        if assignments is None:
-            raise RuntimeError(f"Missing forward reducer assignments for head {idx}")
+        assignments = None
+        cursor = None
+        if self.debug_reducer_replay:
+            assignments = self._reducer_forward_assignments.get(idx)
+            if assignments is None:
+                raise RuntimeError(f"Missing forward reducer assignments for head {idx}")
+            cursor = reducer_assignment_cursors[idx]
 
-        cursor = reducer_assignment_cursors[idx]
-        if cursor >= len(assignments):
-            raise RuntimeError(f"Reducer assignment cursor out of range for head {idx}")
+        reduced_output, reduced_grad, next_cursor = reducer.build_backward_pair(
+            trimmed_output,
+            gradient,
+            input_y=int(input_y),
+            input_x=int(input_x),
+            sides=sides,
+            assignments=assignments,
+            cursor=cursor,
+        )
 
-        (
-            f_tile_y,
-            f_tile_x,
-            f_top,
-            f_left,
-            f_right,
-            f_bottom,
-            f_h,
-            f_w,
-            dst_y0,
-            dst_y1,
-            dst_x0,
-            dst_x1,
-        ) = assignments[cursor]
-        reducer_assignment_cursors[idx] = cursor + 1
+        if next_cursor is not None:
+            reducer_assignment_cursors[idx] = next_cursor
 
-        if (
-            int(input_y) != int(f_tile_y)
-            or int(input_x) != int(f_tile_x)
-            or bool(sides.top) != bool(f_top)
-            or bool(sides.left) != bool(f_left)
-            or bool(sides.right) != bool(f_right)
-            or bool(sides.bottom) != bool(f_bottom)
-        ):
-            raise RuntimeError(
-                f"Reducer tile replay mismatch for head {idx}: "
-                f"forward tile=({f_tile_y},{f_tile_x},{f_top},{f_left},{f_right},{f_bottom}) "
-                f"backward tile=({int(input_y)},{int(input_x)},{bool(sides.top)},{bool(sides.left)},{bool(sides.right)},{bool(sides.bottom)})"
-            )
-
-        if expected_h != int(f_h) or expected_w != int(f_w):
-            raise RuntimeError(
-                f"Reducer trimmed shape mismatch for head {idx}: forward=({f_h},{f_w}) "
-                f"backward=({expected_h},{expected_w})"
-            )
-
-        if (dst_y1 - dst_y0) != expected_h or (dst_x1 - dst_x0) != expected_w:
-            raise RuntimeError(
-                f"Reducer assignment mismatch for head {idx}: "
-                f"stored=({dst_y0}:{dst_y1},{dst_x0}:{dst_x1}) current=({expected_h},{expected_w})"
-            )
-
-    def _validate_reducer_replay_consumed(self, reducer_assignment_cursors):
-        if not self.debug_reducer_replay:
-            return
-        for idx, assignments in self._reducer_forward_assignments.items():
-            consumed = reducer_assignment_cursors.get(idx, 0)
-            if consumed != len(assignments):
-                raise RuntimeError(
-                    f"Reducer assignment replay incomplete for head {idx}: consumed={consumed}, expected={len(assignments)}"
-                )
+        return reduced_output, reduced_grad
 
     def _get_tile_lost_for_sides(self, sides, output_lost=None):
         output_lost = self.tile_output_lost if output_lost is None else output_lost

--- a/lightstream/core/scnn/scnn.py
+++ b/lightstream/core/scnn/scnn.py
@@ -956,75 +956,20 @@ class StreamingCNN(torch.nn.Module):
                 trimmed_outputs = []
                 trimmed_grads = []
                 for idx, (head_output, head_grad) in enumerate(zip(tile_outputs, grad_tensors)):
-                    head_lost = self._get_tile_lost_for_sides(sides, self._tile_output_lost[idx])
-                    head_output_height = self._tile_output_shapes[idx][H_DIM]
-                    head_output_width = self._tile_output_shapes[idx][W_DIM]
-                    head_stride = self._output_stride_per_output[idx]
-                    head_output_y = input_y // int(head_stride[1])
-                    head_output_x = input_x // int(head_stride[2])
-
-                    if sides.bottom:
-                        if idx in self._reducer_head_map:
-                            head_output_y = max(output_heights[idx] - head_output_height, 0)
-                        else:
-                            head_output_y = max(head_grad.shape[H_DIM] - head_output_height, 0)
-                    if sides.right:
-                        if idx in self._reducer_head_map:
-                            head_output_x = max(output_widths[idx] - head_output_width, 0)
-                        else:
-                            head_output_x = max(head_grad.shape[W_DIM] - head_output_width, 0)
-
-                    if idx in self._reducer_head_map:
-                        gradient = head_grad.to(self.device, non_blocking=True)
-                        if gradient.shape[H_DIM] != 1 or gradient.shape[W_DIM] != 1:
-                            raise ValueError(
-                                f"Reducer-backed head expects gradient of shape N,C,1,1, got {tuple(gradient.shape)}"
-                            )
-                    else:
-                        gradient = head_grad[
-                            :,
-                            :,
-                            head_output_y : head_output_y + head_output_height,
-                            head_output_x : head_output_x + head_output_width,
-                        ]
-                    trimmed_output = head_output[
-                        :,
-                        :,
-                        head_lost.top : head_output.shape[H_DIM] - head_lost.bottom,
-                        head_lost.left : head_output.shape[W_DIM] - head_lost.right,
-                    ]
-
-                    trimmed_output = trimmed_output.to(self.device, non_blocking=True)
-
-                    if idx in self._reducer_head_map:
-                        reduced_output, reduced_grad = self._build_reducer_backward_pair(
-                            idx=idx,
-                            trimmed_output=trimmed_output,
-                            gradient=gradient,
-                            input_y=input_y,
-                            input_x=input_x,
-                            sides=sides,
-                            reducer_assignment_cursors=reducer_assignment_cursors,
-                        )
-                        trimmed_outputs.append(reduced_output)
-                        trimmed_grads.append(reduced_grad)
-                        continue
-                    else:
-                        trimmed_grad = gradient[
-                            :,
-                            :,
-                            head_lost.top : gradient.shape[H_DIM] - head_lost.bottom,
-                            head_lost.left : gradient.shape[W_DIM] - head_lost.right,
-                        ]
-
-                        if (
-                            trimmed_grad.shape[H_DIM] != trimmed_output.shape[H_DIM]
-                            or trimmed_grad.shape[W_DIM] != trimmed_output.shape[W_DIM]
-                        ):
-                            assert image.shape[H_DIM] < self.tile_shape[H_DIM] or image.shape[W_DIM] < self.tile_shape[W_DIM]
-                            trimmed_grad = trimmed_grad[:, :, 0 : trimmed_output.shape[H_DIM], 0 : trimmed_output.shape[W_DIM]]
-                    trimmed_outputs.append(trimmed_output)
-                    trimmed_grads.append(trimmed_grad)
+                    paired_output, paired_grad = self._build_head_backward_pair(
+                        idx=idx,
+                        head_output=head_output,
+                        head_grad=head_grad,
+                        input_y=input_y,
+                        input_x=input_x,
+                        sides=sides,
+                        output_heights=output_heights,
+                        output_widths=output_widths,
+                        reducer_assignment_cursors=reducer_assignment_cursors,
+                        image=image,
+                    )
+                    trimmed_outputs.append(paired_output)
+                    trimmed_grads.append(paired_grad)
 
                 torch.autograd.backward(trimmed_outputs, trimmed_grads)
 
@@ -1048,6 +993,91 @@ class StreamingCNN(torch.nn.Module):
         assert last_sides is not None and last_sides.right and last_sides.bottom, (
             "It seems like we could not reconstruct all output"
         )
+
+    def _build_head_backward_pair(
+        self,
+        idx,
+        head_output,
+        head_grad,
+        input_y,
+        input_x,
+        sides,
+        output_heights,
+        output_widths,
+        reducer_assignment_cursors,
+        image,
+    ):
+        is_reducer_head = idx in self._reducer_head_map
+        head_lost = self._get_tile_lost_for_sides(sides, self._tile_output_lost[idx])
+        head_output_height = self._tile_output_shapes[idx][H_DIM]
+        head_output_width = self._tile_output_shapes[idx][W_DIM]
+
+        head_stride = self._output_stride_per_output[idx]
+        head_output_y = input_y // int(head_stride[1])
+        head_output_x = input_x // int(head_stride[2])
+
+        if sides.bottom:
+            if is_reducer_head:
+                head_output_y = max(output_heights[idx] - head_output_height, 0)
+            else:
+                head_output_y = max(head_grad.shape[H_DIM] - head_output_height, 0)
+        if sides.right:
+            if is_reducer_head:
+                head_output_x = max(output_widths[idx] - head_output_width, 0)
+            else:
+                head_output_x = max(head_grad.shape[W_DIM] - head_output_width, 0)
+
+        if is_reducer_head:
+            gradient = head_grad.to(self.device, non_blocking=True)
+            if gradient.shape[H_DIM] != 1 or gradient.shape[W_DIM] != 1:
+                raise ValueError(f"Reducer-backed head expects gradient of shape N,C,1,1, got {tuple(gradient.shape)}")
+        else:
+            gradient = head_grad[
+                :,
+                :,
+                head_output_y : head_output_y + head_output_height,
+                head_output_x : head_output_x + head_output_width,
+            ]
+
+        trimmed_output = head_output[
+            :,
+            :,
+            head_lost.top : head_output.shape[H_DIM] - head_lost.bottom,
+            head_lost.left : head_output.shape[W_DIM] - head_lost.right,
+        ]
+        trimmed_output = trimmed_output.to(self.device, non_blocking=True)
+
+        if is_reducer_head:
+            return self._build_reducer_backward_pair(
+                idx=idx,
+                trimmed_output=trimmed_output,
+                gradient=gradient,
+                input_y=input_y,
+                input_x=input_x,
+                sides=sides,
+                reducer_assignment_cursors=reducer_assignment_cursors,
+            )
+
+        return self._build_non_reducer_backward_pair(
+            trimmed_output=trimmed_output,
+            gradient=gradient,
+            head_lost=head_lost,
+            image=image,
+        )
+
+    def _build_non_reducer_backward_pair(self, trimmed_output, gradient, head_lost, image):
+        trimmed_grad = gradient[
+            :,
+            :,
+            head_lost.top : gradient.shape[H_DIM] - head_lost.bottom,
+            head_lost.left : gradient.shape[W_DIM] - head_lost.right,
+        ]
+
+        if trimmed_grad.shape[H_DIM] != trimmed_output.shape[H_DIM] or trimmed_grad.shape[W_DIM] != trimmed_output.shape[W_DIM]:
+            assert image.shape[H_DIM] < self.tile_shape[H_DIM] or image.shape[W_DIM] < self.tile_shape[W_DIM]
+            trimmed_grad = trimmed_grad[:, :, 0 : trimmed_output.shape[H_DIM], 0 : trimmed_output.shape[W_DIM]]
+
+        return trimmed_output, trimmed_grad
 
     def _build_reducer_backward_pair(
         self,

--- a/lightstream/core/scnn/scnn.py
+++ b/lightstream/core/scnn/scnn.py
@@ -1050,16 +1050,16 @@ class StreamingCNN(torch.nn.Module):
                                 )
 
                         reducer = self._reducer_head_map[idx]
-                        per_pixel_grad = gradient
+                        normalization = None
                         if reducer.mode == "mean":
-                            denom = reducer.running_count.to(per_pixel_grad.device, dtype=per_pixel_grad.dtype).clamp_min(1)
-                            per_pixel_grad = per_pixel_grad / denom
-                        trimmed_grad = per_pixel_grad.expand(
-                            -1,
-                            -1,
-                            expected_h,
-                            expected_w,
+                            normalization = reducer.running_count
+                        reduced_output = reducer.reduce_tile(
+                            trimmed_output,
+                            normalization=normalization,
                         )
+                        trimmed_outputs.append(reduced_output)
+                        trimmed_grads.append(gradient)
+                        continue
                     else:
                         trimmed_grad = gradient[
                             :,

--- a/lightstream/core/scnn/scnn.py
+++ b/lightstream/core/scnn/scnn.py
@@ -997,68 +997,17 @@ class StreamingCNN(torch.nn.Module):
                     trimmed_output = trimmed_output.to(self.device, non_blocking=True)
 
                     if idx in self._reducer_head_map:
-                        expected_h = int(trimmed_output.shape[H_DIM])
-                        expected_w = int(trimmed_output.shape[W_DIM])
-
-                        if self.debug_reducer_replay:
-                            assignments = self._reducer_forward_assignments.get(idx)
-                            if assignments is None:
-                                raise RuntimeError(f"Missing forward reducer assignments for head {idx}")
-                            cursor = reducer_assignment_cursors[idx]
-                            if cursor >= len(assignments):
-                                raise RuntimeError(f"Reducer assignment cursor out of range for head {idx}")
-                            (
-                                f_tile_y,
-                                f_tile_x,
-                                f_top,
-                                f_left,
-                                f_right,
-                                f_bottom,
-                                f_h,
-                                f_w,
-                                dst_y0,
-                                dst_y1,
-                                dst_x0,
-                                dst_x1,
-                            ) = assignments[cursor]
-                            reducer_assignment_cursors[idx] = cursor + 1
-
-                            if (
-                                int(input_y) != int(f_tile_y)
-                                or int(input_x) != int(f_tile_x)
-                                or bool(sides.top) != bool(f_top)
-                                or bool(sides.left) != bool(f_left)
-                                or bool(sides.right) != bool(f_right)
-                                or bool(sides.bottom) != bool(f_bottom)
-                            ):
-                                raise RuntimeError(
-                                    f"Reducer tile replay mismatch for head {idx}: "
-                                    f"forward tile=({f_tile_y},{f_tile_x},{f_top},{f_left},{f_right},{f_bottom}) "
-                                    f"backward tile=({int(input_y)},{int(input_x)},{bool(sides.top)},{bool(sides.left)},{bool(sides.right)},{bool(sides.bottom)})"
-                                )
-
-                            if expected_h != int(f_h) or expected_w != int(f_w):
-                                raise RuntimeError(
-                                    f"Reducer trimmed shape mismatch for head {idx}: forward=({f_h},{f_w}) "
-                                    f"backward=({expected_h},{expected_w})"
-                                )
-
-                            if (dst_y1 - dst_y0) != expected_h or (dst_x1 - dst_x0) != expected_w:
-                                raise RuntimeError(
-                                    f"Reducer assignment mismatch for head {idx}: "
-                                    f"stored=({dst_y0}:{dst_y1},{dst_x0}:{dst_x1}) current=({expected_h},{expected_w})"
-                                )
-
-                        reducer = self._reducer_head_map[idx]
-                        normalization = None
-                        if reducer.mode == "mean":
-                            normalization = reducer.running_count
-                        reduced_output = reducer.reduce_tile(
-                            trimmed_output,
-                            normalization=normalization,
+                        reduced_output, reduced_grad = self._build_reducer_backward_pair(
+                            idx=idx,
+                            trimmed_output=trimmed_output,
+                            gradient=gradient,
+                            input_y=input_y,
+                            input_x=input_x,
+                            sides=sides,
+                            reducer_assignment_cursors=reducer_assignment_cursors,
                         )
                         trimmed_outputs.append(reduced_output)
-                        trimmed_grads.append(gradient)
+                        trimmed_grads.append(reduced_grad)
                         continue
                     else:
                         trimmed_grad = gradient[
@@ -1084,13 +1033,7 @@ class StreamingCNN(torch.nn.Module):
                 del trimmed_grads
                 del trimmed_outputs
 
-        if self.debug_reducer_replay:
-            for idx, assignments in self._reducer_forward_assignments.items():
-                consumed = reducer_assignment_cursors.get(idx, 0)
-                if consumed != len(assignments):
-                    raise RuntimeError(
-                        f"Reducer assignment replay incomplete for head {idx}: consumed={consumed}, expected={len(assignments)}"
-                    )
+        self._validate_reducer_replay_consumed(reducer_assignment_cursors)
 
         # Memory management
         self._saved_tensors = {}
@@ -1105,6 +1048,105 @@ class StreamingCNN(torch.nn.Module):
         assert last_sides is not None and last_sides.right and last_sides.bottom, (
             "It seems like we could not reconstruct all output"
         )
+
+    def _build_reducer_backward_pair(
+        self,
+        idx,
+        trimmed_output,
+        gradient,
+        input_y,
+        input_x,
+        sides,
+        reducer_assignment_cursors,
+    ):
+        expected_h = int(trimmed_output.shape[H_DIM])
+        expected_w = int(trimmed_output.shape[W_DIM])
+
+        if self.debug_reducer_replay:
+            self._validate_reducer_replay_assignment(
+                idx=idx,
+                expected_h=expected_h,
+                expected_w=expected_w,
+                input_y=input_y,
+                input_x=input_x,
+                sides=sides,
+                reducer_assignment_cursors=reducer_assignment_cursors,
+            )
+
+        reducer = self._reducer_head_map[idx]
+        normalization = reducer.running_count if reducer.mode == "mean" else None
+        reduced_output = reducer.reduce_tile(trimmed_output, normalization=normalization)
+        return reduced_output, gradient
+
+    def _validate_reducer_replay_assignment(
+        self,
+        idx,
+        expected_h,
+        expected_w,
+        input_y,
+        input_x,
+        sides,
+        reducer_assignment_cursors,
+    ):
+        assignments = self._reducer_forward_assignments.get(idx)
+        if assignments is None:
+            raise RuntimeError(f"Missing forward reducer assignments for head {idx}")
+
+        cursor = reducer_assignment_cursors[idx]
+        if cursor >= len(assignments):
+            raise RuntimeError(f"Reducer assignment cursor out of range for head {idx}")
+
+        (
+            f_tile_y,
+            f_tile_x,
+            f_top,
+            f_left,
+            f_right,
+            f_bottom,
+            f_h,
+            f_w,
+            dst_y0,
+            dst_y1,
+            dst_x0,
+            dst_x1,
+        ) = assignments[cursor]
+        reducer_assignment_cursors[idx] = cursor + 1
+
+        if (
+            int(input_y) != int(f_tile_y)
+            or int(input_x) != int(f_tile_x)
+            or bool(sides.top) != bool(f_top)
+            or bool(sides.left) != bool(f_left)
+            or bool(sides.right) != bool(f_right)
+            or bool(sides.bottom) != bool(f_bottom)
+        ):
+            raise RuntimeError(
+                f"Reducer tile replay mismatch for head {idx}: "
+                f"forward tile=({f_tile_y},{f_tile_x},{f_top},{f_left},{f_right},{f_bottom}) "
+                f"backward tile=({int(input_y)},{int(input_x)},{bool(sides.top)},{bool(sides.left)},{bool(sides.right)},{bool(sides.bottom)})"
+            )
+
+        if expected_h != int(f_h) or expected_w != int(f_w):
+            raise RuntimeError(
+                f"Reducer trimmed shape mismatch for head {idx}: forward=({f_h},{f_w}) "
+                f"backward=({expected_h},{expected_w})"
+            )
+
+        if (dst_y1 - dst_y0) != expected_h or (dst_x1 - dst_x0) != expected_w:
+            raise RuntimeError(
+                f"Reducer assignment mismatch for head {idx}: "
+                f"stored=({dst_y0}:{dst_y1},{dst_x0}:{dst_x1}) current=({expected_h},{expected_w})"
+            )
+
+    def _validate_reducer_replay_consumed(self, reducer_assignment_cursors):
+        if not self.debug_reducer_replay:
+            return
+        for idx, assignments in self._reducer_forward_assignments.items():
+            consumed = reducer_assignment_cursors.get(idx, 0)
+            if consumed != len(assignments):
+                raise RuntimeError(
+                    f"Reducer assignment replay incomplete for head {idx}: consumed={consumed}, expected={len(assignments)}"
+                )
 
     def _get_tile_lost_for_sides(self, sides, output_lost=None):
         output_lost = self.tile_output_lost if output_lost is None else output_lost

--- a/lightstream/modules/reducer.py
+++ b/lightstream/modules/reducer.py
@@ -89,8 +89,11 @@ class Reducer(nn.Module):
 class StreamingReducer(nn.Module):
     """Streaming counterpart of :class:`Reducer`.
 
-    In streaming mode this module acts as a marker and keeps accumulation state
-    managed from SCNN's tile loop.
+    Responsibility split:
+    - SCNN orchestrates tile traversal/placement and decides which tile pixels
+      are valid contributors.
+    - StreamingReducer owns tile-local reducer math via ``reduce_tile``
+      (custom autograd op) and keeps stream accumulation state.
     """
 
     def __init__(self, mode: str = "mean"):

--- a/lightstream/modules/reducer.py
+++ b/lightstream/modules/reducer.py
@@ -117,13 +117,6 @@ class StreamingReducer(nn.Module):
         self.running_sum = torch.zeros((batch_size, channels, 1, 1), device=device, dtype=dtype)
         self.running_count = torch.zeros((batch_size, 1, 1, 1), device=device, dtype=dtype)
 
-    def reduce_full_output(self, full_output: torch.Tensor) -> torch.Tensor:
-        if full_output.ndim != 4:
-            raise ValueError(f"StreamingReducer expects NCHW tensor, got shape={tuple(full_output.shape)}")
-        if self.mode == "sum":
-            return full_output.sum(dim=(-2, -1), keepdim=True)
-        return full_output.mean(dim=(-2, -1), keepdim=True)
-
     def accumulate_tile(self, tile_valid_output: torch.Tensor, valid_mask: torch.Tensor | None = None):
         if self.running_sum.numel() == 0:
             self.reset_stream_state(

--- a/lightstream/modules/reducer.py
+++ b/lightstream/modules/reducer.py
@@ -2,6 +2,70 @@ import torch
 import torch.nn as nn
 
 
+class StreamingReducerTileF(torch.autograd.Function):
+    """Tile-local reducer op used by :class:`StreamingReducer`.
+
+    The op supports an optional 2D valid mask and optional normalization factor.
+    This lets SCNN keep tile orchestration while reducer math (forward/backward)
+    lives in reducer logic.
+    """
+
+    @staticmethod
+    def forward(
+        ctx,
+        tile_output: torch.Tensor,
+        valid_mask: torch.Tensor | None,
+        normalization: torch.Tensor | None,
+    ) -> torch.Tensor:
+        if tile_output.ndim != 4:
+            raise ValueError(f"StreamingReducer expects NCHW tile, got shape={tuple(tile_output.shape)}")
+
+        if valid_mask is not None:
+            if valid_mask.ndim != 2:
+                raise ValueError(f"valid_mask must be 2D (H,W), got shape={tuple(valid_mask.shape)}")
+            mask_4d = valid_mask.to(dtype=tile_output.dtype, device=tile_output.device)[None, None]
+            masked = tile_output * mask_4d
+            ctx.save_for_backward(mask_4d)
+            ctx.has_mask = True
+        else:
+            masked = tile_output
+            ctx.save_for_backward(torch.zeros(0, device=tile_output.device, dtype=tile_output.dtype))
+            ctx.has_mask = False
+
+        ctx.input_height = tile_output.shape[-2]
+        ctx.input_width = tile_output.shape[-1]
+
+        if normalization is not None:
+            norm = normalization.to(device=tile_output.device, dtype=tile_output.dtype).clamp_min(1)
+            reduced = masked.sum(dim=(-2, -1), keepdim=True) / norm
+            ctx.normalization = norm
+            ctx.has_normalization = True
+        else:
+            reduced = masked.sum(dim=(-2, -1), keepdim=True)
+            ctx.normalization = None
+            ctx.has_normalization = False
+
+        return reduced
+
+    @staticmethod
+    def backward(ctx, grad_output: torch.Tensor):
+        (mask_4d,) = ctx.saved_tensors
+
+        grad_input = grad_output
+        if ctx.has_normalization:
+            grad_input = grad_input / ctx.normalization
+
+        grad_input = grad_input.expand(-1, -1, ctx.input_height, ctx.input_width)
+
+        if ctx.has_mask:
+            grad_input = grad_input * mask_4d.to(dtype=grad_input.dtype, device=grad_input.device)
+
+        return grad_input, None, None
+
+
+streaming_reduce_tile = StreamingReducerTileF.apply
+
+
 class Reducer(nn.Module):
     """Global spatial reducer for NCHW tensors."""
 
@@ -58,8 +122,6 @@ class StreamingReducer(nn.Module):
         return full_output.mean(dim=(-2, -1), keepdim=True)
 
     def accumulate_tile(self, tile_valid_output: torch.Tensor, valid_mask: torch.Tensor | None = None):
-        if tile_valid_output.ndim != 4:
-            raise ValueError(f"StreamingReducer expects NCHW tile, got shape={tuple(tile_valid_output.shape)}")
         if self.running_sum.numel() == 0:
             self.reset_stream_state(
                 batch_size=tile_valid_output.shape[0],
@@ -68,14 +130,12 @@ class StreamingReducer(nn.Module):
                 dtype=tile_valid_output.dtype,
             )
 
+        tile_contribution = self.reduce_tile(tile_valid_output, valid_mask=valid_mask)
+        self.running_sum = self.running_sum + tile_contribution
+
         if valid_mask is None:
-            self.running_sum = self.running_sum + tile_valid_output.sum(dim=(-2, -1), keepdim=True)
             n_pixels = tile_valid_output.shape[-1] * tile_valid_output.shape[-2]
         else:
-            if valid_mask.ndim != 2:
-                raise ValueError(f"valid_mask must be 2D (H,W), got shape={tuple(valid_mask.shape)}")
-            mask = valid_mask.to(tile_valid_output.dtype)[None, None]
-            self.running_sum = self.running_sum + (tile_valid_output * mask).sum(dim=(-2, -1), keepdim=True)
             n_pixels = int(valid_mask.sum().item())
 
         if self.mode == "mean":
@@ -88,6 +148,14 @@ class StreamingReducer(nn.Module):
             return self.running_sum
         denom = self.running_count.clamp_min(1)
         return self.running_sum / denom
+
+    def reduce_tile(
+        self,
+        tile_output: torch.Tensor,
+        valid_mask: torch.Tensor | None = None,
+        normalization: torch.Tensor | None = None,
+    ) -> torch.Tensor:
+        return streaming_reduce_tile(tile_output, valid_mask, normalization)
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:
         # Marker behavior for streaming path; SCNN performs accumulation.

--- a/lightstream/modules/reducer.py
+++ b/lightstream/modules/reducer.py
@@ -160,6 +160,113 @@ class StreamingReducer(nn.Module):
     ) -> torch.Tensor:
         return streaming_reduce_tile(tile_output, valid_mask, normalization)
 
+    def build_backward_pair(
+        self,
+        trimmed_output: torch.Tensor,
+        gradient: torch.Tensor,
+        *,
+        input_y: int,
+        input_x: int,
+        sides,
+        assignments: list[tuple] | None = None,
+        cursor: int | None = None,
+    ) -> tuple[torch.Tensor, torch.Tensor, int | None]:
+        """Build reducer-backed backward pair for a single tile output.
+
+        SCNN provides orchestration metadata (tile location/sides) and optional
+        replay assignment entries; reducer applies reducer-specific checks and
+        tile-local reduction math.
+        """
+        expected_h = int(trimmed_output.shape[-2])
+        expected_w = int(trimmed_output.shape[-1])
+
+        next_cursor = cursor
+        if assignments is not None:
+            if cursor is None:
+                raise RuntimeError("Reducer replay cursor is required when assignments are provided.")
+            next_cursor = self._validate_replay_assignment(
+                assignments=assignments,
+                cursor=cursor,
+                input_y=input_y,
+                input_x=input_x,
+                sides=sides,
+                expected_h=expected_h,
+                expected_w=expected_w,
+            )
+
+        normalization = self.running_count if self.mode == "mean" else None
+        reduced_output = self.reduce_tile(trimmed_output, normalization=normalization)
+        return reduced_output, gradient, next_cursor
+
+    def _validate_replay_assignment(
+        self,
+        *,
+        assignments: list[tuple],
+        cursor: int,
+        input_y: int,
+        input_x: int,
+        sides,
+        expected_h: int,
+        expected_w: int,
+    ) -> int:
+        if cursor >= len(assignments):
+            raise RuntimeError("Reducer assignment cursor out of range.")
+
+        (
+            f_tile_y,
+            f_tile_x,
+            f_top,
+            f_left,
+            f_right,
+            f_bottom,
+            f_h,
+            f_w,
+            dst_y0,
+            dst_y1,
+            dst_x0,
+            dst_x1,
+        ) = assignments[cursor]
+
+        if (
+            int(input_y) != int(f_tile_y)
+            or int(input_x) != int(f_tile_x)
+            or bool(sides.top) != bool(f_top)
+            or bool(sides.left) != bool(f_left)
+            or bool(sides.right) != bool(f_right)
+            or bool(sides.bottom) != bool(f_bottom)
+        ):
+            raise RuntimeError(
+                "Reducer tile replay mismatch: "
+                f"forward tile=({f_tile_y},{f_tile_x},{f_top},{f_left},{f_right},{f_bottom}) "
+                f"backward tile=({int(input_y)},{int(input_x)},{bool(sides.top)},{bool(sides.left)},{bool(sides.right)},{bool(sides.bottom)})"
+            )
+
+        if expected_h != int(f_h) or expected_w != int(f_w):
+            raise RuntimeError(
+                "Reducer trimmed shape mismatch: "
+                f"forward=({f_h},{f_w}) backward=({expected_h},{expected_w})"
+            )
+
+        if (dst_y1 - dst_y0) != expected_h or (dst_x1 - dst_x0) != expected_w:
+            raise RuntimeError(
+                "Reducer assignment mismatch: "
+                f"stored=({dst_y0}:{dst_y1},{dst_x0}:{dst_x1}) current=({expected_h},{expected_w})"
+            )
+
+        return cursor + 1
+
+    @staticmethod
+    def validate_replay_consumed(
+        assignments_map: dict[int, list[tuple]],
+        assignment_cursors: dict[int, int],
+    ) -> None:
+        for idx, assignments in assignments_map.items():
+            consumed = assignment_cursors.get(idx, 0)
+            if consumed != len(assignments):
+                raise RuntimeError(
+                    f"Reducer assignment replay incomplete for head {idx}: consumed={consumed}, expected={len(assignments)}"
+                )
+
     def forward(self, x: torch.Tensor) -> torch.Tensor:
         # Marker behavior for streaming path; SCNN performs accumulation.
         self._last_output = x

--- a/tests/test_streaming_reducer.py
+++ b/tests/test_streaming_reducer.py
@@ -82,3 +82,30 @@ def test_streaming_reducer_multiple_reducers_modes_forward_parity():
     assert streamed_mean.shape == expected_mean.shape
     assert torch.allclose(streamed_sum, expected_sum, atol=1e-5, rtol=1e-4)
     assert torch.allclose(streamed_mean, expected_mean, atol=1e-5, rtol=1e-4)
+
+
+def test_streaming_reducer_backward_parity():
+    torch.manual_seed(3)
+    model = MultiReducerNet().eval()
+    image = torch.randn(1, 3, 11, 9)
+
+    reference = MultiReducerNet().eval()
+    reference.load_state_dict(model.state_dict())
+
+    ref_image = image.clone().requires_grad_(True)
+    ref_sum, ref_mean = reference(ref_image)
+    ref_loss = (0.7 * ref_sum).sum() + (1.3 * ref_mean).sum()
+    ref_loss.backward()
+
+    scnn = _make_streaming(model, tile_size=4)
+    streamed_sum, streamed_mean = scnn.forward(image.clone())
+    grad_sum = torch.full_like(streamed_sum, 0.7)
+    grad_mean = torch.full_like(streamed_mean, 1.3)
+    scnn.backward(image.clone(), (grad_sum, grad_mean))
+
+    ref_grads = {name: p.grad for name, p in reference.named_parameters() if p.grad is not None}
+    stream_grads = {name: p.grad for name, p in scnn.stream_module.named_parameters() if p.grad is not None}
+
+    for name, ref_grad in ref_grads.items():
+        assert name in stream_grads
+        assert torch.allclose(stream_grads[name], ref_grad, atol=1e-5, rtol=1e-4), name

--- a/tests/test_streaming_reducer.py
+++ b/tests/test_streaming_reducer.py
@@ -109,3 +109,30 @@ def test_streaming_reducer_backward_parity():
     for name, ref_grad in ref_grads.items():
         assert name in stream_grads
         assert torch.allclose(stream_grads[name], ref_grad, atol=1e-5, rtol=1e-4), name
+
+
+def test_streaming_reducer_backward_parity_tiny_odd_image():
+    torch.manual_seed(5)
+    model = MultiReducerNet().eval()
+    image = torch.randn(1, 3, 3, 5)
+
+    reference = MultiReducerNet().eval()
+    reference.load_state_dict(model.state_dict())
+
+    ref_image = image.clone().requires_grad_(True)
+    ref_sum, ref_mean = reference(ref_image)
+    ref_loss = (0.2 * ref_sum).sum() + (-0.4 * ref_mean).sum()
+    ref_loss.backward()
+
+    scnn = _make_streaming(model, tile_size=6)
+    streamed_sum, streamed_mean = scnn.forward(image.clone())
+    grad_sum = torch.full_like(streamed_sum, 0.2)
+    grad_mean = torch.full_like(streamed_mean, -0.4)
+    scnn.backward(image.clone(), (grad_sum, grad_mean))
+
+    ref_grads = {name: p.grad for name, p in reference.named_parameters() if p.grad is not None}
+    stream_grads = {name: p.grad for name, p in scnn.stream_module.named_parameters() if p.grad is not None}
+
+    for name, ref_grad in ref_grads.items():
+        assert name in stream_grads
+        assert torch.allclose(stream_grads[name], ref_grad, atol=1e-5, rtol=1e-4), name


### PR DESCRIPTION
### Motivation
- Delegate tile reduction math to a tile-local autograd op to keep streaming orchestration in SCNN while ensuring correct forward/backward behavior. 
- Support optional per-tile valid masks and normalization so mean-mode streaming reductions use the same logic in forward and backward passes. 
- Simplify `StreamingReducer` bookkeeping and fix mismatches where normalization was applied outside reducer logic. 

### Description
- Introduce `StreamingReducerTileF` autograd `Function` (exposed as `streaming_reduce_tile`) that performs sum/mean reduction over a tile with optional 2D `valid_mask` and optional `normalization`, and implements the correct backward that respects mask and normalization. 
- Add `StreamingReducer.reduce_tile` wrapper that calls `streaming_reduce_tile` and update `StreamingReducer.accumulate_tile` to use `reduce_tile` to compute per-tile contributions before updating `running_sum` and `running_count`. 
- Update SCNN tile loop (`StreamingCNN`) to call `reducer.reduce_tile(trimmed_output, normalization=normalization)` and append reduced outputs and gradients so reduction math (including normalization) is handled by the reducer op. 
- Add `test_streaming_reducer_backward_parity` to validate backward parity between the streaming path and a reference non-streaming network. 

### Testing
- Ran the unit tests in `tests/test_streaming_reducer.py`, including `test_streaming_reducer_mixed_outputs_forward_parity`, `test_streaming_reducer_multiple_reducers_modes_forward_parity`, and the new `test_streaming_reducer_backward_parity`, and they all passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a80f8a929c8330afec6b329555703a)