### PR TITLE
Refactor StreamingReducer to own stream/replay session and simplify SCNN plumbing

### DIFF
--- a/lightstream/core/scnn/scnn.py
+++ b/lightstream/core/scnn/scnn.py
@@ -100,7 +100,6 @@ class StreamingCNN(torch.nn.Module):
         self._module_stats = {}
         self._backward_seen_indices = {}
         self._saved_tensors = {}
-        self._reducer_forward_assignments = {}
         self.debug_reducer_replay = False
         self._hooks = []
         self._last_forward_tiles = []
@@ -517,8 +516,6 @@ class StreamingCNN(torch.nn.Module):
                     device=device,
                 ).fill_(999)
         self._reducer_head_map = {}
-        self._reducer_forward_assignments = {}
-        reducer_seen_masks = {}
         reducers_initialized = False
 
         if len(self._tile_output_shapes) > 1:
@@ -610,19 +607,15 @@ class StreamingCNN(torch.nn.Module):
 
                     if self._reducer_head_map and not reducers_initialized:
                         for head_idx, reducer in self._reducer_head_map.items():
-                            reducer.reset_stream_state(
+                            reducer.start_stream(
+                                output_height=output_heights[head_idx],
+                                output_width=output_widths[head_idx],
                                 batch_size=image.shape[B_DIM],
                                 channels=self._tile_output_shapes[head_idx][C_DIM],
                                 device=self.device,
                                 dtype=self.dtype,
+                                debug_replay=self.debug_reducer_replay,
                             )
-                            reducer_seen_masks[head_idx] = torch.zeros(
-                                (output_heights[head_idx], output_widths[head_idx]),
-                                dtype=torch.bool,
-                                device=self.device,
-                            )
-                            if self.debug_reducer_replay:
-                                self._reducer_forward_assignments[head_idx] = []
                         reducers_initialized = True
 
 
@@ -648,28 +641,13 @@ class StreamingCNN(torch.nn.Module):
                             dst_x0 = int(output_loc.x)
                             dst_x1 = int(output_loc.x + trimmed_output.shape[W_DIM])
 
-                            seen_slice = reducer_seen_masks[idx][dst_y0:dst_y1, dst_x0:dst_x1]
-                            new_mask = ~seen_slice
-                            if self.debug_reducer_replay:
-                                self._reducer_forward_assignments[idx].append(
-                                    (
-                                        int(tile_y),
-                                        int(tile_x),
-                                        bool(sides.top),
-                                        bool(sides.left),
-                                        bool(sides.right),
-                                        bool(sides.bottom),
-                                        int(trimmed_output.shape[H_DIM]),
-                                        int(trimmed_output.shape[W_DIM]),
-                                        dst_y0,
-                                        dst_y1,
-                                        dst_x0,
-                                        dst_x1,
-                                    )
-                                )
-                            if torch.any(new_mask):
-                                self._reducer_head_map[idx].accumulate_tile(trimmed_output, valid_mask=new_mask)
-                                seen_slice |= new_mask
+                            self._reducer_head_map[idx].accumulate_stream_tile(
+                                trimmed_output=trimmed_output,
+                                tile_y=int(tile_y),
+                                tile_x=int(tile_x),
+                                sides=sides,
+                                dst_box=(dst_y0, dst_y1, dst_x0, dst_x1),
+                            )
                             continue
 
                         src_y0 = 0
@@ -724,7 +702,7 @@ class StreamingCNN(torch.nn.Module):
         del image
         self._saved_tensors = {}
         for idx, reducer in self._reducer_head_map.items():
-            outputs[idx] = reducer.finalize_stream().to(device)
+            outputs[idx] = reducer.finish_stream().to(device)
         for idx, output in enumerate(outputs):
             if output is None:
                 raise RuntimeError(f"Output head {idx} was not populated during streaming forward.")
@@ -869,7 +847,9 @@ class StreamingCNN(torch.nn.Module):
                     tile_x = tile_x if not sides_left else 0
                     tile_iter.append((int(tile_y), int(tile_x), Sides(sides_left, sides_top, sides_right, sides_bottom)))
 
-        reducer_assignment_cursors = {idx: 0 for idx in self._reducer_head_map} if self.debug_reducer_replay else {}
+        if self.debug_reducer_replay:
+            for reducer in self._reducer_head_map.values():
+                reducer.start_backward_replay()
 
         last_sides = None
         for input_y, input_x, sides in tile_iter:
@@ -914,7 +894,6 @@ class StreamingCNN(torch.nn.Module):
                         sides=sides,
                         output_heights=output_heights,
                         output_widths=output_widths,
-                        reducer_assignment_cursors=reducer_assignment_cursors,
                         image=image,
                     )
                     trimmed_outputs.append(paired_output)
@@ -928,11 +907,11 @@ class StreamingCNN(torch.nn.Module):
                 del trimmed_outputs
 
         if self.debug_reducer_replay:
-            StreamingReducer.validate_replay_consumed(self._reducer_forward_assignments, reducer_assignment_cursors)
+            for idx, reducer in self._reducer_head_map.items():
+                reducer.validate_backward_replay_consumed(head_idx=idx)
 
         # Memory management
         self._saved_tensors = {}
-        self._reducer_forward_assignments = {}
 
         for mod in self.stream_module.modules():
             if isinstance(mod, (StreamingConv2d, StreamingUpsample2d)):
@@ -953,7 +932,6 @@ class StreamingCNN(torch.nn.Module):
         sides,
         output_heights,
         output_widths,
-        reducer_assignment_cursors,
         image,
     ):
         is_reducer_head = idx in self._reducer_head_map
@@ -1004,7 +982,6 @@ class StreamingCNN(torch.nn.Module):
                 input_y=input_y,
                 input_x=input_x,
                 sides=sides,
-                reducer_assignment_cursors=reducer_assignment_cursors,
             )
 
         return self._build_non_reducer_backward_pair(
@@ -1036,30 +1013,16 @@ class StreamingCNN(torch.nn.Module):
         input_y,
         input_x,
         sides,
-        reducer_assignment_cursors,
     ):
         reducer = self._reducer_head_map[idx]
 
-        assignments = None
-        cursor = None
-        if self.debug_reducer_replay:
-            assignments = self._reducer_forward_assignments.get(idx)
-            if assignments is None:
-                raise RuntimeError(f"Missing forward reducer assignments for head {idx}")
-            cursor = reducer_assignment_cursors[idx]
-
-        reduced_output, reduced_grad, next_cursor = reducer.build_backward_pair(
+        reduced_output, reduced_grad = reducer.build_backward_pair(
             trimmed_output,
             gradient,
             input_y=int(input_y),
             input_x=int(input_x),
             sides=sides,
-            assignments=assignments,
-            cursor=cursor,
         )
-
-        if next_cursor is not None:
-            reducer_assignment_cursors[idx] = next_cursor
 
         return reduced_output, reduced_grad
 

--- a/lightstream/modules/reducer.py
+++ b/lightstream/modules/reducer.py
@@ -104,7 +104,11 @@ class StreamingReducer(nn.Module):
         self._streaming_passthrough = False
         self.register_buffer("running_sum", torch.zeros(0), persistent=False)
         self.register_buffer("running_count", torch.zeros(0), persistent=False)
+        self.register_buffer("_stream_seen_mask", torch.zeros(0, dtype=torch.bool), persistent=False)
         self._last_output = None
+        self._debug_replay_enabled = False
+        self._replay_assignments: list[tuple] | None = None
+        self._replay_cursor: int | None = None
 
     @classmethod
     def from_reducer(cls, module: Reducer) -> "StreamingReducer":
@@ -116,6 +120,73 @@ class StreamingReducer(nn.Module):
     def reset_stream_state(self, batch_size: int, channels: int, device: torch.device, dtype: torch.dtype):
         self.running_sum = torch.zeros((batch_size, channels, 1, 1), device=device, dtype=dtype)
         self.running_count = torch.zeros((batch_size, 1, 1, 1), device=device, dtype=dtype)
+
+    def start_stream(
+        self,
+        output_height: int,
+        output_width: int,
+        batch_size: int,
+        channels: int,
+        device: torch.device,
+        dtype: torch.dtype,
+        debug_replay: bool = False,
+    ):
+        self.reset_stream_state(batch_size=batch_size, channels=channels, device=device, dtype=dtype)
+        self._stream_seen_mask = torch.zeros((output_height, output_width), dtype=torch.bool, device=device)
+        self._debug_replay_enabled = debug_replay
+        self._replay_assignments = [] if debug_replay else None
+        self._replay_cursor = None
+
+    def accumulate_stream_tile(self, trimmed_output: torch.Tensor, tile_y: int, tile_x: int, sides, dst_box):
+        dst_y0, dst_y1, dst_x0, dst_x1 = dst_box
+        seen_slice = self._stream_seen_mask[dst_y0:dst_y1, dst_x0:dst_x1]
+        new_mask = ~seen_slice
+
+        if self._debug_replay_enabled:
+            if self._replay_assignments is None:
+                raise RuntimeError("Reducer replay assignments are not initialized.")
+            self._replay_assignments.append(
+                (
+                    int(tile_y),
+                    int(tile_x),
+                    bool(sides.top),
+                    bool(sides.left),
+                    bool(sides.right),
+                    bool(sides.bottom),
+                    int(trimmed_output.shape[-2]),
+                    int(trimmed_output.shape[-1]),
+                    int(dst_y0),
+                    int(dst_y1),
+                    int(dst_x0),
+                    int(dst_x1),
+                )
+            )
+
+        if torch.any(new_mask):
+            self.accumulate_tile(trimmed_output, valid_mask=new_mask)
+            seen_slice |= new_mask
+
+    def finish_stream(self) -> torch.Tensor:
+        return self.finalize_stream()
+
+    def start_backward_replay(self):
+        if self._debug_replay_enabled:
+            if self._replay_assignments is None:
+                raise RuntimeError("Reducer replay assignments are not available for backward replay.")
+            self._replay_cursor = 0
+        else:
+            self._replay_cursor = None
+
+    def validate_backward_replay_consumed(self, *, head_idx: int):
+        if not self._debug_replay_enabled:
+            return
+        if self._replay_assignments is None or self._replay_cursor is None:
+            raise RuntimeError("Reducer replay state is not initialized.")
+        if self._replay_cursor != len(self._replay_assignments):
+            raise RuntimeError(
+                f"Reducer assignment replay incomplete for head {head_idx}: "
+                f"consumed={self._replay_cursor}, expected={len(self._replay_assignments)}"
+            )
 
     def accumulate_tile(self, tile_valid_output: torch.Tensor, valid_mask: torch.Tensor | None = None):
         if self.running_sum.numel() == 0:
@@ -161,9 +232,7 @@ class StreamingReducer(nn.Module):
         input_y: int,
         input_x: int,
         sides,
-        assignments: list[tuple] | None = None,
-        cursor: int | None = None,
-    ) -> tuple[torch.Tensor, torch.Tensor, int | None]:
+    ) -> tuple[torch.Tensor, torch.Tensor]:
         """Build reducer-backed backward pair for a single tile output.
 
         SCNN provides orchestration metadata (tile location/sides) and optional
@@ -173,13 +242,12 @@ class StreamingReducer(nn.Module):
         expected_h = int(trimmed_output.shape[-2])
         expected_w = int(trimmed_output.shape[-1])
 
-        next_cursor = cursor
-        if assignments is not None:
-            if cursor is None:
-                raise RuntimeError("Reducer replay cursor is required when assignments are provided.")
-            next_cursor = self._validate_replay_assignment(
-                assignments=assignments,
-                cursor=cursor,
+        if self._debug_replay_enabled:
+            if self._replay_assignments is None or self._replay_cursor is None:
+                raise RuntimeError("Reducer replay state is not initialized. Call start_backward_replay() first.")
+            self._replay_cursor = self._validate_replay_assignment(
+                assignments=self._replay_assignments,
+                cursor=self._replay_cursor,
                 input_y=input_y,
                 input_x=input_x,
                 sides=sides,
@@ -189,7 +257,7 @@ class StreamingReducer(nn.Module):
 
         normalization = self.running_count if self.mode == "mean" else None
         reduced_output = self.reduce_tile(trimmed_output, normalization=normalization)
-        return reduced_output, gradient, next_cursor
+        return reduced_output, gradient
 
     def _validate_replay_assignment(
         self,
@@ -247,18 +315,6 @@ class StreamingReducer(nn.Module):
             )
 
         return cursor + 1
-
-    @staticmethod
-    def validate_replay_consumed(
-        assignments_map: dict[int, list[tuple]],
-        assignment_cursors: dict[int, int],
-    ) -> None:
-        for idx, assignments in assignments_map.items():
-            consumed = assignment_cursors.get(idx, 0)
-            if consumed != len(assignments):
-                raise RuntimeError(
-                    f"Reducer assignment replay incomplete for head {idx}: consumed={consumed}, expected={len(assignments)}"
-                )
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:
         # Marker behavior for streaming path; SCNN performs accumulation.


### PR DESCRIPTION
### Motivation
- Encapsulate per-forward streaming session and replay bookkeeping inside the reducer so SCNN no longer manipulates reducer internals and reducer-specific branching is reduced.
- Keep existing forward overlap deduplication and debug replay mismatch checks while making the SCNN code simpler and less error-prone.

### Description
- Added a reducer-owned stream/replay session API on `StreamingReducer` including `start_stream(...)`, `accumulate_stream_tile(...)`, `finish_stream()`, `start_backward_replay()` and `validate_backward_replay_consumed(...)`, and internal buffers `_stream_seen_mask`, `_replay_assignments`, and `_replay_cursor` in `lightstream/modules/reducer.py`.
- Moved forward-assignment tuple construction and replay cursor mutation into `StreamingReducer` so `StreamingCNN` no longer builds or mutates `_reducer_forward_assignments` or per-head cursor dicts.
- Updated `StreamingCNN` (`lightstream/core/scnn/scnn.py`) forward logic to call one reducer method per reducer head tile (`start_stream`, `accumulate_stream_tile`, `finish_stream`) and removed external seen-mask / tuple bookkeeping and finalization via `finalize_stream()` -> now `finish_stream()`.
- Updated `StreamingCNN` backward logic to `start_backward_replay()` on reducers and to use reducer-managed replay state when debug replay is enabled; SCNN still passes tile context `(input_y, input_x, sides, trimmed_output, gradient)` to reducers and reducer validation/error semantics are preserved.

### Testing
- Successfully type-checked/compiled the modified modules with `python -m compileall lightstream/modules/reducer.py lightstream/core/scnn/scnn.py`.
- Ran `pytest -q` but collection failed in this environment due to missing optional test dependencies (`numpy` and `lightning`), so full test suite could not be executed here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a852ed4d588330935d12debb457cf2)