### PR TITLE
Clean up unused SCNN streaming state fields

### DIFF
--- a/lightstream/core/scnn/scnn.py
+++ b/lightstream/core/scnn/scnn.py
@@ -98,7 +98,6 @@ class StreamingCNN(torch.nn.Module):
         self._output_stride_per_output = None
         self._output_spec = None
         self._module_stats = {}
-        self._backward_seen_indices = {}
         self._saved_tensors = {}
         self.debug_reducer_replay = False
         self._hooks = []
@@ -574,9 +573,6 @@ class StreamingCNN(torch.nn.Module):
                     sides_right = True if tile_x + self.tile_shape[W_DIM] >= image.shape[W_DIM] else False
                     sides = Sides(sides_left, sides_top, sides_right, sides_bottom)
 
-                    # These values are used to crop invalid output values
-                    lost = self._get_tile_lost_for_sides(sides)
-
                     # Since we need to stay at multiples of output stride we
                     # need to keep that into account when we are at the bottom
                     # and right side of the output.
@@ -777,9 +773,6 @@ class StreamingCNN(torch.nn.Module):
             n_cols = 1
         if image.shape[H_DIM] <= tile_height:
             n_rows = 1
-
-        self._inputs = {}
-        self._backward_seen_indices = {}
 
         # if self.verbose:
         #    print("Number of tiles in backprop:", n_rows, n_cols, n_rows * n_cols)


### PR DESCRIPTION
### Motivation
- Remove stale, unused bookkeeping state and an unused local in the forward tile loop to simplify `StreamingCNN` internals and avoid confusing dead code.

### Description
- Deleted the initialization `self._backward_seen_indices` in `StreamingCNN.__init__`, removed the unused early `lost = self._get_tile_lost_for_sides(sides)` in the forward tile loop, and removed the redundant resets `self._inputs = {}` and `self._backward_seen_indices = {}` in the backward logic of `lightstream/core/scnn/scnn.py`, while preserving the per-head `lost` calculation where it is actually used.

### Testing
- Ran `rg -n "_inputs|_backward_seen_indices" lightstream/core/scnn/scnn.py` and confirmed no matches, reviewed `git diff -- lightstream/core/scnn/scnn.py`, and committed the change successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a85881d36c8330a2f39ac272151599)