### PR TITLE
Preserve fp32 precision in StreamingReducerTileF normalization path

### DIFF
--- a/lightstream/modules/reducer.py
+++ b/lightstream/modules/reducer.py
@@ -36,8 +36,9 @@ class StreamingReducerTileF(torch.autograd.Function):
         ctx.input_width = tile_output.shape[-1]
 
         if normalization is not None:
-            norm = normalization.to(device=tile_output.device, dtype=tile_output.dtype).clamp_min(1)
-            reduced = masked.sum(dim=(-2, -1), keepdim=True) / norm
+            norm = normalization.to(device=tile_output.device, dtype=torch.float32).clamp_min(1)
+            reduced_fp32 = masked.sum(dim=(-2, -1), keepdim=True, dtype=torch.float32) / norm
+            reduced = reduced_fp32.to(dtype=tile_output.dtype)
             ctx.normalization = norm
             ctx.has_normalization = True
         else:
@@ -53,7 +54,7 @@ class StreamingReducerTileF(torch.autograd.Function):
 
         grad_input = grad_output
         if ctx.has_normalization:
-            grad_input = grad_input / ctx.normalization
+            grad_input = (grad_input.to(dtype=torch.float32) / ctx.normalization).to(dtype=grad_output.dtype)
 
         grad_input = grad_input.expand(-1, -1, ctx.input_height, ctx.input_width)
 


### PR DESCRIPTION
### Motivation

- Avoid fp16 precision loss and overflow during normalization math by keeping the reduction/division path in a stable fp32 dtype.

### Description

- In `StreamingReducerTileF.forward()` keep `normalization` in `torch.float32`, compute the sum/divide in fp32 via `masked.sum(..., dtype=torch.float32) / norm`, and cast the final reduced result back to `tile_output.dtype` so downstream dtype expectations are preserved.
- Store `ctx.normalization` as the fp32 tensor so the same stable dtype is available in the backward pass.
- In `StreamingReducerTileF.backward()` perform the division in fp32 by casting `grad_output` to `torch.float32`, dividing by `ctx.normalization`, and then casting the result back to the original gradient dtype to avoid fp16 overflow while preserving the external interface.

### Testing

- Attempted to run a full import-based smoke test via `python -c` that exercised `StreamingReducer` but it failed due to a missing `lightning` dependency in the environment (automated run exited with a ModuleNotFoundError). 
- Loaded `lightstream/modules/reducer.py` directly with `importlib` and executed a focused automated test that uses `torch.float16` tile input and `torch.float16` normalization, and verified that the forward output dtype is the tile dtype and the backward gradient dtype is correct and finite (test passed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ab262c2c4883308426537f67226c77)