### PR TITLE
Stabilize StreamingReducer running_count precision

### DIFF
--- a/lightstream/modules/reducer.py
+++ b/lightstream/modules/reducer.py
@@ -117,9 +117,16 @@ class StreamingReducer(nn.Module):
     def to_reducer(self) -> Reducer:
         return Reducer(mode=self.mode)
 
-    def reset_stream_state(self, batch_size: int, channels: int, device: torch.device, dtype: torch.dtype):
+    def reset_stream_state(
+        self,
+        batch_size: int,
+        channels: int,
+        device: torch.device,
+        dtype: torch.dtype,
+        accumulator_dtype: torch.dtype = torch.float32,
+    ):
         self.running_sum = torch.zeros((batch_size, channels, 1, 1), device=device, dtype=dtype)
-        self.running_count = torch.zeros((batch_size, 1, 1, 1), device=device, dtype=dtype)
+        self.running_count = torch.zeros((batch_size, 1, 1, 1), device=device, dtype=accumulator_dtype)
 
     def start_stream(
         self,
@@ -206,14 +213,17 @@ class StreamingReducer(nn.Module):
             n_pixels = int(valid_mask.sum().item())
 
         if self.mode == "mean":
-            self.running_count = self.running_count + n_pixels
+            pixel_increment = torch.tensor(n_pixels, device=self.running_count.device, dtype=self.running_count.dtype)
+            self.running_count = self.running_count + pixel_increment
 
     def finalize_stream(self) -> torch.Tensor:
         if self.running_sum.numel() == 0:
             raise RuntimeError("StreamingReducer state is empty, accumulate_tile() was not called.")
         if self.mode == "sum":
             return self.running_sum
-        denom = self.running_count.clamp_min(1)
+        denom = self.running_count.to(dtype=torch.float32).clamp_min(1)
+        if denom.dtype != self.running_sum.dtype:
+            denom = denom.to(dtype=self.running_sum.dtype)
         return self.running_sum / denom
 
     def reduce_tile(

--- a/tests/test_streaming_reducer.py
+++ b/tests/test_streaming_reducer.py
@@ -2,7 +2,7 @@ import torch
 import torch.nn as nn
 
 from lightstream.core.constructor import StreamingConstructor
-from lightstream.modules.reducer import Reducer
+from lightstream.modules.reducer import Reducer, StreamingReducer
 
 
 class MixedReducerNet(nn.Module):
@@ -136,3 +136,17 @@ def test_streaming_reducer_backward_parity_tiny_odd_image():
     for name, ref_grad in ref_grads.items():
         assert name in stream_grads
         assert torch.allclose(stream_grads[name], ref_grad, atol=1e-5, rtol=1e-4), name
+
+
+def test_streaming_reducer_running_count_uses_fp32_accumulator():
+    reducer = StreamingReducer(mode="mean")
+    tile = torch.ones((1, 2, 2, 3), dtype=torch.float16)
+
+    reducer.accumulate_tile(tile)
+
+    assert reducer.running_sum.dtype == torch.float16
+    assert reducer.running_count.dtype == torch.float32
+
+    output = reducer.finalize_stream()
+    assert output.dtype == tile.dtype
+    assert torch.allclose(output, torch.ones((1, 2, 1, 1), dtype=tile.dtype))


### PR DESCRIPTION
### Motivation
- Prevent implicit dtype drift when accumulating pixel counts so count accumulation uses a stable, higher-precision accumulator while keeping outputs configurable.
- Ensure final division uses a fp32 denominator for numeric stability but preserve `running_sum` output dtype for API compatibility.

### Description
- Change `reset_stream_state` signature to accept `accumulator_dtype: torch.dtype = torch.float32` and initialize `running_count` with that dtype while keeping `running_sum` created with the provided `dtype`.
- In `accumulate_tile` convert the integer pixel increment to `running_count.dtype` via `torch.tensor(..., dtype=self.running_count.dtype, device=...)` before adding to avoid implicit upcasting or drift.
- In `finalize_stream` compute `denom` from `running_count` in `torch.float32` (`.to(dtype=torch.float32).clamp_min(1)`) and cast `denom` to `running_sum.dtype` only at the division boundary to preserve output dtype.
- Add a regression test `test_streaming_reducer_running_count_uses_fp32_accumulator` validating that `running_sum` can be fp16 while `running_count` is fp32 and that final output has the tile dtype.

### Testing
- Added unit test `tests/test_streaming_reducer.py::test_streaming_reducer_running_count_uses_fp32_accumulator` (included in this change) and verified it via a direct module sanity script which passed locally.
- Running `pytest -q tests/test_streaming_reducer.py` in this environment failed during test collection due to a missing optional dependency `lightning` required by the test harness, so full test-suite execution could not be completed here.
- A targeted import-and-run sanity check (`importlib` load of `lightstream/modules/reducer.py` and exercising `StreamingReducer.accumulate_tile`/`finalize_stream`) succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ab2628c3b883308190e6ca1ca450f9)