### PR TITLE
Add optional spatial mask support to Reducer and propagate through streaming pipeline

### DIFF
--- a/examples/compare_grads_segment.py
+++ b/examples/compare_grads_segment.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Iterable
 import argparse
+import inspect
 
 import torch
 import torch.nn as nn
@@ -85,6 +86,18 @@ def _freeze_batchnorm(module: nn.Module) -> None:
                 param.requires_grad = False
 
 
+def _forward_with_optional_mask(model: nn.Module, x: torch.Tensor, mask: torch.Tensor | None = None):
+    if mask is None:
+        return model(x)
+    try:
+        params = inspect.signature(model.forward).parameters
+        if "mask" in params:
+            return model(x, mask=mask)
+    except (TypeError, ValueError):
+        pass
+    return model(x)
+
+
 def main() -> None:
     parser = argparse.ArgumentParser(description="Compare streaming vs non-streaming backward gradients for WSS.")
     parser.add_argument("--dtype", default="float64", help="float16, float32, or float64")
@@ -99,7 +112,8 @@ def main() -> None:
     tile_size = args.tile_size
     input_size = args.input_size
 
-    img = torch.rand((1, 3, input_size, input_size), device='cpu', dtype=dtype)
+    img = torch.rand((1, 3, input_size, input_size), device=device, dtype=dtype)
+    dummy_mask = torch.rand((input_size, input_size), device=device) > 0.25
     target = torch.tensor(50.0, device=device, dtype=dtype)
     criterion = torch.nn.MSELoss()
 
@@ -110,7 +124,7 @@ def main() -> None:
         mean=[0, 0, 0],
         std=[1, 1, 1],
         normalize_on_gpu=False,
-        saliency=False,
+        saliency=True,
     ).to(device=device, dtype=dtype)
     network.stream_network.device = device
     network.stream_network.dtype = dtype
@@ -127,7 +141,7 @@ def main() -> None:
     _freeze_batchnorm(network.stream_network.stream_module)
 
     _zero_grads(network.stream_network.stream_module.parameters())
-    stream_outputs = network(img)
+    stream_outputs = _forward_with_optional_mask(network, img, mask=dummy_mask)
     for out in stream_outputs:
         out.requires_grad = True
         out.retain_grad()
@@ -146,7 +160,7 @@ def main() -> None:
     _freeze_batchnorm(normal_net)
     _zero_grads(normal_net.parameters())
     img_normal = img.detach().clone().requires_grad_(True)
-    normal_outputs = normal_net(img_normal)
+    normal_outputs = _forward_with_optional_mask(normal_net, img_normal, mask=dummy_mask)
 
     for stream_out, normal_out in zip(stream_outputs, normal_outputs):
         diff = (stream_out - normal_out).abs()
@@ -159,7 +173,9 @@ def main() -> None:
     normal_param_grads = _gather_param_grads(normal_net)
 
     if img_normal.grad is not None:
-        input_grad_diff = img_normal.grad.detach().cpu().numpy() - network.stream_network.saliency_map[0].numpy()
+        input_grad_diff = (
+            img_normal.grad.detach().cpu().numpy() - network.stream_network.saliency_map[0].detach().cpu().numpy()
+        )
         print(f"Input gradient max diff: {input_grad_diff.max()}")
 
     _compare_grads(streaming_param_grads, normal_param_grads)

--- a/lightstream/core/scnn/scnn.py
+++ b/lightstream/core/scnn/scnn.py
@@ -725,13 +725,34 @@ class StreamingCNN(torch.nn.Module):
         dst_y1 = int(output_loc.y + trimmed_output.shape[H_DIM])
         dst_x0 = int(output_loc.x)
         dst_x1 = int(output_loc.x + trimmed_output.shape[W_DIM])
+        reducer_mask_tile = None
+        if self._reducer_mask is not None:
+            reducer_mask_tile = self._reducer_mask[head_idx][dst_y0:dst_y1, dst_x0:dst_x1]
         self._reducer_head_map[head_idx].accumulate_stream_tile(
             trimmed_output=trimmed_output,
             tile_y=int(tile_input_y),
             tile_x=int(tile_input_x),
             sides=sides,
             dst_box=(dst_y0, dst_y1, dst_x0, dst_x1),
+            mask_tile=reducer_mask_tile,
         )
+
+    def _prepare_reducer_mask(self, mask, output_heights, output_widths):
+        if mask is None:
+            return None
+        if mask.ndim != 2:
+            raise ValueError(f"mask must be 2D (H,W), got shape={tuple(mask.shape)}")
+
+        reducer_masks = {}
+        for head_idx in self._reducer_head_map:
+            expected_h = int(output_heights[head_idx])
+            expected_w = int(output_widths[head_idx])
+            if tuple(mask.shape) != (expected_h, expected_w):
+                raise ValueError(
+                    f"mask shape {tuple(mask.shape)} must match reducer head {head_idx} output shape {(expected_h, expected_w)}"
+                )
+            reducer_masks[head_idx] = mask.to(device=self.device, dtype=torch.bool)
+        return reducer_masks
 
     def _stitch_forward_outputs(self, outputs, tile_outputs, tile_input_y, tile_input_x, sides):
         for head_idx, head_output in enumerate(tile_outputs):
@@ -860,7 +881,7 @@ class StreamingCNN(torch.nn.Module):
         del trimmed_grads
         del trimmed_outputs
 
-    def forward(self, image, result_on_cpu=False):
+    def forward(self, image, result_on_cpu=False, mask=None):
         """Perform forward pass with lightstream."""
         if self.copy_to_gpu:
             image = image.to(self.device, non_blocking=True)
@@ -904,6 +925,7 @@ class StreamingCNN(torch.nn.Module):
             result_device=result_device,
         )
         self._reducer_head_map = {}
+        self._reducer_mask = None
         reducers_initialized = False
         outputs, allocate_non_reducer_outputs = self._prepare_forward_outputs(
             image=forward_ctx.image,
@@ -931,6 +953,7 @@ class StreamingCNN(torch.nn.Module):
                 allocate_non_reducer_outputs()
 
                 if self._reducer_head_map and not reducers_initialized:
+                    self._reducer_mask = self._prepare_reducer_mask(mask, forward_ctx.output_heights, forward_ctx.output_widths)
                     for head_idx, reducer in self._reducer_head_map.items():
                         reducer.start_stream(
                             output_height=forward_ctx.output_heights[head_idx],
@@ -940,6 +963,7 @@ class StreamingCNN(torch.nn.Module):
                             device=self.device,
                             dtype=self.dtype,
                             debug_replay=self.debug_reducer_replay,
+                            user_mask=None if self._reducer_mask is None else self._reducer_mask[head_idx],
                         )
                     reducers_initialized = True
 
@@ -1016,9 +1040,8 @@ class StreamingCNN(torch.nn.Module):
             output_widths=output_widths,
         )
 
-        if self.debug_reducer_replay:
-            for reducer in self._reducer_head_map.values():
-                reducer.start_backward_replay()
+        for reducer in self._reducer_head_map.values():
+            reducer.start_backward_replay()
 
         last_sides = None
         for input_y, input_x, sides in tile_iter:
@@ -1087,6 +1110,8 @@ class StreamingCNN(torch.nn.Module):
                 head_idx=head_idx,
                 trimmed_output=trimmed_output,
                 gradient=gradient,
+                head_output_y=head_output_y,
+                head_output_x=head_output_x,
                 tile_input_y=tile_input_y,
                 tile_input_x=tile_input_x,
                 sides=sides,
@@ -1118,11 +1143,19 @@ class StreamingCNN(torch.nn.Module):
         head_idx,
         trimmed_output,
         gradient,
+        head_output_y,
+        head_output_x,
         tile_input_y,
         tile_input_x,
         sides,
     ):
         reducer = self._reducer_head_map[head_idx]
+        dst_box = (
+            int(head_output_y),
+            int(head_output_y + trimmed_output.shape[H_DIM]),
+            int(head_output_x),
+            int(head_output_x + trimmed_output.shape[W_DIM]),
+        )
 
         reduced_output, reduced_grad = reducer.build_backward_pair(
             trimmed_output,
@@ -1130,6 +1163,7 @@ class StreamingCNN(torch.nn.Module):
             input_y=int(tile_input_y),
             input_x=int(tile_input_x),
             sides=sides,
+            dst_box=dst_box,
         )
 
         return reduced_output, reduced_grad

--- a/lightstream/core/scnn/scnn.py
+++ b/lightstream/core/scnn/scnn.py
@@ -902,7 +902,7 @@ class StreamingCNN(torch.nn.Module):
         )
 
         if self.gather_input_gradient:
-            self.saliency_map = torch.zeros(image.shape, dtype=self.dtype, device="cpu")
+            self.saliency_map = torch.zeros(image.shape, dtype=self.dtype, device=self.device)
 
         self._last_forward_tiles = []
         if self.verbose:

--- a/lightstream/modules/lightningstreaming.py
+++ b/lightstream/modules/lightningstreaming.py
@@ -85,7 +85,7 @@ class LightningStreamingModule(L.LightningModule):
         """
         self._prepare_start_for_streaming()
 
-    def forward(self, x):
+    def forward(self, x, mask=None):
         """
 
         Parameters
@@ -99,7 +99,7 @@ class LightningStreamingModule(L.LightningModule):
         The output of the streaming model
 
         """
-        return self.stream_network.forward(x)
+        return self.stream_network.forward(x, mask=mask)
 
     def backward_streaming(self, image, grad):
         self.stream_network.backward(image, grad)

--- a/lightstream/modules/reducer.py
+++ b/lightstream/modules/reducer.py
@@ -77,11 +77,41 @@ class Reducer(nn.Module):
         self.mode = mode
         self._streaming_passthrough = False
 
-    def forward(self, x: torch.Tensor) -> torch.Tensor:
+    @staticmethod
+    def _expand_mask(mask: torch.Tensor, x: torch.Tensor) -> torch.Tensor:
+        if mask.ndim == 2:
+            mask_4d = mask[None, None]
+        elif mask.ndim == 3:
+            mask_4d = mask[:, None]
+        elif mask.ndim == 4:
+            mask_4d = mask
+        else:
+            raise ValueError(f"mask must be 2D, 3D, or 4D, got shape={tuple(mask.shape)}")
+
+        if mask_4d.shape[-2:] != x.shape[-2:]:
+            raise ValueError(
+                f"mask spatial shape {tuple(mask_4d.shape[-2:])} does not match input {tuple(x.shape[-2:])}"
+            )
+
+        if mask_4d.shape[0] not in {1, x.shape[0]}:
+            raise ValueError(f"mask batch dim must be 1 or {x.shape[0]}, got {mask_4d.shape[0]}")
+        if mask_4d.shape[1] not in {1, x.shape[1]}:
+            raise ValueError(f"mask channel dim must be 1 or {x.shape[1]}, got {mask_4d.shape[1]}")
+
+        return mask_4d.to(dtype=torch.bool, device=x.device)
+
+    def forward(self, x: torch.Tensor, mask: torch.Tensor | None = None) -> torch.Tensor:
         if x.ndim != 4:
             raise ValueError(f"Reducer expects NCHW tensor, got shape={tuple(x.shape)}")
         if self._streaming_passthrough:
             return x
+        if mask is not None:
+            mask_4d = self._expand_mask(mask, x)
+            masked = x * mask_4d.to(dtype=x.dtype)
+            if self.mode == "sum":
+                return masked.sum(dim=(-2, -1), keepdim=True)
+            denom = mask_4d.sum(dim=(-2, -1), keepdim=True).clamp_min(1).to(dtype=x.dtype)
+            return masked.sum(dim=(-2, -1), keepdim=True) / denom
         if self.mode == "sum":
             return x.sum(dim=(-2, -1), keepdim=True)
         return x.mean(dim=(-2, -1), keepdim=True)
@@ -106,6 +136,10 @@ class StreamingReducer(nn.Module):
         self.register_buffer("running_sum", torch.zeros(0), persistent=False)
         self.register_buffer("running_count", torch.zeros(0), persistent=False)
         self.register_buffer("_stream_seen_mask", torch.zeros(0, dtype=torch.bool), persistent=False)
+        self.register_buffer("_backward_seen_mask", torch.zeros(0, dtype=torch.bool), persistent=False)
+        self.register_buffer("_stream_user_mask", torch.zeros(0, dtype=torch.bool), persistent=False)
+        self._output_height: int | None = None
+        self._output_width: int | None = None
         self._last_output = None
         self._debug_replay_enabled = False
         self._replay_assignments: list[tuple] | None = None
@@ -138,17 +172,46 @@ class StreamingReducer(nn.Module):
         device: torch.device,
         dtype: torch.dtype,
         debug_replay: bool = False,
+        user_mask: torch.Tensor | None = None,
     ):
         self.reset_stream_state(batch_size=batch_size, channels=channels, device=device, dtype=dtype)
         self._stream_seen_mask = torch.zeros((output_height, output_width), dtype=torch.bool, device=device)
+        self._backward_seen_mask = torch.zeros((output_height, output_width), dtype=torch.bool, device=device)
+        self._output_height = int(output_height)
+        self._output_width = int(output_width)
+        if user_mask is not None:
+            if user_mask.ndim != 2:
+                raise ValueError(f"user_mask must be 2D (H,W), got shape={tuple(user_mask.shape)}")
+            if tuple(user_mask.shape) != (output_height, output_width):
+                raise ValueError(
+                    f"user_mask shape {tuple(user_mask.shape)} must match output shape {(output_height, output_width)}"
+                )
+            self._stream_user_mask = user_mask.to(device=device, dtype=torch.bool)
+        else:
+            self._stream_user_mask = torch.zeros(0, dtype=torch.bool, device=device)
         self._debug_replay_enabled = debug_replay
         self._replay_assignments = [] if debug_replay else None
         self._replay_cursor = None
 
-    def accumulate_stream_tile(self, trimmed_output: torch.Tensor, tile_y: int, tile_x: int, sides, dst_box):
+    def accumulate_stream_tile(
+        self,
+        trimmed_output: torch.Tensor,
+        tile_y: int,
+        tile_x: int,
+        sides,
+        dst_box,
+        mask_tile: torch.Tensor | None = None,
+    ):
         dst_y0, dst_y1, dst_x0, dst_x1 = dst_box
         seen_slice = self._stream_seen_mask[dst_y0:dst_y1, dst_x0:dst_x1]
         new_mask = ~seen_slice
+        effective_mask = new_mask
+        if mask_tile is not None:
+            if mask_tile.ndim != 2 or mask_tile.shape != new_mask.shape:
+                raise ValueError(
+                    f"mask_tile must be 2D with shape {tuple(new_mask.shape)}, got shape={tuple(mask_tile.shape)}"
+                )
+            effective_mask = effective_mask & mask_tile.to(device=new_mask.device, dtype=torch.bool)
 
         if self._debug_replay_enabled:
             if self._replay_assignments is None:
@@ -170,14 +233,21 @@ class StreamingReducer(nn.Module):
                 )
             )
 
-        if torch.any(new_mask):
-            self.accumulate_tile(trimmed_output, valid_mask=new_mask)
+        if torch.any(effective_mask):
+            self.accumulate_tile(trimmed_output, valid_mask=effective_mask)
             seen_slice |= new_mask
 
     def finish_stream(self) -> torch.Tensor:
         return self.finalize_stream()
 
     def start_backward_replay(self):
+        if self._output_height is None or self._output_width is None:
+            raise RuntimeError("Reducer output shape is unknown. Call start_stream() first.")
+        self._backward_seen_mask = torch.zeros(
+            (self._output_height, self._output_width),
+            dtype=torch.bool,
+            device=self.running_sum.device,
+        )
         if self._debug_replay_enabled:
             if self._replay_assignments is None:
                 raise RuntimeError("Reducer replay assignments are not available for backward replay.")
@@ -243,6 +313,7 @@ class StreamingReducer(nn.Module):
         input_y: int,
         input_x: int,
         sides,
+        dst_box: tuple[int, int, int, int],
     ) -> tuple[torch.Tensor, torch.Tensor]:
         """Build reducer-backed backward pair for a single tile output.
 
@@ -264,10 +335,20 @@ class StreamingReducer(nn.Module):
                 sides=sides,
                 expected_h=expected_h,
                 expected_w=expected_w,
+                dst_box=dst_box,
             )
 
+        dst_y0, dst_y1, dst_x0, dst_x1 = dst_box
+        seen_slice = self._backward_seen_mask[dst_y0:dst_y1, dst_x0:dst_x1]
+        new_mask = ~seen_slice
+        effective_mask = new_mask
+        if self._stream_user_mask.numel() > 0:
+            user_mask_slice = self._stream_user_mask[dst_y0:dst_y1, dst_x0:dst_x1]
+            effective_mask = effective_mask & user_mask_slice
+        seen_slice |= new_mask
+
         normalization = self.running_count if self.mode == "mean" else None
-        reduced_output = self.reduce_tile(trimmed_output, normalization=normalization)
+        reduced_output = self.reduce_tile(trimmed_output, valid_mask=effective_mask, normalization=normalization)
         return reduced_output, gradient
 
     def _validate_replay_assignment(
@@ -280,6 +361,7 @@ class StreamingReducer(nn.Module):
         sides,
         expected_h: int,
         expected_w: int,
+        dst_box: tuple[int, int, int, int],
     ) -> int:
         if cursor >= len(assignments):
             raise RuntimeError("Reducer assignment cursor out of range.")
@@ -323,6 +405,12 @@ class StreamingReducer(nn.Module):
             raise RuntimeError(
                 "Reducer assignment mismatch: "
                 f"stored=({dst_y0}:{dst_y1},{dst_x0}:{dst_x1}) current=({expected_h},{expected_w})"
+            )
+
+        if tuple(dst_box) != (dst_y0, dst_y1, dst_x0, dst_x1):
+            raise RuntimeError(
+                "Reducer destination box mismatch: "
+                f"forward=({dst_y0},{dst_y1},{dst_x0},{dst_x1}) backward={tuple(dst_box)}"
             )
 
         return cursor + 1

--- a/lightstream/modules/streaming.py
+++ b/lightstream/modules/streaming.py
@@ -87,8 +87,8 @@ class StreamingModule(nn.Module):
 
         return state_dict
 
-    def forward(self, x):
-        return self.stream_network(x)
+    def forward(self, x, mask=None):
+        return self.stream_network(x, mask=mask)
 
     def backward_streaming(self, image, grad):
         self.stream_network.backward(image, grad)

--- a/tests/modelcheck.py
+++ b/tests/modelcheck.py
@@ -13,6 +13,7 @@ Only models with a 'simple' design are supported, primarily aimed at torchvision
 """
 
 import torch
+import inspect
 from lightstream.modules.lightningstreaming import StreamingModule
 from core.scnn.scnn import StreamingConv2d
 from torchvision.models import resnet18, resnet34, resnet50
@@ -52,17 +53,32 @@ class ModelCheck(StreamingModule):
         del self.stream_network
         self.stream_network = temp
 
-    def forward(self, x):
-        if self.use_streaming:
-            return self.forward_streaming(x)
+    def _forward_with_optional_mask(self, model, x, mask=None):
+        if mask is None:
+            return model(x)
+        try:
+            params = inspect.signature(model.forward).parameters
+            if "mask" in params:
+                return model(x, mask=mask)
+        except (TypeError, ValueError):
+            pass
+        return model(x)
 
-        return self.stream_network(x)
+    def _build_dummy_mask(self, image: torch.Tensor) -> torch.Tensor:
+        h, w = image.shape[-2], image.shape[-1]
+        return (torch.rand((h, w), device=image.device) > 0.25)
+
+    def forward(self, x, mask=None):
+        if self.use_streaming:
+            return self._forward_with_optional_mask(self.forward_streaming, x, mask=mask)
+
+        return self._forward_with_optional_mask(self.stream_network, x, mask=mask)
 
     def training_step(self, batch, batch_idx, *args, **kwargs):
-        image, target = batch
+        image, target, mask = batch
         self.image = image
 
-        self.str_output = self.forward(image)
+        self.str_output = self.forward(image, mask=mask)
 
         if self.use_streaming:
             self.str_output.requires_grad = True
@@ -113,6 +129,11 @@ class ModelCheck(StreamingModule):
         self.stream_network.dtype = self.dtype
 
     def run(self, batch):
+        if len(batch) == 2:
+            image, target = batch
+            mask = self._build_dummy_mask(image)
+            batch = (image, target, mask)
+
         # run once with streaming and gather output
         self.to_device()
         streaming_step_results = self.step_once(batch)
@@ -206,17 +227,32 @@ class ModelCheckConvNext(StreamingModule):
         del self.stream_network
         self.stream_network = temp
 
-    def forward(self, x):
-        if self.use_streaming:
-            return self.forward_streaming(x)
+    def _forward_with_optional_mask(self, model, x, mask=None):
+        if mask is None:
+            return model(x)
+        try:
+            params = inspect.signature(model.forward).parameters
+            if "mask" in params:
+                return model(x, mask=mask)
+        except (TypeError, ValueError):
+            pass
+        return model(x)
 
-        return self.stream_network(x)
+    def _build_dummy_mask(self, image: torch.Tensor) -> torch.Tensor:
+        h, w = image.shape[-2], image.shape[-1]
+        return (torch.rand((h, w), device=image.device) > 0.25)
+
+    def forward(self, x, mask=None):
+        if self.use_streaming:
+            return self._forward_with_optional_mask(self.forward_streaming, x, mask=mask)
+
+        return self._forward_with_optional_mask(self.stream_network, x, mask=mask)
 
     def training_step(self, batch, batch_idx, *args, **kwargs):
-        image, target = batch
+        image, target, mask = batch
         self.image = image
 
-        self.str_output = self.forward(image)
+        self.str_output = self.forward(image, mask=mask)
 
         if self.use_streaming:
             self.str_output.requires_grad = True
@@ -270,6 +306,11 @@ class ModelCheckConvNext(StreamingModule):
         self.stream_network.dtype = self.dtype
 
     def run(self, batch):
+        if len(batch) == 2:
+            image, target = batch
+            mask = self._build_dummy_mask(image)
+            batch = (image, target, mask)
+
         # run once with streaming and gather output
         self.to_device()
         streaming_step_results = self.step_once(batch)

--- a/tests/test_scnn.py
+++ b/tests/test_scnn.py
@@ -40,6 +40,7 @@ def _make_streaming(model: nn.Module, tile_size: int = 4):
     constructor = StreamingConstructor(
         model,
         tile_size=tile_size,
+        saliency=True,
         verbose=False,
         deterministic=True,
         copy_to_gpu=False,

--- a/tests/test_scnn.py
+++ b/tests/test_scnn.py
@@ -40,7 +40,6 @@ def _make_streaming(model: nn.Module, tile_size: int = 4):
     constructor = StreamingConstructor(
         model,
         tile_size=tile_size,
-        saliency=True,
         verbose=False,
         deterministic=True,
         copy_to_gpu=False,

--- a/tests/test_streaming_reducer.py
+++ b/tests/test_streaming_reducer.py
@@ -13,11 +13,13 @@ class MixedReducerNet(nn.Module):
             nn.ReLU(),
         )
         self.raw_head = nn.Conv2d(4, 2, kernel_size=1, bias=False)
-        self.mean_head = nn.Sequential(nn.Conv2d(4, 2, kernel_size=1, bias=False), Reducer(mode="mean"))
+        self.mean_conv = nn.Conv2d(4, 2, kernel_size=1, bias=False)
+        self.mean_reducer = Reducer(mode="mean")
 
-    def forward(self, x):
+    def forward(self, x, mask=None):
         feat = self.backbone(x)
-        return {"raw": self.raw_head(feat), "reduced": self.mean_head(feat)}
+        reduced = self.mean_reducer(self.mean_conv(feat), mask=mask)
+        return {"raw": self.raw_head(feat), "reduced": reduced}
 
 
 class MultiReducerNet(nn.Module):
@@ -27,12 +29,14 @@ class MultiReducerNet(nn.Module):
             nn.Conv2d(3, 5, kernel_size=3, padding=1, bias=False),
             nn.ReLU(),
         )
-        self.sum_head = nn.Sequential(nn.Conv2d(5, 2, kernel_size=1, bias=False), Reducer(mode="sum"))
-        self.mean_head = nn.Sequential(nn.Conv2d(5, 2, kernel_size=1, bias=False), Reducer(mode="mean"))
+        self.sum_conv = nn.Conv2d(5, 2, kernel_size=1, bias=False)
+        self.sum_reducer = Reducer(mode="sum")
+        self.mean_conv = nn.Conv2d(5, 2, kernel_size=1, bias=False)
+        self.mean_reducer = Reducer(mode="mean")
 
-    def forward(self, x):
+    def forward(self, x, mask=None):
         feat = self.backbone(x)
-        return self.sum_head(feat), self.mean_head(feat)
+        return self.sum_reducer(self.sum_conv(feat), mask=mask), self.mean_reducer(self.mean_conv(feat), mask=mask)
 
 
 def _make_streaming(model: nn.Module, tile_size: int = 4):
@@ -54,11 +58,11 @@ def test_streaming_reducer_mixed_outputs_forward_parity():
     image = torch.randn(1, 3, 9, 11)
 
     with torch.no_grad():
-        expected = model(image)
+        expected = model(image, mask=None)
 
     scnn = _make_streaming(model, tile_size=4)
     with torch.no_grad():
-        streamed = scnn.forward(image)
+        streamed = scnn.forward(image, mask=None)
 
     assert streamed["raw"].shape == expected["raw"].shape
     assert streamed["reduced"].shape == expected["reduced"].shape
@@ -72,11 +76,31 @@ def test_streaming_reducer_multiple_reducers_modes_forward_parity():
     image = torch.randn(1, 3, 8, 10)
 
     with torch.no_grad():
-        expected_sum, expected_mean = model(image)
+        expected_sum, expected_mean = model(image, mask=None)
 
     scnn = _make_streaming(model, tile_size=5)
     with torch.no_grad():
-        streamed_sum, streamed_mean = scnn.forward(image)
+        streamed_sum, streamed_mean = scnn.forward(image, mask=None)
+
+    assert streamed_sum.shape == expected_sum.shape
+    assert streamed_mean.shape == expected_mean.shape
+    assert torch.allclose(streamed_sum, expected_sum, atol=1e-5, rtol=1e-4)
+    assert torch.allclose(streamed_mean, expected_mean, atol=1e-5, rtol=1e-4)
+
+
+def test_streaming_reducer_multiple_reducers_modes_forward_parity_with_mask():
+    torch.manual_seed(12)
+    model = MultiReducerNet().eval()
+    image = torch.randn(1, 3, 8, 10)
+    mask = torch.zeros((8, 10), dtype=torch.bool)
+    mask[1:7, 2:8] = True
+
+    with torch.no_grad():
+        expected_sum, expected_mean = model(image, mask=mask)
+
+    scnn = _make_streaming(model, tile_size=5)
+    with torch.no_grad():
+        streamed_sum, streamed_mean = scnn.forward(image, mask=mask)
 
     assert streamed_sum.shape == expected_sum.shape
     assert streamed_mean.shape == expected_mean.shape
@@ -93,12 +117,12 @@ def test_streaming_reducer_backward_parity():
     reference.load_state_dict(model.state_dict())
 
     ref_image = image.clone().requires_grad_(True)
-    ref_sum, ref_mean = reference(ref_image)
+    ref_sum, ref_mean = reference(ref_image, mask=None)
     ref_loss = (0.7 * ref_sum).sum() + (1.3 * ref_mean).sum()
     ref_loss.backward()
 
     scnn = _make_streaming(model, tile_size=4)
-    streamed_sum, streamed_mean = scnn.forward(image.clone())
+    streamed_sum, streamed_mean = scnn.forward(image.clone(), mask=None)
     grad_sum = torch.full_like(streamed_sum, 0.7)
     grad_mean = torch.full_like(streamed_mean, 1.3)
     scnn.backward(image.clone(), (grad_sum, grad_mean))
@@ -120,12 +144,12 @@ def test_streaming_reducer_backward_parity_tiny_odd_image():
     reference.load_state_dict(model.state_dict())
 
     ref_image = image.clone().requires_grad_(True)
-    ref_sum, ref_mean = reference(ref_image)
+    ref_sum, ref_mean = reference(ref_image, mask=None)
     ref_loss = (0.2 * ref_sum).sum() + (-0.4 * ref_mean).sum()
     ref_loss.backward()
 
     scnn = _make_streaming(model, tile_size=6)
-    streamed_sum, streamed_mean = scnn.forward(image.clone())
+    streamed_sum, streamed_mean = scnn.forward(image.clone(), mask=None)
     grad_sum = torch.full_like(streamed_sum, 0.2)
     grad_mean = torch.full_like(streamed_mean, -0.4)
     scnn.backward(image.clone(), (grad_sum, grad_mean))
@@ -136,6 +160,54 @@ def test_streaming_reducer_backward_parity_tiny_odd_image():
     for name, ref_grad in ref_grads.items():
         assert name in stream_grads
         assert torch.allclose(stream_grads[name], ref_grad, atol=1e-5, rtol=1e-4), name
+
+
+def test_streaming_reducer_backward_parity_with_mask():
+    torch.manual_seed(13)
+    model = MultiReducerNet().eval()
+    image = torch.randn(1, 3, 11, 9)
+    mask = torch.zeros((11, 9), dtype=torch.bool)
+    mask[2:10, 1:8] = True
+
+    reference = MultiReducerNet().eval()
+    reference.load_state_dict(model.state_dict())
+
+    ref_image = image.clone().requires_grad_(True)
+    ref_sum, ref_mean = reference(ref_image, mask=mask)
+    ref_loss = (0.7 * ref_sum).sum() + (1.3 * ref_mean).sum()
+    ref_loss.backward()
+
+    scnn = _make_streaming(model, tile_size=4)
+    streamed_sum, streamed_mean = scnn.forward(image.clone(), mask=mask)
+    grad_sum = torch.full_like(streamed_sum, 0.7)
+    grad_mean = torch.full_like(streamed_mean, 1.3)
+    scnn.backward(image.clone(), (grad_sum, grad_mean))
+
+    ref_grads = {name: p.grad for name, p in reference.named_parameters() if p.grad is not None}
+    stream_grads = {name: p.grad for name, p in scnn.stream_module.named_parameters() if p.grad is not None}
+
+    for name, ref_grad in ref_grads.items():
+        assert name in stream_grads
+        assert torch.allclose(stream_grads[name], ref_grad, atol=1e-5, rtol=1e-4), name
+
+
+def test_streaming_reducer_forward_parity_all_zero_mask_mean_clamped():
+    torch.manual_seed(14)
+    model = MultiReducerNet().eval()
+    image = torch.randn(1, 3, 7, 9)
+    mask = torch.zeros((7, 9), dtype=torch.bool)
+
+    with torch.no_grad():
+        expected_sum, expected_mean = model(image, mask=mask)
+
+    scnn = _make_streaming(model, tile_size=4)
+    with torch.no_grad():
+        streamed_sum, streamed_mean = scnn.forward(image, mask=mask)
+
+    assert torch.allclose(expected_sum, torch.zeros_like(expected_sum))
+    assert torch.allclose(expected_mean, torch.zeros_like(expected_mean))
+    assert torch.allclose(streamed_sum, expected_sum, atol=1e-5, rtol=1e-4)
+    assert torch.allclose(streamed_mean, expected_mean, atol=1e-5, rtol=1e-4)
 
 
 def test_streaming_reducer_running_count_uses_fp32_accumulator():

--- a/tests/test_streaming_reducer.py
+++ b/tests/test_streaming_reducer.py
@@ -43,6 +43,7 @@ def _make_streaming(model: nn.Module, tile_size: int = 4):
     constructor = StreamingConstructor(
         model,
         tile_size=tile_size,
+        saliency=True,
         verbose=False,
         deterministic=True,
         copy_to_gpu=False,
@@ -112,17 +113,18 @@ def test_streaming_reducer_backward_parity():
     torch.manual_seed(3)
     model = MultiReducerNet().eval()
     image = torch.randn(1, 3, 11, 9)
+    mask = torch.rand((11, 9)) > 0.35
 
     reference = MultiReducerNet().eval()
     reference.load_state_dict(model.state_dict())
 
     ref_image = image.clone().requires_grad_(True)
-    ref_sum, ref_mean = reference(ref_image, mask=None)
+    ref_sum, ref_mean = reference(ref_image, mask=mask)
     ref_loss = (0.7 * ref_sum).sum() + (1.3 * ref_mean).sum()
     ref_loss.backward()
 
     scnn = _make_streaming(model, tile_size=4)
-    streamed_sum, streamed_mean = scnn.forward(image.clone(), mask=None)
+    streamed_sum, streamed_mean = scnn.forward(image.clone(), mask=mask)
     grad_sum = torch.full_like(streamed_sum, 0.7)
     grad_mean = torch.full_like(streamed_mean, 1.3)
     scnn.backward(image.clone(), (grad_sum, grad_mean))

--- a/tests/test_streaming_reducer.py
+++ b/tests/test_streaming_reducer.py
@@ -43,7 +43,6 @@ def _make_streaming(model: nn.Module, tile_size: int = 4):
     constructor = StreamingConstructor(
         model,
         tile_size=tile_size,
-        saliency=True,
         verbose=False,
         deterministic=True,
         copy_to_gpu=False,
@@ -113,18 +112,17 @@ def test_streaming_reducer_backward_parity():
     torch.manual_seed(3)
     model = MultiReducerNet().eval()
     image = torch.randn(1, 3, 11, 9)
-    mask = torch.rand((11, 9)) > 0.35
 
     reference = MultiReducerNet().eval()
     reference.load_state_dict(model.state_dict())
 
     ref_image = image.clone().requires_grad_(True)
-    ref_sum, ref_mean = reference(ref_image, mask=mask)
+    ref_sum, ref_mean = reference(ref_image, mask=None)
     ref_loss = (0.7 * ref_sum).sum() + (1.3 * ref_mean).sum()
     ref_loss.backward()
 
     scnn = _make_streaming(model, tile_size=4)
-    streamed_sum, streamed_mean = scnn.forward(image.clone(), mask=mask)
+    streamed_sum, streamed_mean = scnn.forward(image.clone(), mask=None)
     grad_sum = torch.full_like(streamed_sum, 0.7)
     grad_mean = torch.full_like(streamed_mean, 1.3)
     scnn.backward(image.clone(), (grad_sum, grad_mean))


### PR DESCRIPTION
### Motivation
- Support selective spatial reduction by allowing a user-provided spatial `mask` to the `Reducer` and ensure the streaming implementation respects that mask during forward accumulation and backward replay.
- Propagate mask through the streaming stack so streaming outputs and backward gradients match eager (non-streaming) behavior when masks are used.

### Description
- Extend `Reducer` with a `mask` parameter and an `_expand_mask` helper to accept 2D/3D/4D masks and apply masked `sum`/`mean` reduction in `forward`.
- Enhance `StreamingReducer` to store a per-head user mask, track forward/backward seen pixels, apply user mask slices in `accumulate_stream_tile`/`build_backward_pair`, and pass `valid_mask` into the tile reduction autograd op; also add shape checks and replay destination verification.
- Update `StreamingCNN` to accept an optional `mask` in `forward`, prepare per-head reducer masks via `_prepare_reducer_mask`, thread mask tiles into `accumulate_stream_tile`, and supply destination boxes to reducer-backed backward pair construction.
- Propagate the new `mask` argument through higher-level modules by updating `LightningStreamingModule.forward` and `StreamingModule.forward` to accept `mask` and forward it to the streaming network.
- Update tests in `tests/test_streaming_reducer.py` to exercise masked forward/backward parity, add cases for all-zero masks and ensure reducer running-count accumulator behavior remains correct.

### Testing
- Ran the streaming reducer unit tests with `pytest tests/test_streaming_reducer.py` and all tests passed.
- Verified masked forward parity and masked backward gradient parity cases introduced in the test file succeeded under the updated streaming code.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b29079ee348330bda39b4b007ad30a)