### PR TITLE
Add optional spatial mask support to Reducer and streaming pipeline

### DIFF
--- a/examples/compare_grads_segment.py
+++ b/examples/compare_grads_segment.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Iterable
+from typing import Iterable, Optional
 import argparse
 
 import torch
@@ -79,9 +79,12 @@ def _parse_dtype(value: str) -> torch.dtype:
 
 
 
-def _masked_output_mean(output: torch.Tensor, mask_2d: torch.Tensor) -> torch.Tensor:
+def _masked_output_mean(output: torch.Tensor, mask_2d: Optional[torch.Tensor]) -> torch.Tensor:
     if output.ndim != 4:
         raise ValueError(f"Expected 4D output tensor (N,C,H,W), got shape={tuple(output.shape)}")
+
+    if mask_2d is None:
+        return output.mean()
 
     if mask_2d.shape != output.shape[-2:]:
         mask_4d = mask_2d.to(dtype=output.dtype)[None, None]
@@ -106,6 +109,7 @@ def main() -> None:
     parser.add_argument("--dtype", default="float64", help="float16, float32, or float64")
     parser.add_argument("--tile-size", type=int, default=3200)
     parser.add_argument("--input-size", type=int, default=6400)
+    parser.add_argument("--disable-mask", action="store_true", help="Disable dummy mask to compare legacy behavior")
     args = parser.parse_args()
 
     torch.manual_seed(0)
@@ -119,7 +123,7 @@ def main() -> None:
     target = torch.tensor(50.0, device=device, dtype=dtype)
     criterion = torch.nn.MSELoss()
 
-    dummy_mask = (torch.rand((input_size, input_size), device=device) > 0.2)
+    dummy_mask = None if args.disable_mask else (torch.rand((input_size, input_size), device=device) > 0.2)
 
     network = StreamingWSS(
         "resnet18",
@@ -145,7 +149,7 @@ def main() -> None:
     _freeze_batchnorm(network.stream_network.stream_module)
 
     _zero_grads(network.stream_network.stream_module.parameters())
-    stream_outputs = network(img, mask=dummy_mask)
+    stream_outputs = network(img, mask=dummy_mask) if dummy_mask is not None else network(img)
     for out in stream_outputs:
         out.requires_grad = True
         out.retain_grad()

--- a/examples/compare_grads_segment.py
+++ b/examples/compare_grads_segment.py
@@ -99,9 +99,11 @@ def main() -> None:
     tile_size = args.tile_size
     input_size = args.input_size
 
-    img = torch.rand((1, 3, input_size, input_size), device='cpu', dtype=dtype)
+    img = torch.rand((1, 3, input_size, input_size), device=device, dtype=dtype)
     target = torch.tensor(50.0, device=device, dtype=dtype)
     criterion = torch.nn.MSELoss()
+
+    dummy_mask = (torch.rand((input_size, input_size), device=device) > 0.2)
 
     network = StreamingWSS(
         "resnet18",
@@ -110,7 +112,7 @@ def main() -> None:
         mean=[0, 0, 0],
         std=[1, 1, 1],
         normalize_on_gpu=False,
-        saliency=False,
+        saliency=True,
     ).to(device=device, dtype=dtype)
     network.stream_network.device = device
     network.stream_network.dtype = dtype
@@ -127,7 +129,7 @@ def main() -> None:
     _freeze_batchnorm(network.stream_network.stream_module)
 
     _zero_grads(network.stream_network.stream_module.parameters())
-    stream_outputs = network(img)
+    stream_outputs = network(img, mask=dummy_mask)
     for out in stream_outputs:
         out.requires_grad = True
         out.retain_grad()

--- a/examples/compare_grads_segment.py
+++ b/examples/compare_grads_segment.py
@@ -149,7 +149,13 @@ def main() -> None:
     _freeze_batchnorm(network.stream_network.stream_module)
 
     _zero_grads(network.stream_network.stream_module.parameters())
-    stream_outputs = network(img, mask=dummy_mask) if dummy_mask is not None else network(img)
+    if dummy_mask is None:
+        print("Mask disabled: running legacy unmasked comparison.")
+        stream_outputs = network(img)
+    else:
+        mask_ratio = dummy_mask.to(dtype=torch.float32).mean().item()
+        print(f"Mask enabled: valid ratio={mask_ratio:.4f}")
+        stream_outputs = network(img, mask=dummy_mask)
     for out in stream_outputs:
         out.requires_grad = True
         out.retain_grad()
@@ -168,7 +174,8 @@ def main() -> None:
     _freeze_batchnorm(normal_net)
     _zero_grads(normal_net.parameters())
     img_normal = img.detach().clone().requires_grad_(True)
-    normal_outputs = normal_net(img_normal)
+    normal_outputs = normal_net(img_normal, mask=dummy_mask) if dummy_mask is not None else normal_net(img_normal)
+    print(f"Normal path mask active: {dummy_mask is not None}")
 
     for stream_out, normal_out in zip(stream_outputs, normal_outputs):
         diff = (stream_out - normal_out).abs()

--- a/examples/compare_grads_segment.py
+++ b/examples/compare_grads_segment.py
@@ -77,6 +77,22 @@ def _parse_dtype(value: str) -> torch.dtype:
     return mapping[key]
 
 
+
+
+def _masked_output_mean(output: torch.Tensor, mask_2d: torch.Tensor) -> torch.Tensor:
+    if output.ndim != 4:
+        raise ValueError(f"Expected 4D output tensor (N,C,H,W), got shape={tuple(output.shape)}")
+
+    if mask_2d.shape != output.shape[-2:]:
+        mask_4d = mask_2d.to(dtype=output.dtype)[None, None]
+        mask_4d = torch.nn.functional.interpolate(mask_4d, size=output.shape[-2:], mode="nearest")
+        mask_2d = mask_4d[0, 0] > 0.5
+
+    mask = mask_2d.to(device=output.device, dtype=output.dtype)[None, None]
+    denom = mask.sum(dtype=torch.float32).clamp_min(1)
+    numer = (output * mask).sum(dtype=torch.float32)
+    return (numer / denom).to(dtype=output.dtype)
+
 def _freeze_batchnorm(module: nn.Module) -> None:
     for submodule in module.modules():
         if isinstance(submodule, nn.BatchNorm2d):
@@ -134,7 +150,7 @@ def main() -> None:
         out.requires_grad = True
         out.retain_grad()
 
-    y_pred_streaming = [torch.sigmoid(torch.mean(x)) for x in stream_outputs]
+    y_pred_streaming = [torch.sigmoid(_masked_output_mean(x, dummy_mask)) for x in stream_outputs]
     loss = [criterion(x, target) for x in y_pred_streaming]
     total_loss = sum(loss)
     total_loss.backward()
@@ -154,7 +170,7 @@ def main() -> None:
         diff = (stream_out - normal_out).abs()
         print(f"Forward output sum/max diff: {diff.sum().item()}, {diff.max().item()}")
 
-    y_pred_normal = [torch.sigmoid(torch.mean(x)) for x in normal_outputs]
+    y_pred_normal = [torch.sigmoid(_masked_output_mean(x, dummy_mask)) for x in normal_outputs]
     normal_loss = [criterion(x, target) for x in y_pred_normal]
     total_loss = sum(normal_loss)
     total_loss.backward()

--- a/lightstream/core/scnn/scnn.py
+++ b/lightstream/core/scnn/scnn.py
@@ -720,20 +720,22 @@ class StreamingCNN(torch.nn.Module):
         trimmed_output = self._trim_head_output(head_output, head_lost)
         return head_lost, output_loc, trimmed_output
 
-    def _accumulate_reducer_forward_tile(self, head_idx, trimmed_output, output_loc, tile_input_y, tile_input_x, sides):
+    def _accumulate_reducer_forward_tile(self, head_idx, trimmed_output, output_loc, tile_input_y, tile_input_x, sides, mask):
         dst_y0 = int(output_loc.y)
         dst_y1 = int(output_loc.y + trimmed_output.shape[H_DIM])
         dst_x0 = int(output_loc.x)
         dst_x1 = int(output_loc.x + trimmed_output.shape[W_DIM])
+        tile_user_mask = None if mask is None else mask[dst_y0:dst_y1, dst_x0:dst_x1]
         self._reducer_head_map[head_idx].accumulate_stream_tile(
             trimmed_output=trimmed_output,
             tile_y=int(tile_input_y),
             tile_x=int(tile_input_x),
             sides=sides,
             dst_box=(dst_y0, dst_y1, dst_x0, dst_x1),
+            user_mask=tile_user_mask,
         )
 
-    def _stitch_forward_outputs(self, outputs, tile_outputs, tile_input_y, tile_input_x, sides):
+    def _stitch_forward_outputs(self, outputs, tile_outputs, tile_input_y, tile_input_x, sides, mask):
         for head_idx, head_output in enumerate(tile_outputs):
             _, output_loc, trimmed_output = self._build_stitched_tile_output(
                 head_idx=head_idx,
@@ -751,6 +753,7 @@ class StreamingCNN(torch.nn.Module):
                     tile_input_y=tile_input_y,
                     tile_input_x=tile_input_x,
                     sides=sides,
+                    mask=mask,
                 )
                 continue
 
@@ -860,10 +863,19 @@ class StreamingCNN(torch.nn.Module):
         del trimmed_grads
         del trimmed_outputs
 
-    def forward(self, image, result_on_cpu=False):
+    def forward(self, image, result_on_cpu=False, mask=None):
         """Perform forward pass with lightstream."""
         if self.copy_to_gpu:
             image = image.to(self.device, non_blocking=True)
+
+        if mask is not None:
+            if not torch.is_tensor(mask):
+                raise ValueError("mask must be a torch.Tensor")
+            if mask.ndim != 2:
+                raise ValueError(f"Streaming mask must be 2D (H,W), got shape={tuple(mask.shape)}")
+            if mask.shape != image.shape[-2:]:
+                raise ValueError(f"Streaming mask shape must match image (H,W)={tuple(image.shape[-2:])}, got {tuple(mask.shape)}")
+            mask = mask.to(self.device, dtype=torch.bool, non_blocking=True)
 
         tile_height = self.tile_shape[H_DIM]
         tile_width = self.tile_shape[W_DIM]
@@ -946,7 +958,7 @@ class StreamingCNN(torch.nn.Module):
                 if torch.backends.cudnn.benchmark:
                     torch.cuda.empty_cache()
 
-                self._stitch_forward_outputs(outputs, tile_outputs, input_y, input_x, sides)
+                self._stitch_forward_outputs(outputs, tile_outputs, input_y, input_x, sides, mask)
                 del tile
 
         assert last_sides is not None and last_sides.bottom and last_sides.right, (

--- a/lightstream/core/scnn/scnn.py
+++ b/lightstream/core/scnn/scnn.py
@@ -1028,8 +1028,8 @@ class StreamingCNN(torch.nn.Module):
             output_widths=output_widths,
         )
 
-        if self.debug_reducer_replay:
-            for reducer in self._reducer_head_map.values():
+        for reducer in self._reducer_head_map.values():
+            if reducer.requires_backward_replay():
                 reducer.start_backward_replay()
 
         last_sides = None
@@ -1042,8 +1042,8 @@ class StreamingCNN(torch.nn.Module):
                 sides=sides,
             )
 
-        if self.debug_reducer_replay:
-            for idx, reducer in self._reducer_head_map.items():
+        for idx, reducer in self._reducer_head_map.items():
+            if reducer.requires_backward_replay():
                 reducer.validate_backward_replay_consumed(head_idx=idx)
 
         self._saved_tensors = {}

--- a/lightstream/models/segment/model.py
+++ b/lightstream/models/segment/model.py
@@ -2,8 +2,8 @@
 https://github.com/Nexuslkl/Swin_MIL/blob/main/models/swin_mil.py
 
 """
+from typing import Optional
 import torch
-from torch import Tensor
 import torch.nn as nn
 
 from lightstream.models.segment.resnet import make_resnet_backbone
@@ -41,14 +41,14 @@ class WSS(nn.Module):
         self.w = [0.3, 0.4, 0.3]
 
 
-    def forward(self, x):
+    def forward(self, x, mask: Optional[torch.Tensor] = None):
         x1, x2, x3 = self.backbone(x)
 
         y1 = self.decoder1(x1)
         y2 = self.decoder2(x2)
         y3 = self.decoder3(x3)
         y = 0.3 * y1 + 0.3*y2 + 0.3*y3
-        return self.red1(y1), self.red2(y2), self.red3(y3), y
+        return self.red1(y1, mask=mask), self.red2(y2, mask=mask), self.red3(y3, mask=mask), y
 
 if __name__ == "__main__":
     print(" is cuda available? ", torch.cuda.is_available())

--- a/lightstream/modules/lightningstreaming.py
+++ b/lightstream/modules/lightningstreaming.py
@@ -85,7 +85,7 @@ class LightningStreamingModule(L.LightningModule):
         """
         self._prepare_start_for_streaming()
 
-    def forward(self, x):
+    def forward(self, x, mask=None):
         """
 
         Parameters
@@ -99,7 +99,7 @@ class LightningStreamingModule(L.LightningModule):
         The output of the streaming model
 
         """
-        return self.stream_network.forward(x)
+        return self.stream_network.forward(x, mask=mask)
 
     def backward_streaming(self, image, grad):
         self.stream_network.backward(image, grad)

--- a/lightstream/modules/reducer.py
+++ b/lightstream/modules/reducer.py
@@ -77,14 +77,42 @@ class Reducer(nn.Module):
         self.mode = mode
         self._streaming_passthrough = False
 
-    def forward(self, x: torch.Tensor) -> torch.Tensor:
+    def _normalize_mask(self, x: torch.Tensor, mask: torch.Tensor) -> torch.Tensor:
+        if mask.ndim == 2:
+            if mask.shape != x.shape[-2:]:
+                raise ValueError(f"2D mask shape must match (H,W)={tuple(x.shape[-2:])}, got {tuple(mask.shape)}")
+            return mask[None, None]
+
+        if mask.ndim == 4:
+            if mask.shape[-2:] != x.shape[-2:]:
+                raise ValueError(f"4D mask shape must match spatial dims (H,W)={tuple(x.shape[-2:])}, got {tuple(mask.shape)}")
+            if mask.shape[0] not in {1, x.shape[0]}:
+                raise ValueError(f"4D mask batch dimension must be 1 or N={x.shape[0]}, got {mask.shape[0]}")
+            if mask.shape[1] not in {1, x.shape[1]}:
+                raise ValueError(f"4D mask channel dimension must be 1 or C={x.shape[1]}, got {mask.shape[1]}")
+            return mask
+
+        raise ValueError(f"mask must be 2D (H,W) or 4D (N,C,H,W)/(N,1,H,W), got shape={tuple(mask.shape)}")
+
+    def forward(self, x: torch.Tensor, mask: torch.Tensor | None = None) -> torch.Tensor:
         if x.ndim != 4:
             raise ValueError(f"Reducer expects NCHW tensor, got shape={tuple(x.shape)}")
         if self._streaming_passthrough:
             return x
+        if mask is None:
+            if self.mode == "sum":
+                return x.sum(dim=(-2, -1), keepdim=True)
+            return x.mean(dim=(-2, -1), keepdim=True)
+
+        mask_4d = self._normalize_mask(x, mask).to(dtype=x.dtype, device=x.device)
+        masked = x * mask_4d
+
         if self.mode == "sum":
-            return x.sum(dim=(-2, -1), keepdim=True)
-        return x.mean(dim=(-2, -1), keepdim=True)
+            return masked.sum(dim=(-2, -1), keepdim=True)
+
+        numerator = masked.sum(dim=(-2, -1), keepdim=True, dtype=torch.float32)
+        denominator = mask_4d.sum(dim=(-2, -1), keepdim=True, dtype=torch.float32).clamp_min(1)
+        return (numerator / denominator).to(dtype=x.dtype)
 
 
 class StreamingReducer(nn.Module):
@@ -110,6 +138,8 @@ class StreamingReducer(nn.Module):
         self._debug_replay_enabled = False
         self._replay_assignments: list[tuple] | None = None
         self._replay_cursor: int | None = None
+        self._forward_tile_masks: list[torch.Tensor] = []
+        self._backward_mask_cursor: int = 0
 
     @classmethod
     def from_reducer(cls, module: Reducer) -> "StreamingReducer":
@@ -144,11 +174,24 @@ class StreamingReducer(nn.Module):
         self._debug_replay_enabled = debug_replay
         self._replay_assignments = [] if debug_replay else None
         self._replay_cursor = None
+        self._forward_tile_masks = []
+        self._backward_mask_cursor = 0
 
-    def accumulate_stream_tile(self, trimmed_output: torch.Tensor, tile_y: int, tile_x: int, sides, dst_box):
+    def accumulate_stream_tile(
+        self,
+        trimmed_output: torch.Tensor,
+        tile_y: int,
+        tile_x: int,
+        sides,
+        dst_box,
+        user_mask: torch.Tensor | None = None,
+    ):
         dst_y0, dst_y1, dst_x0, dst_x1 = dst_box
         seen_slice = self._stream_seen_mask[dst_y0:dst_y1, dst_x0:dst_x1]
         new_mask = ~seen_slice
+        valid_mask = new_mask if user_mask is None else (new_mask & user_mask.to(dtype=torch.bool, device=new_mask.device))
+
+        self._forward_tile_masks.append(valid_mask.detach().clone())
 
         if self._debug_replay_enabled:
             if self._replay_assignments is None:
@@ -170,9 +213,9 @@ class StreamingReducer(nn.Module):
                 )
             )
 
-        if torch.any(new_mask):
-            self.accumulate_tile(trimmed_output, valid_mask=new_mask)
-            seen_slice |= new_mask
+        if torch.any(valid_mask):
+            self.accumulate_tile(trimmed_output, valid_mask=valid_mask)
+            seen_slice |= valid_mask
 
     def finish_stream(self) -> torch.Tensor:
         return self.finalize_stream()
@@ -253,6 +296,8 @@ class StreamingReducer(nn.Module):
         expected_h = int(trimmed_output.shape[-2])
         expected_w = int(trimmed_output.shape[-1])
 
+        replay_valid_mask = self._next_backward_mask(trimmed_output)
+
         if self._debug_replay_enabled:
             if self._replay_assignments is None or self._replay_cursor is None:
                 raise RuntimeError("Reducer replay state is not initialized. Call start_backward_replay() first.")
@@ -267,8 +312,20 @@ class StreamingReducer(nn.Module):
             )
 
         normalization = self.running_count if self.mode == "mean" else None
-        reduced_output = self.reduce_tile(trimmed_output, normalization=normalization)
+        reduced_output = self.reduce_tile(trimmed_output, valid_mask=replay_valid_mask, normalization=normalization)
         return reduced_output, gradient
+
+    def _next_backward_mask(self, trimmed_output: torch.Tensor) -> torch.Tensor | None:
+        if self._backward_mask_cursor >= len(self._forward_tile_masks):
+            raise RuntimeError("Reducer mask replay cursor out of range.")
+        mask = self._forward_tile_masks[self._backward_mask_cursor]
+        self._backward_mask_cursor += 1
+        if mask.shape != trimmed_output.shape[-2:]:
+            raise RuntimeError(
+                "Reducer mask replay shape mismatch: "
+                f"forward={tuple(mask.shape)} backward={tuple(trimmed_output.shape[-2:])}"
+            )
+        return mask
 
     def _validate_replay_assignment(
         self,
@@ -327,7 +384,7 @@ class StreamingReducer(nn.Module):
 
         return cursor + 1
 
-    def forward(self, x: torch.Tensor) -> torch.Tensor:
+    def forward(self, x: torch.Tensor, mask: torch.Tensor | None = None) -> torch.Tensor:
         # Marker behavior for streaming path; SCNN performs accumulation.
         self._last_output = x
         return x

--- a/lightstream/modules/reducer.py
+++ b/lightstream/modules/reducer.py
@@ -138,8 +138,9 @@ class StreamingReducer(nn.Module):
         self._debug_replay_enabled = False
         self._replay_assignments: list[tuple] | None = None
         self._replay_cursor: int | None = None
-        self._forward_tile_masks: list[torch.Tensor] = []
-        self._backward_mask_cursor: int = 0
+        self._forward_tile_masks: dict[tuple[int, int, bool, bool, bool, bool, int, int], torch.Tensor] = {}
+        self._consumed_backward_mask_keys: set[tuple[int, int, bool, bool, bool, bool, int, int]] = set()
+        self._masking_active = False
 
     @classmethod
     def from_reducer(cls, module: Reducer) -> "StreamingReducer":
@@ -174,8 +175,21 @@ class StreamingReducer(nn.Module):
         self._debug_replay_enabled = debug_replay
         self._replay_assignments = [] if debug_replay else None
         self._replay_cursor = None
-        self._forward_tile_masks = []
-        self._backward_mask_cursor = 0
+        self._forward_tile_masks = {}
+        self._consumed_backward_mask_keys = set()
+        self._masking_active = False
+
+    def _tile_mask_key(self, tile_y: int, tile_x: int, sides, trimmed_h: int, trimmed_w: int):
+        return (
+            int(tile_y),
+            int(tile_x),
+            bool(sides.top),
+            bool(sides.left),
+            bool(sides.right),
+            bool(sides.bottom),
+            int(trimmed_h),
+            int(trimmed_w),
+        )
 
     def accumulate_stream_tile(
         self,
@@ -190,8 +204,16 @@ class StreamingReducer(nn.Module):
         seen_slice = self._stream_seen_mask[dst_y0:dst_y1, dst_x0:dst_x1]
         new_mask = ~seen_slice
         valid_mask = new_mask if user_mask is None else (new_mask & user_mask.to(dtype=torch.bool, device=new_mask.device))
-
-        self._forward_tile_masks.append(valid_mask.detach().clone())
+        if user_mask is not None:
+            self._masking_active = True
+            mask_key = self._tile_mask_key(
+                tile_y=tile_y,
+                tile_x=tile_x,
+                sides=sides,
+                trimmed_h=trimmed_output.shape[-2],
+                trimmed_w=trimmed_output.shape[-1],
+            )
+            self._forward_tile_masks[mask_key] = valid_mask.detach().clone()
 
         if self._debug_replay_enabled:
             if self._replay_assignments is None:
@@ -227,16 +249,31 @@ class StreamingReducer(nn.Module):
             self._replay_cursor = 0
         else:
             self._replay_cursor = None
+        if self._masking_active:
+            self._consumed_backward_mask_keys = set()
+
+    def requires_backward_replay(self) -> bool:
+        return self._debug_replay_enabled or self._masking_active
 
     def validate_backward_replay_consumed(self, *, head_idx: int):
-        if not self._debug_replay_enabled:
+        if self._debug_replay_enabled:
+            if self._replay_assignments is None or self._replay_cursor is None:
+                raise RuntimeError("Reducer replay state is not initialized.")
+            if self._replay_cursor != len(self._replay_assignments):
+                raise RuntimeError(
+                    f"Reducer assignment replay incomplete for head {head_idx}: "
+                    f"consumed={self._replay_cursor}, expected={len(self._replay_assignments)}"
+                )
+
+        if not self._masking_active:
             return
-        if self._replay_assignments is None or self._replay_cursor is None:
-            raise RuntimeError("Reducer replay state is not initialized.")
-        if self._replay_cursor != len(self._replay_assignments):
+
+        expected = set(self._forward_tile_masks.keys())
+        missing = expected - self._consumed_backward_mask_keys
+        if missing:
             raise RuntimeError(
-                f"Reducer assignment replay incomplete for head {head_idx}: "
-                f"consumed={self._replay_cursor}, expected={len(self._replay_assignments)}"
+                f"Reducer mask replay incomplete for head {head_idx}: "
+                f"consumed={len(self._consumed_backward_mask_keys)}, expected={len(expected)}"
             )
 
     def accumulate_tile(self, tile_valid_output: torch.Tensor, valid_mask: torch.Tensor | None = None):
@@ -296,7 +333,14 @@ class StreamingReducer(nn.Module):
         expected_h = int(trimmed_output.shape[-2])
         expected_w = int(trimmed_output.shape[-1])
 
-        replay_valid_mask = self._next_backward_mask(trimmed_output)
+        replay_valid_mask = None
+        if self._masking_active:
+            replay_valid_mask = self._backward_mask_for_tile(
+                trimmed_output=trimmed_output,
+                input_y=input_y,
+                input_x=input_x,
+                sides=sides,
+            )
 
         if self._debug_replay_enabled:
             if self._replay_assignments is None or self._replay_cursor is None:
@@ -315,16 +359,33 @@ class StreamingReducer(nn.Module):
         reduced_output = self.reduce_tile(trimmed_output, valid_mask=replay_valid_mask, normalization=normalization)
         return reduced_output, gradient
 
-    def _next_backward_mask(self, trimmed_output: torch.Tensor) -> torch.Tensor | None:
-        if self._backward_mask_cursor >= len(self._forward_tile_masks):
-            raise RuntimeError("Reducer mask replay cursor out of range.")
-        mask = self._forward_tile_masks[self._backward_mask_cursor]
-        self._backward_mask_cursor += 1
+    def _backward_mask_for_tile(
+        self,
+        *,
+        trimmed_output: torch.Tensor,
+        input_y: int,
+        input_x: int,
+        sides,
+    ) -> torch.Tensor:
+        key = self._tile_mask_key(
+            tile_y=input_y,
+            tile_x=input_x,
+            sides=sides,
+            trimmed_h=trimmed_output.shape[-2],
+            trimmed_w=trimmed_output.shape[-1],
+        )
+        if key not in self._forward_tile_masks:
+            raise RuntimeError(f"Reducer mask replay key not found for key={key}.")
+        if key in self._consumed_backward_mask_keys:
+            raise RuntimeError(f"Reducer mask replay key consumed more than once for key={key}.")
+
+        mask = self._forward_tile_masks[key]
         if mask.shape != trimmed_output.shape[-2:]:
             raise RuntimeError(
                 "Reducer mask replay shape mismatch: "
                 f"forward={tuple(mask.shape)} backward={tuple(trimmed_output.shape[-2:])}"
             )
+        self._consumed_backward_mask_keys.add(key)
         return mask
 
     def _validate_replay_assignment(

--- a/lightstream/modules/streaming.py
+++ b/lightstream/modules/streaming.py
@@ -87,8 +87,8 @@ class StreamingModule(nn.Module):
 
         return state_dict
 
-    def forward(self, x):
-        return self.stream_network(x)
+    def forward(self, x, mask=None):
+        return self.stream_network(x, mask=mask)
 
     def backward_streaming(self, image, grad):
         self.stream_network.backward(image, grad)

--- a/tests/test_streaming_reducer.py
+++ b/tests/test_streaming_reducer.py
@@ -35,6 +35,23 @@ class MultiReducerNet(nn.Module):
         return self.sum_head(feat), self.mean_head(feat)
 
 
+class MaskedMultiReducerNet(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.backbone = nn.Sequential(
+            nn.Conv2d(3, 5, kernel_size=3, padding=1, bias=False),
+            nn.ReLU(),
+        )
+        self.sum_conv = nn.Conv2d(5, 2, kernel_size=1, bias=False)
+        self.mean_conv = nn.Conv2d(5, 2, kernel_size=1, bias=False)
+        self.sum_reducer = Reducer(mode="sum")
+        self.mean_reducer = Reducer(mode="mean")
+
+    def forward(self, x, mask=None):
+        feat = self.backbone(x)
+        return self.sum_reducer(self.sum_conv(feat), mask=mask), self.mean_reducer(self.mean_conv(feat), mask=mask)
+
+
 def _make_streaming(model: nn.Module, tile_size: int = 4):
     constructor = StreamingConstructor(
         model,
@@ -150,3 +167,52 @@ def test_streaming_reducer_running_count_uses_fp32_accumulator():
     output = reducer.finalize_stream()
     assert output.dtype == tile.dtype
     assert torch.allclose(output, torch.ones((1, 2, 1, 1), dtype=tile.dtype))
+
+
+def test_streaming_reducer_masked_forward_parity():
+    torch.manual_seed(7)
+    model = MaskedMultiReducerNet().eval()
+    image = torch.randn(1, 3, 9, 13)
+    mask = torch.zeros((9, 13), dtype=torch.bool)
+    mask[1:8, 2:11] = True
+    mask[::2, ::3] = False
+
+    with torch.no_grad():
+        expected_sum, expected_mean = model(image, mask=mask)
+
+    scnn = _make_streaming(model, tile_size=5)
+    with torch.no_grad():
+        streamed_sum, streamed_mean = scnn.forward(image, mask=mask)
+
+    assert torch.allclose(streamed_sum, expected_sum, atol=1e-5, rtol=1e-4)
+    assert torch.allclose(streamed_mean, expected_mean, atol=1e-5, rtol=1e-4)
+
+
+def test_streaming_reducer_masked_backward_parity():
+    torch.manual_seed(11)
+    model = MaskedMultiReducerNet().eval()
+    image = torch.randn(1, 3, 10, 9)
+    mask = torch.zeros((10, 9), dtype=torch.bool)
+    mask[1:9, 1:8] = True
+    mask[3:5, 2:4] = False
+
+    reference = MaskedMultiReducerNet().eval()
+    reference.load_state_dict(model.state_dict())
+
+    ref_image = image.clone().requires_grad_(True)
+    ref_sum, ref_mean = reference(ref_image, mask=mask)
+    ref_loss = (0.9 * ref_sum).sum() + (-1.1 * ref_mean).sum()
+    ref_loss.backward()
+
+    scnn = _make_streaming(model, tile_size=4)
+    streamed_sum, streamed_mean = scnn.forward(image.clone(), mask=mask)
+    grad_sum = torch.full_like(streamed_sum, 0.9)
+    grad_mean = torch.full_like(streamed_mean, -1.1)
+    scnn.backward(image.clone(), (grad_sum, grad_mean))
+
+    ref_grads = {name: p.grad for name, p in reference.named_parameters() if p.grad is not None}
+    stream_grads = {name: p.grad for name, p in scnn.stream_module.named_parameters() if p.grad is not None}
+
+    for name, ref_grad in ref_grads.items():
+        assert name in stream_grads
+        assert torch.allclose(stream_grads[name], ref_grad, atol=1e-5, rtol=1e-4), name

--- a/tests/test_streaming_reducer.py
+++ b/tests/test_streaming_reducer.py
@@ -216,3 +216,30 @@ def test_streaming_reducer_masked_backward_parity():
     for name, ref_grad in ref_grads.items():
         assert name in stream_grads
         assert torch.allclose(stream_grads[name], ref_grad, atol=1e-5, rtol=1e-4), name
+
+
+def test_streaming_reducer_mask_optional_none_matches_legacy_behavior():
+    torch.manual_seed(13)
+    model = MaskedMultiReducerNet().eval()
+    image = torch.randn(1, 3, 9, 9)
+
+    reference = MaskedMultiReducerNet().eval()
+    reference.load_state_dict(model.state_dict())
+
+    ref_image = image.clone().requires_grad_(True)
+    ref_sum, ref_mean = reference(ref_image)
+    ref_loss = (0.6 * ref_sum).sum() + (0.4 * ref_mean).sum()
+    ref_loss.backward()
+
+    scnn = _make_streaming(model, tile_size=4)
+    streamed_sum, streamed_mean = scnn.forward(image.clone(), mask=None)
+    grad_sum = torch.full_like(streamed_sum, 0.6)
+    grad_mean = torch.full_like(streamed_mean, 0.4)
+    scnn.backward(image.clone(), (grad_sum, grad_mean))
+
+    ref_grads = {name: p.grad for name, p in reference.named_parameters() if p.grad is not None}
+    stream_grads = {name: p.grad for name, p in scnn.stream_module.named_parameters() if p.grad is not None}
+
+    for name, ref_grad in ref_grads.items():
+        assert name in stream_grads
+        assert torch.allclose(stream_grads[name], ref_grad, atol=1e-5, rtol=1e-4), name


### PR DESCRIPTION
### Motivation
- Allow users to provide a spatial validity mask so reducers (sum/mean) only consider a subset of pixels during both streamed forward and backward passes.
- Propagate mask support through the streaming orchestration so tile accumulation and replay are consistent when masking is used.

### Description
- Added an optional `mask` argument to `StreamingCNN.forward` and propagated it into `_stitch_forward_outputs` and `_accumulate_reducer_forward_tile` so reducer accumulation receives a per-tile `user_mask`.
- Extended `Reducer.forward` to accept `mask` (2D or 4D) with validation via a new helper `_normalize_mask`, and applied masked `sum`/`mean` semantics while preserving dtype behavior for the mean accumulator.
- Enhanced `StreamingReducer` to record per-forward-tile valid masks (`_forward_tile_masks`), apply the user mask when computing the effective valid pixels, and replay those masks during backward pairing via `_next_backward_mask` and `build_backward_pair` so backward reduction matches forward accumulation.
- Threaded mask parameter through higher-level modules by adding `mask` to `LightningStreamingModule.forward` and `StreamingModule.forward` and forwarding it to the streaming network.
- Updated the streaming reduce autograd path to respect masks for forward/backward (mask handling is passed into tile reduction and gradient computation).

### Testing
- Added `tests/test_streaming_reducer.py` cases `test_streaming_reducer_masked_forward_parity` and `test_streaming_reducer_masked_backward_parity` exercising masked `sum` and `mean` parity between reference and streaming implementations, and retained existing reducer parity/backward tests.
- Ran the reducer streaming test suite including the new masked forward/backward tests; all tests passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b2bd8e26f08330b391bc8fa28dc6bf)