### PR TITLE
Add streaming GeM reducer with forward/backward support and tests

### DIFF
--- a/lightstream/core/reducer/gem.py
+++ b/lightstream/core/reducer/gem.py
@@ -1,24 +1,94 @@
-"""GeM reducer API entry points for streaming integration."""
+"""GeM reducer implementation for streaming integration."""
 
 import torch
 
-from .base import StreamingReducer
+from .base import BaseStreamingGlobalReducer, streaming_reduce_tile
+from .utils import resolve_accumulator_dtype
 
 
-class StreamingGeMReducer(StreamingReducer):
-    """Compatibility streaming reducer entry point for GeM-style reducers.
+class StreamingGeMReducer(BaseStreamingGlobalReducer):
+    """Streaming global GeM reducer with optional learnable exponent ``r``."""
 
-    Notes
-    -----
-    This class currently reuses mean-style streaming accumulation behavior.
-    """
-
-    def __init__(self, accumulator_dtype: torch.dtype | None = None):
-        """Create a GeM reducer placeholder.
-
-        Parameters
-        ----------
-        accumulator_dtype : torch.dtype | None, default=None
-            Optional accumulator dtype used by base streaming logic.
-        """
+    def __init__(
+        self,
+        r_init: float = 4.0,
+        learnable_r: bool = False,
+        eps: float = 1e-6,
+        accumulator_dtype: torch.dtype | None = None,
+    ):
         super().__init__(mode="mean", accumulator_dtype=accumulator_dtype)
+        self.learnable_r = bool(learnable_r)
+        self.eps = float(eps)
+        init_r = torch.tensor(float(r_init), dtype=torch.float32)
+        if self.learnable_r:
+            self.r = torch.nn.Parameter(init_r)
+        else:
+            self.register_buffer("r", init_r)
+
+        self.register_buffer("running_q", torch.zeros(0), persistent=False)
+
+    @property
+    def current_r(self) -> torch.Tensor:
+        return self.r
+
+    def init_reduction_state(self, *, batch_size: int, channels: int, device: torch.device, dtype: torch.dtype, accumulator_dtype: torch.dtype) -> None:
+        self.running_q = torch.zeros((batch_size, channels, 1, 1), device=device, dtype=accumulator_dtype)
+
+    def accumulate_valid_tile(self, tile: torch.Tensor, valid_mask: torch.Tensor) -> None:
+        if self.running_sum.numel() == 0:
+            self.reset_stream_state(batch_size=tile.shape[0], channels=tile.shape[1], device=tile.device, dtype=tile.dtype)
+
+        acc_dtype = resolve_accumulator_dtype(self.accumulator_dtype, tile.dtype)
+        x = tile.to(dtype=acc_dtype)
+        x_clamped = x.clamp_min(self.eps)
+        r = self.current_r.to(device=tile.device, dtype=acc_dtype)
+
+        x_pow = x_clamped.pow(r)
+        s_tile = streaming_reduce_tile(x_pow, valid_mask, None).to(dtype=self.running_sum.dtype)
+        q_tile = streaming_reduce_tile(x_pow * x_clamped.log(), valid_mask, None).to(dtype=self.running_q.dtype)
+
+        self.running_sum = self.running_sum + s_tile
+        self.running_q = self.running_q + q_tile
+
+        n_pixels = int(valid_mask.sum().item())
+        pixel_increment = torch.tensor(n_pixels, device=self.running_count.device, dtype=self.running_count.dtype)
+        self.running_count = self.running_count + pixel_increment
+
+    def finalize_from_state(self) -> torch.Tensor:
+        if self.running_sum.numel() == 0:
+            raise RuntimeError("StreamingGeMReducer state is empty, accumulate_stream_tile() was not called.")
+
+        acc_dtype = resolve_accumulator_dtype(self.accumulator_dtype, self.running_sum.dtype)
+        r = self.current_r.to(device=self.running_sum.device, dtype=acc_dtype)
+        s = self.running_sum.to(dtype=acc_dtype)
+        n = self.running_count.to(dtype=acc_dtype).clamp_min(1)
+        m = (s / n).clamp_min(self.eps)
+        y = m.pow(1.0 / r)
+        return y.to(dtype=self.running_sum.dtype)
+
+    def extra_state_for_backward(self) -> dict[str, torch.Tensor | int | float | None]:
+        acc_dtype = resolve_accumulator_dtype(self.accumulator_dtype, self.running_sum.dtype)
+        r = self.current_r.to(device=self.running_sum.device, dtype=acc_dtype)
+        n = self.running_count.to(dtype=acc_dtype).clamp_min(1)
+        s = self.running_sum.to(dtype=acc_dtype)
+        m = (s / n).clamp_min(self.eps)
+        return {
+            "normalization": n,
+            "r": r,
+            "m": m,
+            "q": self.running_q.to(dtype=acc_dtype),
+        }
+
+    def reduce_tile_for_backward(self, trimmed_output: torch.Tensor, valid_mask: torch.Tensor | None, global_context: dict[str, torch.Tensor | int | float | None]) -> torch.Tensor:
+        if valid_mask is None:
+            raise ValueError("StreamingGeMReducer backward replay requires a valid_mask.")
+
+        acc_dtype = resolve_accumulator_dtype(self.accumulator_dtype, trimmed_output.dtype)
+        x = trimmed_output.to(dtype=acc_dtype)
+        x_clamped = x.clamp_min(self.eps)
+        r = global_context["r"].to(device=trimmed_output.device, dtype=acc_dtype)
+        n = global_context["normalization"].to(device=trimmed_output.device, dtype=acc_dtype).clamp_min(1)
+
+        x_pow = x_clamped.pow(r)
+        m_tile = streaming_reduce_tile(x_pow, valid_mask, n)
+        return m_tile.clamp_min(self.eps).pow(1.0 / r).to(dtype=trimmed_output.dtype)

--- a/tests/test_streaming_reducer.py
+++ b/tests/test_streaming_reducer.py
@@ -161,3 +161,80 @@ def test_streaming_sum_reducer_does_not_normalize():
     output = reducer.finalize_stream()
     assert output.dtype == tile.dtype
     assert torch.allclose(output, torch.full((1, 2, 1, 1), 6.0, dtype=tile.dtype))
+
+from lightstream.core.reducer import StreamingGeMReducer
+
+
+def _gem_reference(x: torch.Tensor, mask: torch.Tensor, r: torch.Tensor, eps: float):
+    x_clamped = x.clamp_min(eps)
+    mask4 = mask.to(dtype=x.dtype, device=x.device)[None, None]
+    n = mask4.sum(dim=(-2, -1), keepdim=True).clamp_min(1)
+    m = (x_clamped.pow(r) * mask4).sum(dim=(-2, -1), keepdim=True) / n
+    return m.clamp_min(eps).pow(1.0 / r)
+
+
+def test_streaming_gem_default_r_init():
+    reducer = StreamingGeMReducer()
+    assert reducer.learnable_r is False
+    assert torch.isclose(reducer.current_r, torch.tensor(4.0), atol=1e-6)
+
+
+def test_streaming_gem_learnable_r_matches_init():
+    reducer = StreamingGeMReducer(r_init=16.0, learnable_r=True)
+    assert isinstance(reducer.r, torch.nn.Parameter)
+    assert torch.isclose(reducer.current_r.detach(), torch.tensor(16.0), atol=1e-6)
+
+
+def test_streaming_gem_forward_parity_masked_tiny_odd_shape():
+    torch.manual_seed(7)
+    reducer = StreamingGeMReducer(r_init=3.5, learnable_r=False, eps=1e-6)
+    x = torch.rand(1, 2, 3, 5) + 0.01
+    mask = torch.tensor([[1, 0, 1, 0, 1], [1, 1, 0, 1, 0], [0, 1, 1, 0, 1]], dtype=torch.bool)
+
+    reducer.start_stream(output_height=3, output_width=5, batch_size=1, channels=2, device=x.device, dtype=x.dtype)
+    reducer.accumulate_stream_tile(x[:, :, :2, :3], 0, 0, type('S', (), dict(top=False,left=False,right=False,bottom=False))(), (0,2,0,3), user_mask=mask[:2,:3])
+    reducer.accumulate_stream_tile(x[:, :, :2, 3:], 0, 1, type('S', (), dict(top=False,left=False,right=False,bottom=False))(), (0,2,3,5), user_mask=mask[:2,3:])
+    reducer.accumulate_stream_tile(x[:, :, 2:, :], 1, 0, type('S', (), dict(top=False,left=False,right=False,bottom=False))(), (2,3,0,5), user_mask=mask[2:,:])
+    y_stream = reducer.finish_stream()
+
+    y_ref = _gem_reference(x, mask, reducer.current_r.to(dtype=x.dtype), reducer.eps)
+    assert torch.allclose(y_stream, y_ref, atol=1e-5, rtol=1e-4)
+
+
+def test_streaming_gem_backward_input_and_r_grad_parity():
+    torch.manual_seed(9)
+    x = (torch.rand(1, 3, 5, 7) + 0.05).requires_grad_(True)
+    mask = (torch.rand(5, 7) > 0.3)
+
+    reducer = StreamingGeMReducer(r_init=2.3, learnable_r=True, eps=1e-6)
+    reducer.start_stream(output_height=5, output_width=7, batch_size=1, channels=3, device=x.device, dtype=x.dtype)
+    reducer.accumulate_stream_tile(x[:, :, :, :4], 0, 0, type('S', (), dict(top=False,left=False,right=False,bottom=False))(), (0,5,0,4), user_mask=mask[:, :4])
+    reducer.accumulate_stream_tile(x[:, :, :, 4:], 0, 1, type('S', (), dict(top=False,left=False,right=False,bottom=False))(), (0,5,4,7), user_mask=mask[:, 4:])
+    y_stream = reducer.finish_stream()
+    loss_stream = y_stream.sum()
+    loss_stream.backward()
+    grad_x_stream = x.grad.detach().clone()
+    grad_r_stream = reducer.r.grad.detach().clone()
+
+    x_ref = x.detach().clone().requires_grad_(True)
+    r_ref = torch.nn.Parameter(reducer.r.detach().clone())
+    y_ref = _gem_reference(x_ref, mask, r_ref.to(dtype=x_ref.dtype), reducer.eps)
+    y_ref.sum().backward()
+
+    assert torch.allclose(grad_x_stream, x_ref.grad, atol=1e-5, rtol=1e-4)
+    assert torch.allclose(grad_r_stream, r_ref.grad, atol=1e-5, rtol=1e-4)
+
+
+def test_streaming_gem_fp16_stability_accumulator_fp32():
+    torch.manual_seed(11)
+    reducer = StreamingGeMReducer(r_init=4.0, learnable_r=False)
+    x = (torch.rand(1, 2, 4, 4, dtype=torch.float16) + 0.01)
+    mask = torch.ones((4, 4), dtype=torch.bool)
+
+    reducer.start_stream(output_height=4, output_width=4, batch_size=1, channels=2, device=x.device, dtype=x.dtype)
+    reducer.accumulate_stream_tile(x, 0, 0, type('S', (), dict(top=False,left=False,right=False,bottom=False))(), (0,4,0,4), user_mask=mask)
+    y = reducer.finish_stream()
+
+    assert reducer.running_count.dtype == torch.float32
+    assert y.dtype == torch.float16
+    assert torch.isfinite(y).all()


### PR DESCRIPTION
### Motivation
- Provide a proper streaming implementation of global GeM pooling with optional learnable exponent `r`, stable accumulation and support for fp16 accumulators.
- Enable replayable backward passes for streaming GeM so gradients for both input and `r` are correct when tiled inputs are used.

### Description
- Implement `StreamingGeMReducer` in `lightstream/core/reducer/gem.py` with constructor parameters `r_init`, `learnable_r`, `eps`, and `accumulator_dtype`, and register `r` as either a `Parameter` or a buffer depending on `learnable_r`.
- Build on `BaseStreamingGlobalReducer` and use `streaming_reduce_tile` and `resolve_accumulator_dtype` to perform tile-wise accumulation of `x.pow(r)` and `x.pow(r) * log(x)` into `running_sum` and `running_q` respectively.
- Add streaming lifecycle methods: `init_reduction_state`, `accumulate_valid_tile`, `finalize_from_state`, `extra_state_for_backward`, and `reduce_tile_for_backward` to produce final outputs and to provide/contextualize data required for backward replay.
- Register `running_q` as a non-persistent buffer and ensure numeric stability via `eps` and accumulator dtype resolution.
- Add comprehensive unit tests in `tests/test_streaming_reducer.py` for `StreamingGeMReducer` covering default and learnable `r` initialization, forward parity with masks, backward gradient parity for input and `r`, and fp16 stability with fp32 accumulator.

### Testing
- Ran unit tests in `tests/test_streaming_reducer.py` including `test_streaming_gem_default_r_init`, `test_streaming_gem_learnable_r_matches_init`, `test_streaming_gem_forward_parity_masked_tiny_odd_shape`, `test_streaming_gem_backward_input_and_r_grad_parity`, and `test_streaming_gem_fp16_stability_accumulator_fp32`, and they all passed.
- Existing streaming reducer tests (e.g. mean and sum reducer tests) were exercised and continued to pass.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1220c224a0833099718eadb08a61e8)