### PR TITLE
Add BaseReducer abstract class for non-streaming reducers

### DIFF
--- a/lightstream/core/reducer/__init__.py
+++ b/lightstream/core/reducer/__init__.py
@@ -1,9 +1,11 @@
 from .base import BaseStreamingGlobalReducer, StreamingReducer
 from .gem import StreamingGeMReducer
 from .mean import Reducer, StreamingMeanReducer, StreamingSumReducer
+from .reducer_base import BaseReducer
 
 __all__ = [
     "Reducer",
+    "BaseReducer",
     "BaseStreamingGlobalReducer",
     "StreamingReducer",
     "StreamingMeanReducer",

--- a/lightstream/core/reducer/mean.py
+++ b/lightstream/core/reducer/mean.py
@@ -1,13 +1,13 @@
 """Mean/sum reducer implementations for offline and streaming execution."""
 
 import torch
-import torch.nn as nn
 
 from .base import BaseStreamingGlobalReducer, streaming_reduce_tile
+from .reducer_base import BaseReducer
 from .utils import normalize_spatial_mask, resolve_accumulator_dtype
 
 
-class Reducer(nn.Module):
+class Reducer(BaseReducer):
     """Apply global spatial sum or mean reduction on NCHW tensors.
 
     Parameters
@@ -24,7 +24,7 @@ class Reducer(nn.Module):
             raise ValueError(f"Unsupported reducer mode '{mode}', expected 'sum' or 'mean'.")
         self.mode = mode
         self.accumulator_dtype = accumulator_dtype
-        self._streaming_passthrough = False
+
 
     def forward(self, x: torch.Tensor, mask: torch.Tensor | None = None) -> torch.Tensor:
         """Reduce spatial dimensions for a batch of feature maps.
@@ -58,6 +58,12 @@ class Reducer(nn.Module):
         if self.mode == "sum":
             return x.sum(dim=(-2, -1), keepdim=True, dtype=acc_dtype).to(dtype=x.dtype)
         return x.mean(dim=(-2, -1), keepdim=True, dtype=acc_dtype).to(dtype=x.dtype)
+
+    def to_streaming(self) -> BaseStreamingGlobalReducer:
+        """Create streaming reducer with equivalent sum/mean semantics."""
+        if self.mode == "sum":
+            return StreamingSumReducer(accumulator_dtype=self.accumulator_dtype)
+        return StreamingMeanReducer(accumulator_dtype=self.accumulator_dtype)
 
 
 class _StreamingSumMeanReducer(BaseStreamingGlobalReducer):

--- a/lightstream/core/reducer/reducer_base.py
+++ b/lightstream/core/reducer/reducer_base.py
@@ -1,0 +1,39 @@
+"""Abstract base types for non-streaming global reducers."""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+
+import torch
+import torch.nn as nn
+
+from .base import BaseStreamingGlobalReducer
+
+
+class BaseReducer(nn.Module, ABC):
+    """Base class for non-streaming reducers.
+
+    Non-streaming reducers implement offline/global reduction in :meth:`forward`
+    and must provide deterministic conversion to a streaming reducer via
+    :meth:`to_streaming` with equivalent reduction semantics.
+
+    Parameters
+    ----------
+    streaming_passthrough : bool, default=False
+        When ``True``, :meth:`forward` must return the input unchanged. This is
+        used for reducer-head tagging in SCNN where execution is deferred to
+        streaming orchestration.
+    """
+
+    def __init__(self, *, streaming_passthrough: bool = False):
+        super().__init__()
+        self._streaming_passthrough = bool(streaming_passthrough)
+
+    @abstractmethod
+    def forward(self, x: torch.Tensor, mask: torch.Tensor | None = None) -> torch.Tensor:
+        """Run non-streaming reduction on ``x`` (or passthrough when enabled)."""
+
+    @abstractmethod
+    def to_streaming(self) -> BaseStreamingGlobalReducer:
+        """Create the equivalent streaming reducer implementation."""
+


### PR DESCRIPTION
### Motivation
- Introduce a shared abstract base for non-streaming/global reducers so offline reducers expose a passthrough flag and a deterministic conversion path to streaming reducers (required for reducer-head tagging / SCNN integration).

### Description
- Add `BaseReducer(nn.Module, ABC)` in `lightstream/core/reducer/reducer_base.py` with `_streaming_passthrough` support, abstract `forward(x, mask=None)`, and abstract `to_streaming()` returning a `BaseStreamingGlobalReducer`.
- Update `Reducer` in `lightstream/core/reducer/mean.py` to inherit from `BaseReducer` and preserve passthrough behavior when `self._streaming_passthrough` is set.
- Implement `Reducer.to_streaming()` to return the deterministic streaming counterpart (`StreamingSumReducer` or `StreamingMeanReducer`) carrying `accumulator_dtype`.
- Export `BaseReducer` from `lightstream/core/reducer/__init__.py` and document the contract that non-streaming reducers must provide deterministic conversion to streaming reducers with equivalent semantics.

### Testing
- Ran `python -m compileall lightstream/core/reducer` and compilation completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a12d808c34883308788444ed6c554ce)