### PR TITLE
Remove mode-based Reducer and split reducer modules by responsibility

### DIFF
--- a/lightstream/core/constructor.py
+++ b/lightstream/core/constructor.py
@@ -15,7 +15,7 @@ import torch.nn as nn
 
 from copy import deepcopy
 from lightstream.core.scnn.scnn import StreamingCNN
-from lightstream.core.reducer import Reducer
+from lightstream.core.reducer import BaseReducer
 from typing import Callable, Optional, Any
 
 
@@ -66,7 +66,7 @@ class StreamingConstructor:
             torch.nn.MaxPool2d,
             torch.nn.MaxPool3d,
             torch.nn.Upsample,
-            Reducer,
+            BaseReducer,
         ]
 
         if add_keep_modules is not None:

--- a/lightstream/core/reducer/README.md
+++ b/lightstream/core/reducer/README.md
@@ -59,12 +59,12 @@ input `H x W`.
 
 ```python
 import torch
-from lightstream.core.reducer import Reducer
+from lightstream.core.reducer import MeanReducer, SumReducer
 
 # N=2, C=64, H=W=32
 x = torch.randn(2, 64, 32, 32)
 
-reducer = Reducer(mode="mean")
+reducer = MeanReducer()
 y = reducer(x)
 
 print(y.shape)  # torch.Size([2, 64, 1, 1])
@@ -86,7 +86,7 @@ Create a module like `lightstream/core/reducer/mean.py` with an `nn.Module` that
 accepts `x: [N, C, H, W]` and returns `[N, C, 1, 1]`.
 
 ```python
-class Reducer(nn.Module):
+class MeanReducer(nn.Module):
     def __init__(self, mode: str = "mean", accumulator_dtype=None):
         ...
 
@@ -146,9 +146,9 @@ predictable.
 **Offline mean reduction**
 
 ```python
-from lightstream.core.reducer import Reducer
+from lightstream.core.reducer import MeanReducer, SumReducer
 
-reducer = Reducer(mode="mean")
+reducer = MeanReducer()
 out = reducer(x)  # [N, C, 1, 1]
 ```
 

--- a/lightstream/core/reducer/__init__.py
+++ b/lightstream/core/reducer/__init__.py
@@ -1,10 +1,12 @@
 from .base import BaseStreamingGlobalReducer, StreamingReducer
 from .gem import StreamingGeMReducer
-from .mean import Reducer, StreamingMeanReducer, StreamingSumReducer
+from .mean import MeanReducer, StreamingMeanReducer
 from .reducer_base import BaseReducer
+from .sum import StreamingSumReducer, SumReducer
 
 __all__ = [
-    "Reducer",
+    "MeanReducer",
+    "SumReducer",
     "BaseReducer",
     "BaseStreamingGlobalReducer",
     "StreamingReducer",

--- a/lightstream/core/reducer/sum.py
+++ b/lightstream/core/reducer/sum.py
@@ -1,15 +1,14 @@
-"""Mean reducer implementations for offline and streaming execution."""
+"""Sum reducer implementations for offline and streaming execution."""
 
 import torch
 
 from .base import BaseStreamingGlobalReducer, streaming_reduce_tile
 from .reducer_base import BaseReducer
-from .sum import StreamingSumReducer
 from .utils import normalize_spatial_mask, resolve_accumulator_dtype
 
 
-class MeanReducer(BaseReducer):
-    """Apply global spatial mean reduction on NCHW tensors."""
+class SumReducer(BaseReducer):
+    """Apply global spatial sum reduction on NCHW tensors."""
 
     def __init__(self, accumulator_dtype: torch.dtype | None = None):
         super().__init__()
@@ -24,39 +23,35 @@ class MeanReducer(BaseReducer):
         if mask is not None:
             mask_nchw = normalize_spatial_mask(mask, x)
             masked = x * mask_nchw.to(dtype=x.dtype)
-            denom = mask_nchw.sum(dim=(-2, -1), keepdim=True, dtype=acc_dtype).clamp_min(1)
-            mean = masked.sum(dim=(-2, -1), keepdim=True, dtype=acc_dtype) / denom
-            return mean.to(dtype=x.dtype)
-        return x.mean(dim=(-2, -1), keepdim=True, dtype=acc_dtype).to(dtype=x.dtype)
+            return masked.sum(dim=(-2, -1), keepdim=True, dtype=acc_dtype).to(dtype=x.dtype)
+        return x.sum(dim=(-2, -1), keepdim=True, dtype=acc_dtype).to(dtype=x.dtype)
 
     def to_streaming(self) -> BaseStreamingGlobalReducer:
-        return StreamingMeanReducer(accumulator_dtype=self.accumulator_dtype)
+        return StreamingSumReducer(accumulator_dtype=self.accumulator_dtype)
 
 
-class StreamingMeanReducer(StreamingSumReducer):
-    """Streaming reducer configured for mean semantics."""
+class StreamingSumReducer(BaseStreamingGlobalReducer):
+    """Streaming reducer configured for sum semantics."""
 
     def __init__(self, accumulator_dtype: torch.dtype | None = None):
-        super().__init__(accumulator_dtype=accumulator_dtype)
-        self.mode = "mean"
+        super().__init__(mode="sum", accumulator_dtype=accumulator_dtype)
+
+    def init_reduction_state(self, *, batch_size: int, channels: int, device: torch.device, dtype: torch.dtype, accumulator_dtype: torch.dtype) -> None:
+        _ = (batch_size, channels, device, dtype, accumulator_dtype)
 
     def accumulate_valid_tile(self, tile: torch.Tensor, valid_mask: torch.Tensor) -> None:
-        super().accumulate_valid_tile(tile, valid_mask)
-        n_pixels = int(valid_mask.sum().item())
-        pixel_increment = torch.tensor(n_pixels, device=self.running_count.device, dtype=self.running_count.dtype)
-        self.running_count = self.running_count + pixel_increment
+        if self.running_sum.numel() == 0:
+            self.reset_stream_state(batch_size=tile.shape[0], channels=tile.shape[1], device=tile.device, dtype=tile.dtype)
+        tile_contribution = streaming_reduce_tile(tile, valid_mask, None)
+        self.running_sum = self.running_sum + tile_contribution
 
     def finalize_from_state(self) -> torch.Tensor:
         if self.running_sum.numel() == 0:
             raise RuntimeError("StreamingReducer state is empty, accumulate_stream_tile() was not called.")
-        acc_dtype = resolve_accumulator_dtype(self.accumulator_dtype, self.running_sum.dtype)
-        denom = self.running_count.to(dtype=acc_dtype).clamp_min(1)
-        if denom.dtype != self.running_sum.dtype:
-            denom = denom.to(dtype=self.running_sum.dtype)
-        return self.running_sum / denom
+        return self.running_sum
 
     def extra_state_for_backward(self) -> dict[str, torch.Tensor | int | float | None]:
-        return {"normalization": self.running_count}
+        return {"normalization": None}
 
     def reduce_tile_for_backward(self, trimmed_output: torch.Tensor, valid_mask: torch.Tensor | None, global_context: dict[str, torch.Tensor | int | float | None]) -> torch.Tensor:
         return streaming_reduce_tile(trimmed_output, valid_mask, global_context.get("normalization"))

--- a/lightstream/core/scnn/scnn.py
+++ b/lightstream/core/scnn/scnn.py
@@ -16,7 +16,7 @@ import torch.nn.functional
 from lightstream.core.scnn.utils import Sides, Box, Lost, _ntuple, _new_value_indices, B_DIM, C_DIM, H_DIM, W_DIM
 from lightstream.core.scnn.streamingconv import StreamingConv2d
 from lightstream.core.scnn.streamingupsample import StreamingUpsample2d
-from lightstream.core.reducer import Reducer, StreamingReducer
+from lightstream.core.reducer import BaseReducer, StreamingReducer
 
 
 _triple = _ntuple(3)
@@ -227,7 +227,7 @@ class StreamingCNN(torch.nn.Module):
 
     def _set_reducer_passthrough(self, enabled: bool):
         for mod in self.stream_module.modules():
-            if isinstance(mod, Reducer):
+            if isinstance(mod, BaseReducer):
                 mod._streaming_passthrough = enabled
 
     def _gather_backward_statistics(self, tile):
@@ -426,7 +426,7 @@ class StreamingCNN(torch.nn.Module):
                 mod.output_stride = self._module_stats[module].get("output_stride", torch.tensor([1, 1, 1]))
                 self._module_stats[mod] = self._module_stats[module]
                 del self._module_stats[module]
-        elif isinstance(module, Reducer):
+        elif isinstance(module, BaseReducer):
             mod = StreamingReducer.from_reducer(module)
             self._streaming_reducers.append(mod)
         for name, child in module.named_children():

--- a/lightstream/models/segment/model.py
+++ b/lightstream/models/segment/model.py
@@ -7,7 +7,7 @@ from torch import Tensor
 import torch.nn as nn
 
 from lightstream.models.segment.resnet import make_resnet_backbone
-from lightstream.core.reducer import Reducer
+from lightstream.core.reducer import MeanReducer
 from torchinfo import summary
 
 
@@ -23,9 +23,9 @@ class WSS(nn.Module):
     ):
         super(WSS, self).__init__()
         self.backbone, self.channels = make_resnet_backbone(encoder, weights=weights, include_layer4=not remove_last_block)
-        self.red1 = Reducer(mode="mean", accumulator_dtype=reducer_accumulator_dtype)
-        self.red2 = Reducer(mode="mean", accumulator_dtype=reducer_accumulator_dtype)
-        self.red3 = Reducer(mode="mean", accumulator_dtype=reducer_accumulator_dtype)
+        self.red1 = MeanReducer(accumulator_dtype=reducer_accumulator_dtype)
+        self.red2 = MeanReducer(accumulator_dtype=reducer_accumulator_dtype)
+        self.red3 = MeanReducer(accumulator_dtype=reducer_accumulator_dtype)
 
 
         self.decoder1 = nn.Sequential(

--- a/lightstream/modules/reducer.py
+++ b/lightstream/modules/reducer.py
@@ -7,10 +7,12 @@ warnings.warn(
 )
 
 from lightstream.core.reducer import (  # noqa: E402
-    Reducer,
+    MeanReducer,
+    SumReducer,
     StreamingGeMReducer,
     StreamingMeanReducer,
     StreamingReducer,
+    StreamingSumReducer,
 )
 
-__all__ = ["Reducer", "StreamingReducer", "StreamingMeanReducer", "StreamingGeMReducer"]
+__all__ = ["MeanReducer", "SumReducer", "StreamingReducer", "StreamingMeanReducer", "StreamingSumReducer", "StreamingGeMReducer"]

--- a/tests/test_scnn.py
+++ b/tests/test_scnn.py
@@ -3,7 +3,7 @@ import torch.nn as nn
 import pytest
 
 from lightstream.core.constructor import StreamingConstructor
-from lightstream.core.reducer import Reducer
+from lightstream.core.reducer import MeanReducer, SumReducer
 
 
 class AllReducerHeadsNet(nn.Module):
@@ -13,8 +13,8 @@ class AllReducerHeadsNet(nn.Module):
             nn.Conv2d(3, 6, kernel_size=3, padding=1, bias=False),
             nn.ReLU(),
         )
-        self.sum_head = nn.Sequential(nn.Conv2d(6, 2, kernel_size=1, bias=False), Reducer(mode="sum"))
-        self.mean_head = nn.Sequential(nn.Conv2d(6, 3, kernel_size=1, bias=False), Reducer(mode="mean"))
+        self.sum_head = nn.Sequential(nn.Conv2d(6, 2, kernel_size=1, bias=False), SumReducer())
+        self.mean_head = nn.Sequential(nn.Conv2d(6, 3, kernel_size=1, bias=False), MeanReducer())
 
     def forward(self, x):
         feat = self.backbone(x)
@@ -29,7 +29,7 @@ class MixedHeadsNet(nn.Module):
             nn.ReLU(),
         )
         self.raw_head = nn.Conv2d(5, 4, kernel_size=1, bias=False)
-        self.reducer_head = nn.Sequential(nn.Conv2d(5, 4, kernel_size=1, bias=False), Reducer(mode="mean"))
+        self.reducer_head = nn.Sequential(nn.Conv2d(5, 4, kernel_size=1, bias=False), MeanReducer())
 
     def forward(self, x):
         feat = self.backbone(x)

--- a/tests/test_streaming_reducer.py
+++ b/tests/test_streaming_reducer.py
@@ -2,7 +2,7 @@ import torch
 import torch.nn as nn
 
 from lightstream.core.constructor import StreamingConstructor
-from lightstream.core.reducer import Reducer, StreamingMeanReducer, StreamingSumReducer
+from lightstream.core.reducer import MeanReducer, StreamingMeanReducer, StreamingSumReducer, SumReducer
 
 
 class MixedReducerNet(nn.Module):
@@ -13,7 +13,7 @@ class MixedReducerNet(nn.Module):
             nn.ReLU(),
         )
         self.raw_head = nn.Conv2d(4, 2, kernel_size=1, bias=False)
-        self.mean_head = nn.Sequential(nn.Conv2d(4, 2, kernel_size=1, bias=False), Reducer(mode="mean"))
+        self.mean_head = nn.Sequential(nn.Conv2d(4, 2, kernel_size=1, bias=False), MeanReducer())
 
     def forward(self, x):
         feat = self.backbone(x)
@@ -27,8 +27,8 @@ class MultiReducerNet(nn.Module):
             nn.Conv2d(3, 5, kernel_size=3, padding=1, bias=False),
             nn.ReLU(),
         )
-        self.sum_head = nn.Sequential(nn.Conv2d(5, 2, kernel_size=1, bias=False), Reducer(mode="sum"))
-        self.mean_head = nn.Sequential(nn.Conv2d(5, 2, kernel_size=1, bias=False), Reducer(mode="mean"))
+        self.sum_head = nn.Sequential(nn.Conv2d(5, 2, kernel_size=1, bias=False), SumReducer())
+        self.mean_head = nn.Sequential(nn.Conv2d(5, 2, kernel_size=1, bias=False), MeanReducer())
 
     def forward(self, x):
         feat = self.backbone(x)


### PR DESCRIPTION
## Summary
- removed the mode-driven `Reducer(mode=...)` path in favor of explicit class types
- split reducer implementation into dedicated files:
  - `mean.py`: `MeanReducer`, `StreamingMeanReducer`
  - `sum.py`: `SumReducer`, `StreamingSumReducer`
- kept class-driven streaming conversion (`to_streaming`) on each concrete reducer class
- updated SCNN conversion and passthrough checks to be type-driven via `BaseReducer` instead of a specific `Reducer` wrapper
- updated WSS segment model to use `MeanReducer` directly
- updated reducer exports and compatibility shim module exports (`lightstream/modules/reducer.py`)
- updated tests that instantiated `Reducer(mode=...)` to instantiate `MeanReducer` / `SumReducer`

## Notes
- `StreamingMeanReducer` now subclasses `StreamingSumReducer` to share tile accumulation logic while remaining in the mean module and exposing mean-specific finalize/backward normalization behavior.
- README examples were adjusted to remove `Reducer(mode=...)` usage in favor of explicit reducers.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a12e62e3ba883309ec3ea2f25fdacb7)