### PR TITLE
Generalize SCNN reducer conversion to BaseReducer mappings

### DIFF
--- a/lightstream/core/scnn/scnn.py
+++ b/lightstream/core/scnn/scnn.py
@@ -16,7 +16,7 @@ import torch.nn.functional
 from lightstream.core.scnn.utils import Sides, Box, Lost, _ntuple, _new_value_indices, B_DIM, C_DIM, H_DIM, W_DIM
 from lightstream.core.scnn.streamingconv import StreamingConv2d
 from lightstream.core.scnn.streamingupsample import StreamingUpsample2d
-from lightstream.core.reducer import BaseReducer, StreamingReducer
+from lightstream.core.reducer import BaseReducer, BaseStreamingGlobalReducer
 
 
 _triple = _ntuple(3)
@@ -427,7 +427,7 @@ class StreamingCNN(torch.nn.Module):
                 self._module_stats[mod] = self._module_stats[module]
                 del self._module_stats[module]
         elif isinstance(module, BaseReducer):
-            mod = StreamingReducer.from_reducer(module)
+            mod = module.to_streaming()
             self._streaming_reducers.append(mod)
         for name, child in module.named_children():
             mod.add_module(name, self._convert_modules_for_streaming(child))
@@ -456,7 +456,7 @@ class StreamingCNN(torch.nn.Module):
             else:
                 self._module_stats[mod] = self._module_stats[module]
                 del self._module_stats[module]
-        elif isinstance(module, StreamingReducer):
+        elif isinstance(module, BaseStreamingGlobalReducer):
             mod = module.to_reducer()
         for name, child in module.named_children():
             mod.add_module(name, self._reset_converted_modules(child))


### PR DESCRIPTION
### Motivation
- Allow any non-streaming `BaseReducer` implementation to provide its own streaming mapping so SCNN can convert custom reducers via `to_streaming()` and later restore them, extending support beyond the single built-in streaming reducer type.

### Description
- Import `BaseStreamingGlobalReducer` and update `_convert_modules_for_streaming` to call `module.to_streaming()` for any `BaseReducer` and append the resulting streaming reducer to `self._streaming_reducers`, while leaving `Conv2d`/`Upsample` logic unchanged.
- Update `_reset_converted_modules` to detect `BaseStreamingGlobalReducer` and call `to_reducer()` to restore original reducer modules.
- No changes to reducer passthrough toggling (still operates on `BaseReducer`) and reducer-head resolution is preserved by continuing to track converted reducers in `self._streaming_reducers`.

### Testing
- Ran `pytest -q tests/test_streaming_reducer.py`, which failed during test collection due to a missing optional dependency (`lightning`) in the test environment, so no in-repo unit test failures related to the change were observed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a131d1ed2d08330bf47fe48d6231148)