### PR TITLE
Add SCNN reducer conversion and GeM parity tests

### DIFF
--- a/tests/test_scnn.py
+++ b/tests/test_scnn.py
@@ -3,7 +3,14 @@ import torch.nn as nn
 import pytest
 
 from lightstream.core.constructor import StreamingConstructor
-from lightstream.core.reducer import MeanReducer, SumReducer
+from lightstream.core.reducer import (
+    GeMReducer,
+    MeanReducer,
+    StreamingGeMReducer,
+    StreamingMeanReducer,
+    StreamingSumReducer,
+    SumReducer,
+)
 
 
 class AllReducerHeadsNet(nn.Module):
@@ -34,6 +41,23 @@ class MixedHeadsNet(nn.Module):
     def forward(self, x):
         feat = self.backbone(x)
         return {"raw": self.raw_head(feat), "reduced": self.reducer_head(feat)}
+
+
+class GeMHeadNet(nn.Module):
+    def __init__(self, learnable_r: bool):
+        super().__init__()
+        self.backbone = nn.Sequential(
+            nn.Conv2d(3, 5, kernel_size=3, padding=1, bias=False),
+            nn.ReLU(),
+        )
+        self.gem_head = nn.Sequential(
+            nn.Conv2d(5, 3, kernel_size=1, bias=False),
+            GeMReducer(r=3.2, eps=1e-6, learnable_r=learnable_r),
+        )
+
+    def forward(self, x):
+        feat = self.backbone(x)
+        return self.gem_head(feat)
 
 
 def _make_streaming(model: nn.Module, tile_size: int = 4):
@@ -161,3 +185,80 @@ def test_scnn_backward_requires_forward_for_reducer_heads():
     grad = tuple(torch.ones_like(head) for head in expected_output)
     with pytest.raises(RuntimeError, match="requires prior streaming forward pass"):
         scnn.backward(image, grad)
+
+
+@pytest.mark.parametrize(
+    ("head_module_name", "expected_streaming_type"),
+    [
+        ("sum_head.1", StreamingSumReducer),
+        ("mean_head.1", StreamingMeanReducer),
+    ],
+)
+def test_scnn_converts_reducer_heads_to_streaming_types(head_module_name, expected_streaming_type):
+    model = AllReducerHeadsNet().eval()
+    scnn = _make_streaming(model, tile_size=4)
+    assert isinstance(scnn.stream_module.get_submodule(head_module_name), expected_streaming_type)
+
+
+@pytest.mark.parametrize("learnable_r", [False, True])
+def test_scnn_gem_conversion_forward_backward_parity(learnable_r):
+    torch.manual_seed(53 if learnable_r else 47)
+    model = GeMHeadNet(learnable_r=learnable_r).eval()
+    reference = GeMHeadNet(learnable_r=learnable_r).eval()
+    reference.load_state_dict(model.state_dict())
+
+    image = (torch.rand(1, 3, 9, 11) + 0.05).requires_grad_(True)
+    ref_image = image.detach().clone().requires_grad_(True)
+
+    ref_out = reference(ref_image)
+    ref_grad = torch.full_like(ref_out, 0.37)
+    torch.autograd.backward(ref_out, ref_grad)
+
+    scnn = _make_streaming(model, tile_size=4)
+    assert isinstance(scnn.stream_module.get_submodule("gem_head.1"), StreamingGeMReducer)
+    stream_out = scnn.forward(image.detach().clone())
+    assert torch.allclose(stream_out, ref_out.detach(), atol=1e-5, rtol=1e-4)
+
+    scnn.backward(image.detach().clone(), ref_grad.detach().clone())
+
+    stream_grads = {name: p.grad for name, p in scnn.stream_module.named_parameters() if p.grad is not None}
+    ref_grads = {name: p.grad for name, p in reference.named_parameters() if p.grad is not None}
+    for name, ref_param_grad in ref_grads.items():
+        assert name in stream_grads
+        assert torch.allclose(stream_grads[name], ref_param_grad, atol=1e-5, rtol=1e-4), name
+
+    # input-grad parity under real SCNN execution
+    input_scnn = _make_streaming(GeMHeadNet(learnable_r=learnable_r).eval(), tile_size=4)
+    input_scnn.gather_input_gradient = True
+    input_scnn._remove_hooks()
+    input_scnn._add_hooks_for_streaming()
+    scnn_image = image.detach().clone()
+    _ = input_scnn.forward(scnn_image)
+    input_scnn.backward(scnn_image, ref_grad.detach().clone())
+    assert torch.allclose(input_scnn.saliency_map, ref_image.grad, atol=1e-5, rtol=1e-4)
+
+    if learnable_r:
+        assert reference.gem_head[1].r.grad is not None
+        assert stream_grads["gem_head.1.r"] is not None
+        assert torch.allclose(stream_grads["gem_head.1.r"], reference.gem_head[1].r.grad, atol=1e-5, rtol=1e-4)
+
+
+def test_scnn_mixed_head_reducer_mapping_stable():
+    torch.manual_seed(61)
+    model = MixedHeadsNet().eval()
+    image = torch.randn(1, 3, 13, 9)
+
+    scnn = _make_streaming(model, tile_size=4)
+    assert isinstance(scnn.stream_module.reducer_head[1], StreamingMeanReducer)
+    with torch.no_grad():
+        expected = model(image)
+        stream_first = scnn.forward(image)
+        stream_second = scnn.forward(image)
+
+    assert scnn._reducer_head_map
+    reducer_head_index = next(iter(scnn._reducer_head_map.keys()))
+    assert reducer_head_index == 1
+    assert torch.allclose(stream_first["raw"], expected["raw"], atol=1e-5, rtol=1e-4)
+    assert torch.allclose(stream_first["reduced"], expected["reduced"], atol=1e-5, rtol=1e-4)
+    assert torch.allclose(stream_second["raw"], expected["raw"], atol=1e-5, rtol=1e-4)
+    assert torch.allclose(stream_second["reduced"], expected["reduced"], atol=1e-5, rtol=1e-4)


### PR DESCRIPTION
### Motivation
- Validate that reducer heads (Mean/Sum/GeM) are automatically converted to their streaming equivalents inside the SCNN constructor. 
- Ensure forward parity between streaming and non-streaming execution for reducer-backed heads (including GeM) across tile layouts. 
- Verify backward parity for parameter gradients and input gradients (including `r.grad` when GeM has a learnable exponent), and ensure reducer-head mapping is stable for mixed-head models.

### Description
- Extended `tests/test_scnn.py` with additional imports and a new `GeMHeadNet` fixture that exercises `GeMReducer(r=..., learnable_r=...)` and the streaming conversion path. 
- Added a parameterized test `test_scnn_converts_reducer_heads_to_streaming_types` asserting that `SumReducer`/`MeanReducer` become `StreamingSumReducer`/`StreamingMeanReducer` in the streaming module. 
- Added `test_scnn_gem_conversion_forward_backward_parity` (parametrized for `learnable_r=False/True`) that asserts conversion to `StreamingGeMReducer`, forward parity vs reference model, backward parameter-gradient parity, input-gradient parity via SCNN saliency hooks, and `r.grad` parity when `learnable_r=True`. 
- Added `test_scnn_mixed_head_reducer_mapping_stable` to verify reducer-head mapping remains stable across repeated forwards for mixed (raw + reducer) outputs.

### Testing
- Ran a targeted pytest selection: `pytest -q tests/test_scnn.py -k 'gem_conversion or converts_reducer_heads or mixed_head_reducer_mapping_stable'`. 
- Test collection failed due to missing optional environment dependencies (`ModuleNotFoundError: No module named 'lightning'` and `numpy` not available), so the new tests were not executed to completion in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a13224ded3c83308d5158dcc1c6a356)