### PR TITLE
Remove stale `Reducer` compatibility exports from modules package

### DIFF
--- a/lightstream/modules/__init__.py
+++ b/lightstream/modules/__init__.py
@@ -1,5 +1,25 @@
 from .lightningstreaming import LightningStreamingModule
 from .imagenet_template import ImageNetClassifier
-from .reducer import Reducer, StreamingReducer
+from .reducer import (
+    BaseReducer,
+    GeMReducer,
+    MeanReducer,
+    StreamingGeMReducer,
+    StreamingMeanReducer,
+    StreamingReducer,
+    StreamingSumReducer,
+    SumReducer,
+)
 
-__all__ = ["LightningStreamingModule", "ImageNetClassifier", "Reducer", "StreamingReducer"]
+__all__ = [
+    "LightningStreamingModule",
+    "ImageNetClassifier",
+    "BaseReducer",
+    "MeanReducer",
+    "SumReducer",
+    "GeMReducer",
+    "StreamingReducer",
+    "StreamingMeanReducer",
+    "StreamingSumReducer",
+    "StreamingGeMReducer",
+]

--- a/lightstream/modules/reducer.py
+++ b/lightstream/modules/reducer.py
@@ -7,12 +7,23 @@ warnings.warn(
 )
 
 from lightstream.core.reducer import (  # noqa: E402
+    BaseReducer,
+    GeMReducer,
     MeanReducer,
-    SumReducer,
     StreamingGeMReducer,
     StreamingMeanReducer,
     StreamingReducer,
     StreamingSumReducer,
+    SumReducer,
 )
 
-__all__ = ["MeanReducer", "SumReducer", "StreamingReducer", "StreamingMeanReducer", "StreamingSumReducer", "StreamingGeMReducer"]
+__all__ = [
+    "BaseReducer",
+    "MeanReducer",
+    "SumReducer",
+    "GeMReducer",
+    "StreamingReducer",
+    "StreamingMeanReducer",
+    "StreamingSumReducer",
+    "StreamingGeMReducer",
+]


### PR DESCRIPTION
### Motivation
- The package previously re-exported a removed `Reducer` symbol from `lightstream.modules`, which caused package initialization to reference a non-existent name. 
- Align top-level module exports with the current reducer API surface in `lightstream.core.reducer` so imports no longer rely on deprecated/removed symbols.

### Description
- Updated `lightstream/modules/__init__.py` to stop importing `Reducer` and instead import and export concrete reducer classes (`BaseReducer`, `MeanReducer`, `SumReducer`, `GeMReducer`, `StreamingReducer`, `StreamingMeanReducer`, `StreamingSumReducer`, `StreamingGeMReducer`) and adjusted the `__all__` accordingly. 
- Rewrote the compatibility shim in `lightstream/modules/reducer.py` to re-export only the active reducer symbols from `lightstream.core.reducer` and added `BaseReducer`/`GeMReducer` to the shim `__all__`. 
- Removed dangling references to the removed `Reducer` symbol so package initialization no longer requires it.

### Testing
- Ran the stale-import search with `rg -n "from lightstream\.modules\.reducer import .*Reducer|from lightstream\.core\.reducer import Reducer|\bReducer\(" lightstream examples tests` and confirmed it returned no matches after the changes (success). 
- Ran `python examples/compare_grads_segment.py --help` and observed it failed with `ModuleNotFoundError: No module named 'lightstream'` when executed directly in this environment (failure due to how the script was invoked here). 
- Ran `PYTHONPATH=. python -c "import lightstream; print('ok')"` to validate package import and observed the import reached the package but failed with `ModuleNotFoundError: No module named 'lightning'` due to an external dependency missing in this environment (failure unrelated to the export changes).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a132524e8b48330881b442e80f11cb1)