### PR TITLE
Refactor reducers to accept positional multi-input payloads with legacy compatibility

### DIFF
--- a/lightstream/core/reducer/base.py
+++ b/lightstream/core/reducer/base.py
@@ -285,21 +285,32 @@ class BaseStreamingGlobalReducer(nn.Module, ABC):
             raise RuntimeError("Reducer assignment mismatch: " f"stored=({dst_y0}:{dst_y1},{dst_x0}:{dst_x1}) current=({expected_h},{expected_w})")
         return cursor + 1
 
-    def forward(self, x: torch.Tensor, mask: torch.Tensor | None = None) -> torch.Tensor:
-        """Streaming forward passthrough.
+    def forward(self, *inputs: torch.Tensor, mask: torch.Tensor | None = None) -> torch.Tensor:
+        """Streaming forward passthrough for reducer tile payloads.
 
         Parameters
         ----------
-        x : torch.Tensor
-            Tile output tensor.
+        *inputs : torch.Tensor
+            Positional tile payload.
+            Legacy reducers pass exactly one tile tensor. Multi-input reducers
+            may pass multiple tensors, and should document expected arity and
+            per-input shapes. This base implementation preserves only the legacy
+            one-input passthrough behavior.
         mask : torch.Tensor | None, default=None
             Unused placeholder for API parity with non-streaming reducers.
+            Behaves as keyword-only metadata and is not part of ``*inputs``.
 
         Returns
         -------
         torch.Tensor
-            Input tensor unchanged.
+            Input tensor unchanged for one-input legacy reducers.
         """
+        if len(inputs) != 1:
+            raise ValueError(
+                "BaseStreamingGlobalReducer legacy passthrough expects exactly one tensor input; "
+                f"got {len(inputs)}."
+            )
+        x = inputs[0]
         self._last_output = x
         return x
 

--- a/lightstream/core/reducer/gem.py
+++ b/lightstream/core/reducer/gem.py
@@ -27,7 +27,10 @@ class GeMReducer(BaseReducer):
     def current_r(self) -> torch.Tensor:
         return self.r
 
-    def forward(self, x: torch.Tensor, mask: torch.Tensor | None = None) -> torch.Tensor:
+    def forward(self, *inputs: torch.Tensor, mask: torch.Tensor | None = None) -> torch.Tensor:
+        if len(inputs) != 1:
+            raise ValueError(f"GeMReducer expects exactly one tensor input, got {len(inputs)}.")
+        x = inputs[0]
         if x.ndim != 4:
             raise ValueError(f"Reducer expects NCHW tensor, got shape={tuple(x.shape)}")
         if self._streaming_passthrough:

--- a/lightstream/core/reducer/mean.py
+++ b/lightstream/core/reducer/mean.py
@@ -15,7 +15,10 @@ class MeanReducer(BaseReducer):
         super().__init__()
         self.accumulator_dtype = accumulator_dtype
 
-    def forward(self, x: torch.Tensor, mask: torch.Tensor | None = None) -> torch.Tensor:
+    def forward(self, *inputs: torch.Tensor, mask: torch.Tensor | None = None) -> torch.Tensor:
+        if len(inputs) != 1:
+            raise ValueError(f"MeanReducer expects exactly one tensor input, got {len(inputs)}.")
+        x = inputs[0]
         if x.ndim != 4:
             raise ValueError(f"Reducer expects NCHW tensor, got shape={tuple(x.shape)}")
         if self._streaming_passthrough:

--- a/lightstream/core/reducer/reducer_base.py
+++ b/lightstream/core/reducer/reducer_base.py
@@ -30,10 +30,18 @@ class BaseReducer(nn.Module, ABC):
         self._streaming_passthrough = bool(streaming_passthrough)
 
     @abstractmethod
-    def forward(self, x: torch.Tensor, mask: torch.Tensor | None = None) -> torch.Tensor:
-        """Run non-streaming reduction on ``x`` (or passthrough when enabled)."""
+    def forward(self, *inputs: torch.Tensor, mask: torch.Tensor | None = None) -> torch.Tensor:
+        """Run non-streaming reduction over positional ``inputs``.
+
+        Conventions
+        -----------
+        - Legacy reducers consume exactly one tensor input (``inputs[0]``).
+        - Multi-input reducers must define and validate expected arity and
+          per-input shape contracts.
+        - ``mask`` is always a keyword-only auxiliary argument and is not part
+          of ``*inputs``.
+        """
 
     @abstractmethod
     def to_streaming(self) -> BaseStreamingGlobalReducer:
         """Create the equivalent streaming reducer implementation."""
-

--- a/lightstream/core/reducer/sum.py
+++ b/lightstream/core/reducer/sum.py
@@ -14,7 +14,10 @@ class SumReducer(BaseReducer):
         super().__init__()
         self.accumulator_dtype = accumulator_dtype
 
-    def forward(self, x: torch.Tensor, mask: torch.Tensor | None = None) -> torch.Tensor:
+    def forward(self, *inputs: torch.Tensor, mask: torch.Tensor | None = None) -> torch.Tensor:
+        if len(inputs) != 1:
+            raise ValueError(f"SumReducer expects exactly one tensor input, got {len(inputs)}.")
+        x = inputs[0]
         if x.ndim != 4:
             raise ValueError(f"Reducer expects NCHW tensor, got shape={tuple(x.shape)}")
         if self._streaming_passthrough:


### PR DESCRIPTION
### Motivation
- Enable reducers to accept arbitrary positional tile payloads so multi-input reduction strategies can be implemented using a unified `forward` contract. 
- Make streaming- and non-streaming-facing APIs consistent about payload shape while preserving simple legacy single-tensor reducers. 
- Keep `mask` behavior as a keyword-only auxiliary argument and avoid packing it into positional inputs.

### Description
- Change the non-streaming reducer base signature from `def forward(self, x, mask=None)` to `def forward(self, *inputs, mask=None)` and document conventions for legacy vs multi-input reducers. 
- Change the streaming-facing `BaseStreamingGlobalReducer.forward` to `def forward(self, *inputs, mask=None)` and implement a legacy passthrough that validates exactly one tensor input. 
- Update built-in legacy reducers (`SumReducer`, `MeanReducer`, `GeMReducer`) to accept `*inputs` while enforcing one-input arity and extracting `x = inputs[0]` to preserve prior behavior. 
- Preserve `mask` as keyword-only metadata and raise clear `ValueError`s when legacy arity expectations are violated.

### Testing
- Compiled the modified modules with `python -m compileall lightstream/core/reducer/reducer_base.py lightstream/core/reducer/base.py lightstream/core/reducer/sum.py lightstream/core/reducer/mean.py lightstream/core/reducer/gem.py`, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1413df9ce4833092c751860e263205)