### PR TITLE
Validate reducer replay arity and add AttentionGeM backward-parity test

### DIFF
--- a/lightstream/core/reducer/attention_gem.py
+++ b/lightstream/core/reducer/attention_gem.py
@@ -126,7 +126,23 @@ class StreamingAttentionGeMReducer(BaseStreamingGlobalReducer):
         if self._debug_replay_enabled:
             if self._replay_assignments is None:
                 raise RuntimeError("Reducer replay assignments are not initialized.")
-            self._replay_assignments.append((int(tile_y), int(tile_x), bool(sides.top), bool(sides.left), bool(sides.right), bool(sides.bottom), int(x_tile.shape[-2]), int(x_tile.shape[-1]), int(dst_y0), int(dst_y1), int(dst_x0), int(dst_x1)))
+            self._replay_assignments.append(
+                (
+                    int(tile_y),
+                    int(tile_x),
+                    bool(sides.top),
+                    bool(sides.left),
+                    bool(sides.right),
+                    bool(sides.bottom),
+                    int(x_tile.shape[-2]),
+                    int(x_tile.shape[-1]),
+                    int(dst_y0),
+                    int(dst_y1),
+                    int(dst_x0),
+                    int(dst_x1),
+                    len(payload),
+                )
+            )
         if torch.any(effective_mask):
             self.accumulate_valid_tile(payload, valid_mask=effective_mask)
         seen_slice |= new_mask
@@ -138,7 +154,16 @@ class StreamingAttentionGeMReducer(BaseStreamingGlobalReducer):
         if self._debug_replay_enabled:
             if self._replay_assignments is None or self._replay_cursor is None:
                 raise RuntimeError("Reducer replay state is not initialized. Call start_backward_replay() first.")
-            self._replay_cursor = self._validate_replay_assignment(assignments=self._replay_assignments, cursor=self._replay_cursor, input_y=input_y, input_x=input_x, sides=sides, expected_h=expected_h, expected_w=expected_w)
+            self._replay_cursor = self._validate_replay_assignment(
+                assignments=self._replay_assignments,
+                cursor=self._replay_cursor,
+                input_y=input_y,
+                input_x=input_x,
+                sides=sides,
+                expected_h=expected_h,
+                expected_w=expected_w,
+                expected_arity=len(payload),
+            )
         reduced_output = self.reduce_tile_for_backward(payload, valid_mask=valid_mask, global_context=self.extra_state_for_backward())
         return reduced_output, gradient
 

--- a/lightstream/core/reducer/base.py
+++ b/lightstream/core/reducer/base.py
@@ -249,7 +249,23 @@ class BaseStreamingGlobalReducer(nn.Module, ABC):
         if self._debug_replay_enabled:
             if self._replay_assignments is None:
                 raise RuntimeError("Reducer replay assignments are not initialized.")
-            self._replay_assignments.append((int(tile_y), int(tile_x), bool(sides.top), bool(sides.left), bool(sides.right), bool(sides.bottom), int(tile_payload.shape[-2]), int(tile_payload.shape[-1]), int(dst_y0), int(dst_y1), int(dst_x0), int(dst_x1)))
+            self._replay_assignments.append(
+                (
+                    int(tile_y),
+                    int(tile_x),
+                    bool(sides.top),
+                    bool(sides.left),
+                    bool(sides.right),
+                    bool(sides.bottom),
+                    int(tile_payload.shape[-2]),
+                    int(tile_payload.shape[-1]),
+                    int(dst_y0),
+                    int(dst_y1),
+                    int(dst_x0),
+                    int(dst_x1),
+                    1,
+                )
+            )
         if torch.any(effective_mask):
             self.accumulate_valid_tile(tile_payload, valid_mask=effective_mask)
         seen_slice |= new_mask
@@ -295,7 +311,16 @@ class BaseStreamingGlobalReducer(nn.Module, ABC):
         if self._debug_replay_enabled:
             if self._replay_assignments is None or self._replay_cursor is None:
                 raise RuntimeError("Reducer replay state is not initialized. Call start_backward_replay() first.")
-            self._replay_cursor = self._validate_replay_assignment(assignments=self._replay_assignments, cursor=self._replay_cursor, input_y=input_y, input_x=input_x, sides=sides, expected_h=expected_h, expected_w=expected_w)
+            self._replay_cursor = self._validate_replay_assignment(
+                assignments=self._replay_assignments,
+                cursor=self._replay_cursor,
+                input_y=input_y,
+                input_x=input_x,
+                sides=sides,
+                expected_h=expected_h,
+                expected_w=expected_w,
+                expected_arity=1,
+            )
         global_context = self.extra_state_for_backward()
         reduced_output = self.reduce_tile_for_backward(tile_payload, valid_mask=valid_mask, global_context=global_context)
         return reduced_output, gradient
@@ -326,17 +351,30 @@ class BaseStreamingGlobalReducer(nn.Module, ABC):
         """Optional global state to feed `reduce_tile_for_backward`."""
         return {}
 
-    def _validate_replay_assignment(self, *, assignments: list[tuple], cursor: int, input_y: int, input_x: int, sides, expected_h: int, expected_w: int) -> int:
+    def _validate_replay_assignment(
+        self,
+        *,
+        assignments: list[tuple],
+        cursor: int,
+        input_y: int,
+        input_x: int,
+        sides,
+        expected_h: int,
+        expected_w: int,
+        expected_arity: int,
+    ) -> int:
         """Check backward tile metadata against recorded forward metadata."""
         if cursor >= len(assignments):
             raise RuntimeError("Reducer assignment cursor out of range.")
-        (f_tile_y, f_tile_x, f_top, f_left, f_right, f_bottom, f_h, f_w, dst_y0, dst_y1, dst_x0, dst_x1) = assignments[cursor]
+        (f_tile_y, f_tile_x, f_top, f_left, f_right, f_bottom, f_h, f_w, dst_y0, dst_y1, dst_x0, dst_x1, f_arity) = assignments[cursor]
         if (int(input_y) != int(f_tile_y) or int(input_x) != int(f_tile_x) or bool(sides.top) != bool(f_top) or bool(sides.left) != bool(f_left) or bool(sides.right) != bool(f_right) or bool(sides.bottom) != bool(f_bottom)):
             raise RuntimeError("Reducer tile replay mismatch: " f"forward tile=({f_tile_y},{f_tile_x},{f_top},{f_left},{f_right},{f_bottom}) " f"backward tile=({int(input_y)},{int(input_x)},{bool(sides.top)},{bool(sides.left)},{bool(sides.right)},{bool(sides.bottom)})")
         if expected_h != int(f_h) or expected_w != int(f_w):
             raise RuntimeError("Reducer trimmed shape mismatch: " f"forward=({f_h},{f_w}) backward=({expected_h},{expected_w})")
         if (dst_y1 - dst_y0) != expected_h or (dst_x1 - dst_x0) != expected_w:
             raise RuntimeError("Reducer assignment mismatch: " f"stored=({dst_y0}:{dst_y1},{dst_x0}:{dst_x1}) current=({expected_h},{expected_w})")
+        if int(f_arity) != int(expected_arity):
+            raise RuntimeError(f"Reducer input arity mismatch: forward={int(f_arity)} backward={int(expected_arity)}")
         return cursor + 1
 
     def forward(self, *inputs: torch.Tensor, mask: torch.Tensor | None = None) -> torch.Tensor:

--- a/tests/test_streaming_reducer.py
+++ b/tests/test_streaming_reducer.py
@@ -2,7 +2,14 @@ import torch
 import torch.nn as nn
 
 from lightstream.core.constructor import StreamingConstructor
-from lightstream.core.reducer import MeanReducer, StreamingMeanReducer, StreamingSumReducer, SumReducer
+from lightstream.core.reducer import (
+    AttentionGeMReducer,
+    MeanReducer,
+    StreamingAttentionGeMReducer,
+    StreamingMeanReducer,
+    StreamingSumReducer,
+    SumReducer,
+)
 
 
 class MixedReducerNet(nn.Module):
@@ -233,3 +240,45 @@ def test_streaming_gem_fp16_stability_accumulator_fp32():
     assert reducer.running_count.dtype == torch.float32
     assert y.dtype == torch.float16
     assert torch.isfinite(y).all()
+
+
+class AttentionGeMHeadNet(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.backbone = nn.Sequential(nn.Conv2d(3, 4, kernel_size=3, padding=1, bias=False), nn.ReLU())
+        self.feat_head = nn.Conv2d(4, 3, kernel_size=1, bias=False)
+        self.logit_head = nn.Conv2d(4, 1, kernel_size=1, bias=False)
+        self.reducer = AttentionGeMReducer(r_init=2.7, eps=1e-6)
+
+    def forward(self, x):
+        feat = self.backbone(x)
+        return self.reducer(self.feat_head(feat), self.logit_head(feat))
+
+
+def test_streaming_attention_gem_backward_parity_x_and_logits():
+    torch.manual_seed(13)
+    model = AttentionGeMHeadNet().eval()
+    reference = AttentionGeMHeadNet().eval()
+    reference.load_state_dict(model.state_dict())
+
+    image = (torch.rand(1, 3, 9, 11) + 0.05).requires_grad_(True)
+    ref_image = image.detach().clone().requires_grad_(True)
+    grad_out = torch.full((1, 3, 1, 1), 0.41, dtype=image.dtype)
+
+    ref_out = reference(ref_image)
+    torch.autograd.backward(ref_out, grad_out)
+
+    scnn = _make_streaming(model, tile_size=4)
+    scnn.debug_reducer_replay = True
+    assert isinstance(scnn.stream_module.reducer, StreamingAttentionGeMReducer)
+    stream_out = scnn.forward(image.detach().clone())
+    assert torch.allclose(stream_out, ref_out.detach(), atol=1e-5, rtol=1e-4)
+    scnn.backward(image.detach().clone(), grad_out.detach().clone())
+
+    stream_grads = {name: p.grad for name, p in scnn.stream_module.named_parameters() if p.grad is not None}
+    ref_grads = {name: p.grad for name, p in reference.named_parameters() if p.grad is not None}
+
+    for name in ("feat_head.weight", "logit_head.weight"):
+        assert name in stream_grads
+        assert name in ref_grads
+        assert torch.allclose(stream_grads[name], ref_grads[name], atol=2e-5, rtol=2e-4), name


### PR DESCRIPTION
### Motivation
- Ensure replay bookkeeping remains correct when reducers consume structured per-tile payloads (tuples) rather than a single tensor.  
- Prevent silent arity/tuple-order drift between forward sampling and backward replay that could produce incorrect backward pairs.  
- Add explicit regression coverage for `AttentionGeM` to verify gradients flow through both `x` and logits branches and match the non-streaming reference.

### Description
- Extend recorded replay metadata to include per-tile input arity by appending an arity field to the replay tuple in `lightstream/core/reducer/base.py` and `lightstream/core/reducer/attention_gem.py`.  
- Add an `expected_arity` parameter to `_validate_replay_assignment` in `lightstream/core/reducer/base.py` and raise a `RuntimeError` when forward/backward arity mismatches are detected.  
- Wire the new arity check into `build_backward_pair` and `accumulate_stream_tile` call sites so backward replay enforces the same ordered input tuple used during forward sampling.  
- Update `StreamingAttentionGeMReducer` to record `len(payload)` per tile and validate that the replayed payload matches that arity.  
- Add `test_streaming_attention_gem_backward_parity_x_and_logits` in `tests/test_streaming_reducer.py` which converts an `AttentionGeM` head to streaming, runs forward/backward, and asserts parameter gradients for both the feature head and logits head match the non-streaming reference within tolerances.

### Testing
- Added a regression unit test `test_streaming_attention_gem_backward_parity_x_and_logits` in `tests/test_streaming_reducer.py` (not executed in this environment).  
- Attempted to run the two targeted tests via `pytest -q tests/test_streaming_reducer.py::test_streaming_attention_gem_backward_parity_x_and_logits tests/test_scnn.py::test_scnn_backward_reducer_replay_consumed_debug_mode`, but test collection failed with `ModuleNotFoundError: No module named 'lightning'` due to a missing optional dependency, so the tests could not be executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1426ec8c448330b0a12e9c125c6106)