### PR TITLE
Preserve logits graph connectivity in AttentionGeM passthrough

### DIFF
--- a/lightstream/core/reducer/attention_gem.py
+++ b/lightstream/core/reducer/attention_gem.py
@@ -53,7 +53,8 @@ class AttentionGeMReducer(BaseReducer):
             raise ValueError(f"Reducer expects NCHW x tensor, got shape={tuple(x.shape)}")
         logits = _normalize_logits(attn_logits, x)
         if self._streaming_passthrough:
-            return x
+            zero_from_logits = logits.to(dtype=x.dtype).sum(dim=(-2, -1), keepdim=True) * 0.0
+            return x + zero_from_logits
 
         acc_dtype = resolve_accumulator_dtype(self.accumulator_dtype, x.dtype)
         x_acc = x.to(dtype=acc_dtype)


### PR DESCRIPTION
### Motivation
- Ensure autograd connectivity for multi-input reducers so `attn_logits` remains part of the gradient graph during SCNN stats collection instead of being dropped by the passthrough path.

### Description
- Change `AttentionGeMReducer.forward()` passthrough path to return a numerically-identical tensor while keeping `attn_logits` connected by computing `zero_from_logits = logits.to(dtype=x.dtype).sum(dim=(-2, -1), keepdim=True) * 0.0` and returning `x + zero_from_logits`.
- Use shape-safe spatial reduction and explicit `dtype`/device alignment to preserve broadcasting safety and tensor types.
- Leave non-passthrough reduction logic unchanged.

### Testing
- `python -m py_compile lightstream/core/reducer/attention_gem.py` succeeded.
- `pytest -q tests/test_streaming_reducer.py` failed during collection due to missing optional environment dependencies (`lightning`, `numpy`), so full test runs could not complete.
- A small automated gradient connectivity check was attempted but also failed during import for the same missing dependencies.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1758d10d408330bf72375f804002e3)