### PR TITLE
Handle all-zero gradients during backward stats gathering

### DIFF
--- a/lightstream/core/reducer/attention_gem.py
+++ b/lightstream/core/reducer/attention_gem.py
@@ -53,7 +53,8 @@ class AttentionGeMReducer(BaseReducer):
             raise ValueError(f"Reducer expects NCHW x tensor, got shape={tuple(x.shape)}")
         logits = _normalize_logits(attn_logits, x)
         if self._streaming_passthrough:
-            return x
+            zero_from_logits = logits.to(dtype=x.dtype).sum(dim=(-2, -1), keepdim=True) * 0.0
+            return x + zero_from_logits
 
         acc_dtype = resolve_accumulator_dtype(self.accumulator_dtype, x.dtype)
         x_acc = x.to(dtype=acc_dtype)

--- a/lightstream/core/scnn/scnn.py
+++ b/lightstream/core/scnn/scnn.py
@@ -1465,6 +1465,11 @@ class StreamingCNN(torch.nn.Module):
                 f_grad = torch.from_numpy(grad)
                 f_grad = f_grad.to(self.device)
 
+            if grad_out[0].numel() == 0 or torch.count_nonzero(grad_out[0]) == 0:
+                # Some connected branches (e.g. zero-scaled passthrough links for graph connectivity)
+                # produce valid but all-zero gradients during stats gathering; skip border inference.
+                return grad_in
+
             grad_lost = self._non_max_border_amount(grad_out[0])
 
             if self.verbose:


### PR DESCRIPTION
## Summary
- Guard SCNN backward statistics hook against all-zero gradients that can arise from intentionally zero-scaled graph-connectivity links.
- Prevents `IndexError` in `_non_max_border_amount()` when `nonzero()` is empty.

## Details
- In `lightstream/core/scnn/scnn.py` (`_backward_gather_statistics_hook`), add an early return when `grad_out[0]` has no nonzero entries (or empty tensor):
  - `if grad_out[0].numel() == 0 or torch.count_nonzero(grad_out[0]) == 0: return grad_in`
- This preserves existing behavior for normal nonzero gradients while skipping invalid border inference on degenerate zero-gradient branches.

## Validation
- `python -m py_compile lightstream/core/scnn/scnn.py lightstream/core/reducer/attention_gem.py` passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1758d10d408330bf72375f804002e3)