### PR TITLE
Infer SCNN stats via gradient-carrying passthrough surrogate

### DIFF
--- a/lightstream/core/reducer/attention_gem.py
+++ b/lightstream/core/reducer/attention_gem.py
@@ -53,7 +53,9 @@ class AttentionGeMReducer(BaseReducer):
             raise ValueError(f"Reducer expects NCHW x tensor, got shape={tuple(x.shape)}")
         logits = _normalize_logits(attn_logits, x)
         if self._streaming_passthrough:
-            return x
+            logits_term = logits.to(dtype=x.dtype).sum(dim=(-2, -1), keepdim=True)
+            graph_passthrough = logits_term - logits_term.detach()
+            return x + graph_passthrough
 
         acc_dtype = resolve_accumulator_dtype(self.accumulator_dtype, x.dtype)
         x_acc = x.to(dtype=acc_dtype)


### PR DESCRIPTION
## Summary
- Replace zero-gradient passthrough link in `AttentionGeMReducer` with a zero-valued but gradient-carrying surrogate so SCNN backward stats can infer both branches naturally.
- Remove the SCNN backward-hook skip/manual fallback that masked inference issues.

## Changes
1. `lightstream/core/reducer/attention_gem.py`
- In `_streaming_passthrough` mode, replace:
  - `x + 0 * logits_term`
- With:
  - `logits_term = logits.to(dtype=x.dtype).sum(dim=(-2, -1), keepdim=True)`
  - `graph_passthrough = logits_term - logits_term.detach()`
  - `return x + graph_passthrough`

This keeps forward output exactly equal to `x`, while allowing nonzero gradient flow through the logits path.

2. `lightstream/core/scnn/scnn.py`
- Remove prior all-zero `grad_out` early-return/manual `Lost(0,0,0,0)` assignment in `_backward_gather_statistics_hook`.
- Stats inference now relies on real traversed gradients rather than a manual fallback.

## Rationale
- The previous `0 * logits_term` preserved graph connectivity but forced zero gradients, preventing true branch-wise inference in stats collection.
- The detach-surrogate preserves exact passthrough numerics and restores inferability for backward statistics.

## Validation
- `python -m py_compile lightstream/core/reducer/attention_gem.py lightstream/core/scnn/scnn.py` passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1758d10d408330bf72375f804002e3)