### PR TITLE
Fix AttentionGeM passthrough output arity for streaming tile stitching

### DIFF
--- a/lightstream/core/reducer/attention_gem.py
+++ b/lightstream/core/reducer/attention_gem.py
@@ -45,7 +45,7 @@ class AttentionGeMReducer(BaseReducer):
     def current_r(self) -> torch.Tensor:
         return self.r
 
-    def forward(self, *inputs: torch.Tensor, mask: torch.Tensor | None = None) -> torch.Tensor:
+    def forward(self, *inputs: torch.Tensor, mask: torch.Tensor | None = None) -> torch.Tensor | tuple[torch.Tensor, torch.Tensor]:
         if len(inputs) != 2:
             raise ValueError(f"AttentionGeMReducer expects exactly two inputs (x, attn_logits), got {len(inputs)}.")
         x, attn_logits = inputs
@@ -53,7 +53,10 @@ class AttentionGeMReducer(BaseReducer):
             raise ValueError(f"Reducer expects NCHW x tensor, got shape={tuple(x.shape)}")
         logits = _normalize_logits(attn_logits, x)
         if self._streaming_passthrough:
-            return x
+            logits_term = logits.to(dtype=x.dtype).sum(dim=(-2, -1), keepdim=True)
+            graph_passthrough = logits_term - logits_term.detach()
+            x_passthrough = x + graph_passthrough
+            return x_passthrough, logits
 
         acc_dtype = resolve_accumulator_dtype(self.accumulator_dtype, x.dtype)
         x_acc = x.to(dtype=acc_dtype)
@@ -111,6 +114,7 @@ class StreamingAttentionGeMReducer(BaseStreamingGlobalReducer):
         if len(inputs) != 2:
             raise ValueError(f"StreamingAttentionGeMReducer expects exactly two inputs (x_tile, logits_tile), got {len(inputs)}.")
         x_tile, logits_tile = inputs
+        self._last_inputs = (x_tile, logits_tile)
         self._last_output = x_tile
         return x_tile, logits_tile
 


### PR DESCRIPTION
## Summary
- Fix `IndexError: list index out of range` during forward tile stitching by aligning passthrough output structure with streaming multi-input reducer expectations.

## Root cause
- SCNN forward stitching builds reducer payloads from flattened tile outputs and indexes per-head lost stats (`_tile_output_lost`).
- `StreamingAttentionGeMReducer` expects 2 inputs (`x_tile`, `logits_tile`), but offline passthrough stats were collected with a single tensor output shape contract.
- This created inconsistent head indexing/arity during stitching and caused out-of-range access when retrieving per-head loss metadata.

## Change
- In `AttentionGeMReducer.forward()` passthrough mode (`_streaming_passthrough=True`):
  - keep the gradient-carrying surrogate for `x` (`x + (logits_term - logits_term.detach())`)
  - return a structured 2-tensor payload `(x_passthrough, logits)` instead of only `x`
- Update forward return annotation accordingly.

## Effect
- Forward statistics and runtime tile flattening now use a consistent 2-input reducer payload shape for this multi-input reducer.
- Streaming stitcher can build reducer payloads and per-head metadata without index mismatch.

## Validation
- `python -m py_compile lightstream/core/reducer/attention_gem.py` passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1758d10d408330bf72375f804002e3)