### PR TITLE
Restore single public output spec after reducer passthrough stats collection

### DIFF
--- a/lightstream/core/reducer/attention_gem.py
+++ b/lightstream/core/reducer/attention_gem.py
@@ -45,7 +45,7 @@ class AttentionGeMReducer(BaseReducer):
     def current_r(self) -> torch.Tensor:
         return self.r
 
-    def forward(self, *inputs: torch.Tensor, mask: torch.Tensor | None = None) -> torch.Tensor:
+    def forward(self, *inputs: torch.Tensor, mask: torch.Tensor | None = None) -> torch.Tensor | tuple[torch.Tensor, torch.Tensor]:
         if len(inputs) != 2:
             raise ValueError(f"AttentionGeMReducer expects exactly two inputs (x, attn_logits), got {len(inputs)}.")
         x, attn_logits = inputs
@@ -53,7 +53,10 @@ class AttentionGeMReducer(BaseReducer):
             raise ValueError(f"Reducer expects NCHW x tensor, got shape={tuple(x.shape)}")
         logits = _normalize_logits(attn_logits, x)
         if self._streaming_passthrough:
-            return x
+            logits_term = logits.to(dtype=x.dtype).sum(dim=(-2, -1), keepdim=True)
+            graph_passthrough = logits_term - logits_term.detach()
+            x_passthrough = x + graph_passthrough
+            return x_passthrough, logits
 
         acc_dtype = resolve_accumulator_dtype(self.accumulator_dtype, x.dtype)
         x_acc = x.to(dtype=acc_dtype)
@@ -111,6 +114,7 @@ class StreamingAttentionGeMReducer(BaseStreamingGlobalReducer):
         if len(inputs) != 2:
             raise ValueError(f"StreamingAttentionGeMReducer expects exactly two inputs (x_tile, logits_tile), got {len(inputs)}.")
         x_tile, logits_tile = inputs
+        self._last_inputs = (x_tile, logits_tile)
         self._last_output = x_tile
         return x_tile, logits_tile
 

--- a/lightstream/core/scnn/scnn.py
+++ b/lightstream/core/scnn/scnn.py
@@ -210,6 +210,7 @@ class StreamingCNN(torch.nn.Module):
         self._set_reducer_passthrough(False)
         #
         self._restore_parameters(state_dict)
+        self._capture_public_output_spec(tile.detach())
         self._streaming_reducers = []
         self.stream_module = self._convert_modules_for_streaming(self.stream_module)
         self._add_hooks_for_streaming()
@@ -225,6 +226,13 @@ class StreamingCNN(torch.nn.Module):
 
         self._set_cudnn_flags(old_deterministic_flag, old_benchmark_flag)
         del state_dict
+
+    def _capture_public_output_spec(self, tile: torch.Tensor) -> None:
+        """Capture user-facing output structure with reducers in normal (non-passthrough) mode."""
+        with torch.no_grad():
+            output = self.stream_module(tile)
+        _, output_spec = self._flatten_output_structure(output)
+        self._output_spec = output_spec
 
     def _set_reducer_passthrough(self, enabled: bool):
         for mod in self.stream_module.modules():
@@ -801,7 +809,15 @@ class StreamingCNN(torch.nn.Module):
         )
 
     def _stitch_forward_outputs(self, outputs, tile_outputs, tile_input_y, tile_input_x, sides, user_mask):
+        reducer_aux_indices = {
+            idx
+            for reducer_head, indices in self._reducer_input_indices.items()
+            for idx in indices[1:]
+            if reducer_head in self._reducer_head_map
+        }
         for head_idx, head_output in enumerate(tile_outputs):
+            if head_idx in reducer_aux_indices:
+                continue
             _, output_loc, trimmed_output = self._build_stitched_tile_output(
                 head_idx=head_idx,
                 head_output=head_output,


### PR DESCRIPTION
## Summary
- Fix remaining issue where streaming still returned two outputs after multi-input reducer passthrough changes.

## Root cause
- During `_configure`, reducer passthrough mode is enabled to collect tile statistics.
- In passthrough mode, `AttentionGeMReducer` intentionally returns a structured payload `(x_passthrough, logits)` for internal multi-input reducer mapping.
- `_output_spec` was being captured from this passthrough-mode forward, so final output reconstruction followed tuple shape instead of the normal user-facing reducer output.

## Change
- Add `_capture_public_output_spec(tile)` in `lightstream/core/scnn/scnn.py`.
- After restoring model parameters and disabling passthrough, run one no-grad forward and set `_output_spec` from normal (non-passthrough) output structure.
- This preserves internal passthrough behavior for stats while restoring correct external output contract.

## Effect
- Streaming output reconstruction uses the intended public output spec (single reduced prediction for AttentionGeM), not internal reducer transport payload structure.

## Validation
- `python -m py_compile lightstream/core/scnn/scnn.py` passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1758d10d408330bf72375f804002e3)