### PR TITLE
Map public gradients to internal SCNN heads

### DIFF
--- a/lightstream/core/scnn/scnn.py
+++ b/lightstream/core/scnn/scnn.py
@@ -973,7 +973,9 @@ class StreamingCNN(torch.nn.Module):
 
         trimmed_outputs = []
         trimmed_grads = []
-        for head_idx, head_grad in zip(self._public_output_indices(), backward_ctx.grad_tensors):
+        for head_idx, head_grad in enumerate(backward_ctx.grad_tensors):
+            if head_grad is None:
+                continue
             paired_output, paired_grad = self._build_head_backward_pair(
                 head_idx=head_idx,
                 head_output=tile_outputs[head_idx],
@@ -1144,8 +1146,19 @@ class StreamingCNN(torch.nn.Module):
         if grad_spec != self._output_spec:
             raise ValueError("Gradient output structure does not match streaming output structure")
 
+        public_indices = self._public_output_indices()
+        if len(grad_tensors) != len(public_indices):
+            raise ValueError(
+                f"Gradient tensor count mismatch: expected={len(public_indices)}, "
+                f"actual={len(grad_tensors)}, public_indices={public_indices}"
+            )
+
+        internal_grad_tensors = [None] * len(self._tile_output_shapes)
+        for public_grad, internal_idx in zip(grad_tensors, public_indices):
+            internal_grad_tensors[internal_idx] = public_grad
+
         if len(self._tile_output_shapes) == 1:
-            tile_iter = self._prepare_backward_tile_iter_single_head(image, grad_tensors, tile_height, tile_width)
+            tile_iter = self._prepare_backward_tile_iter_single_head(image, internal_grad_tensors, tile_height, tile_width)
         else:
             tile_iter = self._prepare_backward_tile_iter_multi_head(
                 image=image,
@@ -1161,7 +1174,7 @@ class StreamingCNN(torch.nn.Module):
 
         backward_ctx = BackwardContext(
             image=image,
-            grad_tensors=grad_tensors,
+            grad_tensors=internal_grad_tensors,
             tile_height=tile_height,
             tile_width=tile_width,
             output_heights=output_heights,


### PR DESCRIPTION
### Motivation
- Reducer heads (e.g. `AttentionGeM`) expose auxiliary internal payloads that are not part of the public flattened output, so backward must map user-facing gradients into the internal per-head index space to replay tiles correctly.
- Validate the number of provided public gradients against the captured public indices to catch mismatches early.

### Description
- Added resolution of `public_indices = self._public_output_indices()` in `StreamingCNN.backward()` and validate `len(grad_tensors) == len(public_indices)`.
- Constructed `internal_grad_tensors = [None] * len(self._tile_output_shapes)` and populated it by mapping each `public_grad` into its corresponding internal index via `for public_grad, internal_idx in zip(grad_tensors, public_indices): internal_grad_tensors[internal_idx] = public_grad`.
- Stored `internal_grad_tensors` in the `BackwardContext` (`grad_tensors` field) so reducer-aux slots remain `None` while public gradients are placed at the correct internal heads.
- Updated backward tile replay (`_run_backward_tile`) to iterate `for head_idx, head_grad in enumerate(backward_ctx.grad_tensors):` and `continue` on `None` entries so only mapped heads participate in `torch.autograd.backward`.
- This maps `AttentionGeM` public gradients to internals as: public 0→internal 0, public 1→internal 2, public 2→internal 4, public 3→internal 6, while `MeanReducer` public indices remain `[0,1,2,3]` and are unchanged.

### Testing
- Ran `python -m py_compile lightstream/core/scnn/scnn.py` which succeeded without syntax errors.
- Attempted to run a targeted `pytest` selection covering reducer/backward parity tests, but test collection failed due to a missing environment dependency (`ModuleNotFoundError: No module named 'lightning'`), so the unit tests could not complete in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a197b3161408330b424f5aaeda1b5e5)