### PR TITLE
Fix StreamingCNN backward tile head iteration

### DIFF
--- a/lightstream/core/scnn/scnn.py
+++ b/lightstream/core/scnn/scnn.py
@@ -973,12 +973,13 @@ class StreamingCNN(torch.nn.Module):
 
         trimmed_outputs = []
         trimmed_grads = []
-        for head_idx, head_grad in enumerate(backward_ctx.grad_tensors):
+        for idx, head_output in enumerate(tile_outputs):
+            head_grad = backward_ctx.grad_tensors[idx]
             if head_grad is None:
                 continue
             paired_output, paired_grad = self._build_head_backward_pair(
-                head_idx=head_idx,
-                head_output=tile_outputs[head_idx],
+                head_idx=idx,
+                head_output=head_output,
                 tile_outputs=tile_outputs,
                 head_grad=head_grad,
                 tile_input_y=input_y,


### PR DESCRIPTION
### Motivation
- Ensure `_run_backward_tile()` iterates over internal `tile_outputs` by index so reducer heads can still access auxiliary inputs and gradients pair correctly with their respective outputs.

### Description
- Replace the previous `zip` loop with `for idx, head_output in enumerate(tile_outputs):`, fetch `head_grad = backward_ctx.grad_tensors[idx]`, skip when `head_grad is None`, and call `_build_head_backward_pair()` while continuing to pass the full `tile_outputs` list.

### Testing
- Ran `python -m py_compile lightstream/core/scnn/scnn.py`, which succeeded.
- Attempted targeted `pytest` runs for reducer/backward tests but they could not complete due to a missing `lightning` dependency in the environment, so pytest did not fully execute.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a197dfc633483308e269a0e1943298f)