### PR TITLE
Add sanity checks for StreamingCNN.forward public outputs

### DIFF
--- a/lightstream/core/scnn/scnn.py
+++ b/lightstream/core/scnn/scnn.py
@@ -136,6 +136,7 @@ class StreamingCNN(torch.nn.Module):
         self._module_stats = {}
         self._saved_tensors = {}
         self.debug_reducer_replay = False
+        self.debug_forward_sentinel_check = False
         self._hooks = []
         self._last_forward_tiles = []
         self._streaming_reducers = []
@@ -357,6 +358,38 @@ class StreamingCNN(torch.nn.Module):
             for idx in range(len(self._tile_output_shapes))
             if idx not in reducer_aux_indices
         ]
+
+    def _public_output_debug_context(self, public_indices, reducer_aux_indices=None) -> str:
+        if reducer_aux_indices is None:
+            reducer_aux_indices = self._reducer_aux_indices()
+        return (
+            f"public_indices={list(public_indices)}, "
+            f"reducer_auxiliary_indices={sorted(reducer_aux_indices)}, "
+            f"self._reducer_input_indices={self._reducer_input_indices}"
+        )
+
+    def _validate_public_output_indices(self, public_indices) -> None:
+        reducer_aux_indices = self._reducer_aux_indices()
+        leaked_aux_indices = sorted(set(public_indices) & reducer_aux_indices)
+        if leaked_aux_indices:
+            raise RuntimeError(
+                "Public output indices include reducer auxiliary indices; "
+                f"leaked_auxiliary_indices={leaked_aux_indices}; "
+                f"{self._public_output_debug_context(public_indices, reducer_aux_indices)}"
+            )
+
+    def _validate_public_forward_outputs(self, outputs, public_indices) -> None:
+        context = self._public_output_debug_context(public_indices)
+        for idx in public_indices:
+            output = outputs[idx]
+            if output is None:
+                raise RuntimeError(
+                    f"Public output head {idx} was not populated during streaming forward; {context}"
+                )
+            if getattr(self, "debug_forward_sentinel_check", False) and torch.all(output == 999):
+                raise RuntimeError(
+                    f"Public output head {idx} still contains only the unstitched sentinel value 999; {context}"
+                )
 
     def _count_tensors_in_spec(self, spec) -> int:
         kind, payload = spec
@@ -1106,16 +1139,15 @@ class StreamingCNN(torch.nn.Module):
             outputs[idx] = reducer.finish_stream().to(result_device)
 
         public_indices = self._public_output_indices()
+        self._validate_public_output_indices(public_indices)
         expected_flat_outputs = self._count_tensors_in_spec(self._output_spec)
         if len(public_indices) != expected_flat_outputs:
             raise RuntimeError(
                 f"Public output index count mismatch: expected={expected_flat_outputs}, "
-                f"actual={len(public_indices)}, indices={public_indices}"
+                f"actual={len(public_indices)}; {self._public_output_debug_context(public_indices)}"
             )
+        self._validate_public_forward_outputs(outputs, public_indices)
         materialized_outputs = [outputs[idx] for idx in public_indices]
-        for idx, output in zip(public_indices, materialized_outputs):
-            if output is None:
-                raise RuntimeError(f"Output head {idx} was not populated during streaming forward.")
 
         output, final_idx = self._unflatten_output_structure(materialized_outputs, self._output_spec)
         assert final_idx == len(materialized_outputs)

--- a/tests/test_streaming_reducer.py
+++ b/tests/test_streaming_reducer.py
@@ -325,6 +325,55 @@ def test_prepare_forward_outputs_skips_reducer_aux_payloads():
     assert outputs[2] is existing_output
 
 
+def test_public_output_index_validation_rejects_reducer_aux_leak():
+    scnn = StreamingCNN.__new__(StreamingCNN)
+    scnn._reducer_head_map = {0: object()}
+    scnn._reducer_input_indices = {0: (0, 1)}
+
+    with pytest.raises(RuntimeError) as exc_info:
+        scnn._validate_public_output_indices([0, 1])
+
+    message = str(exc_info.value)
+    assert "public_indices=[0, 1]" in message
+    assert "reducer_auxiliary_indices=[1]" in message
+    assert "self._reducer_input_indices={0: (0, 1)}" in message
+
+
+def test_public_forward_output_validation_reports_none_with_reducer_context():
+    scnn = StreamingCNN.__new__(StreamingCNN)
+    scnn._reducer_head_map = {0: object()}
+    scnn._reducer_input_indices = {0: (0, 1)}
+    outputs = [torch.ones((1, 1, 1, 1)), None]
+
+    with pytest.raises(RuntimeError) as exc_info:
+        scnn._validate_public_forward_outputs(outputs, [0, 1])
+
+    message = str(exc_info.value)
+    assert "Public output head 1 was not populated" in message
+    assert "public_indices=[0, 1]" in message
+    assert "reducer_auxiliary_indices=[1]" in message
+    assert "self._reducer_input_indices={0: (0, 1)}" in message
+
+
+def test_public_forward_output_sentinel_check_is_debug_only():
+    scnn = StreamingCNN.__new__(StreamingCNN)
+    scnn._reducer_head_map = {}
+    scnn._reducer_input_indices = {}
+    outputs = [torch.full((1, 1, 1, 1), 999.0)]
+
+    scnn._validate_public_forward_outputs(outputs, [0])
+
+    scnn.debug_forward_sentinel_check = True
+    with pytest.raises(RuntimeError) as exc_info:
+        scnn._validate_public_forward_outputs(outputs, [0])
+
+    message = str(exc_info.value)
+    assert "unstitched sentinel value 999" in message
+    assert "public_indices=[0]" in message
+    assert "reducer_auxiliary_indices=[]" in message
+    assert "self._reducer_input_indices={}" in message
+
+
 def test_streaming_attention_gem_backward_parity_x_and_logits():
     torch.manual_seed(13)
     model = AttentionGeMHeadNet().eval()


### PR DESCRIPTION
### Motivation
- Prevent subtle multi-input reducer bugs by validating the mapping between flattened tile outputs and public outputs after forward streaming.
- Make failures actionable by including reducer diagnostics (public indices, reducer auxiliary indices, and reducer input indices) in error messages.
- Avoid false positives from sentinel values by keeping full-`999` detection off by default and opt-in for debug/runtime checks.

### Description
- Add an opt-in `debug_forward_sentinel_check` flag to `StreamingCNN` to enable detection of full-`999` sentinel tensors only when explicitly enabled.
- Add `_public_output_debug_context`, `_validate_public_output_indices`, and `_validate_public_forward_outputs` helpers that build diagnostic context and assert that public indices do not include reducer auxiliary indices and that each public output is populated (and optionally not a full-`999` sentinel).
- Wire the validations into `StreamingCNN.forward()` immediately after computing `public_indices`, before materializing/unflattening outputs, and include diagnostic details in raised `RuntimeError`s.
- Add unit tests in `tests/test_streaming_reducer.py` to cover auxiliary-index leakage, missing public outputs, and the debug-only sentinel assertion.

### Testing
- Ran `python -m compileall -q lightstream/core/scnn/scnn.py tests/test_streaming_reducer.py`, which succeeded.
- Ran basic repository checks (`git diff --check`) with no issues reported.
- Ran `pytest -q tests/test_streaming_reducer.py`, which failed during test collection due to a missing external dependency (`ModuleNotFoundError: No module named 'lightning'`), so the new tests were not executed end-to-end in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a197ecb185883309239c21272de138a)