### PR TITLE
Add WSS AttentionGeM streaming output test and allow random weights for StreamingWSS

### DIFF
--- a/lightstream/models/segment/streamingwss.py
+++ b/lightstream/models/segment/streamingwss.py
@@ -17,6 +17,7 @@ class StreamingWSS(StreamingModule):
         tile_size: int,
         additional_modules: nn.Module | None = None,
         remove_last_block=True,
+        weights: str | None = "default",
         verbose: bool = True,
         deterministic: bool = True,
         saliency: bool = False,
@@ -37,7 +38,7 @@ class StreamingWSS(StreamingModule):
             stream_network = Sequential(
                 WSS(
                     encoder=encoder,
-                    weights="default",
+                    weights=weights,
                     remove_last_block=remove_last_block,
                     reducer_accumulator_dtype=reducer_accumulator_dtype,
                 ),
@@ -46,7 +47,7 @@ class StreamingWSS(StreamingModule):
         else:
             stream_network = WSS(
                 encoder=encoder,
-                weights="default",
+                weights=weights,
                 remove_last_block=remove_last_block,
                 reducer_accumulator_dtype=reducer_accumulator_dtype,
             )

--- a/tests/test_streaming_reducer.py
+++ b/tests/test_streaming_reducer.py
@@ -4,6 +4,8 @@ import pytest
 
 from lightstream.core.constructor import StreamingConstructor
 from lightstream.core.scnn.scnn import StreamingCNN
+from lightstream.models.segment.streamingwss import StreamingWSS
+
 from lightstream.core.reducer import (
     AttentionGeMReducer,
     MeanReducer,
@@ -372,6 +374,52 @@ def test_public_forward_output_sentinel_check_is_debug_only():
     assert "public_indices=[0]" in message
     assert "reducer_auxiliary_indices=[]" in message
     assert "self._reducer_input_indices={}" in message
+
+
+def test_streaming_wss_attention_gem_public_outputs_skip_aux_maps(tmp_path):
+    torch.manual_seed(17)
+    image = torch.rand(1, 3, 80, 80)
+    network = StreamingWSS(
+        "resnet18",
+        tile_size=64,
+        weights=None,
+        verbose=False,
+        deterministic=True,
+        copy_to_gpu=False,
+        statistics_on_cpu=False,
+        normalize_on_gpu=False,
+        mean=[0, 0, 0],
+        std=[1, 1, 1],
+        tile_cache_path=tmp_path / "resnet18_wss_attention_gem_tile_cache",
+    ).eval()
+    scnn = network.stream_network
+    scnn.debug_forward_sentinel_check = True
+
+    with torch.no_grad():
+        streamed = network(image)
+        public_indices = scnn._public_output_indices()
+        auxiliary_indices = scnn._reducer_aux_indices()
+
+        scnn.disable()
+        expected = scnn.stream_module(image)
+
+    assert isinstance(streamed, tuple)
+    assert len(streamed) == 4
+    assert len(public_indices) == 4
+    assert set(public_indices).isdisjoint(auxiliary_indices)
+    assert sorted(auxiliary_indices) == [1, 3, 5]
+
+    for streamed_reduced, expected_reduced in zip(streamed[:3], expected[:3]):
+        assert streamed_reduced.shape == expected_reduced.shape
+        assert list(streamed_reduced.shape) == [image.shape[0], expected_reduced.shape[1], 1, 1]
+
+    assert streamed[3].shape == expected[3].shape
+
+    for output in streamed:
+        assert not torch.all(output == 999)
+
+    for streamed_output, expected_output in zip(streamed, expected):
+        assert torch.allclose(streamed_output, expected_output, atol=2e-4, rtol=2e-3)
 
 
 def test_streaming_attention_gem_backward_parity_x_and_logits():


### PR DESCRIPTION
### Motivation
- Add coverage and runtime assertions for the WSS/AttentionGeM streaming path to ensure streaming returns the correct public outputs and shapes and to detect aux/sentinel leaks or numeric regressions. 

### Description
- Add a `weights: str | None` argument to `StreamingWSS` and forward it to `WSS` so tests can instantiate the streaming path with `weights=None` (avoid downloading pretrained weights). (`lightstream/models/segment/streamingwss.py`)
- Add `test_streaming_wss_attention_gem_public_outputs_skip_aux_maps` in `tests/test_streaming_reducer.py` which instantiates `StreamingWSS` with small input/tile sizes and verifies: exactly 4 public outputs are returned, the three AttentionGeM reduced outputs have shape `[N, C, 1, 1]`, the segmentation map matches the non-streaming forward shape, reducer auxiliary indices exclude the attention-logit auxiliary maps (expected `[1,3,5]`), no public output is entirely the `999` sentinel, and streaming vs non-streaming forward outputs match numerically under a relaxed tolerance.

### Testing
- Ran Python syntax/byte-compile check: `python -m py_compile tests/test_streaming_reducer.py lightstream/models/segment/streamingwss.py` which succeeded.
- Attempted to run the new test with `pytest -q tests/test_streaming_reducer.py::test_streaming_wss_attention_gem_public_outputs_skip_aux_maps`, but collection fails in this environment due to a missing optional dependency (`ModuleNotFoundError: No module named 'lightning'`).
- The environment-level `pytest` collection error prevents automated test confirmation here; the new test is self-contained and should run in an environment where optional deps (or alternative import guards) are present.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a198123ea30833092df0a9eff030a4e)