### PR TITLE
Validate streaming tile cache metadata

### DIFF
--- a/lightstream/modules/streaming.py
+++ b/lightstream/modules/streaming.py
@@ -11,10 +11,59 @@ from lightstream.core.reducer import BaseReducer
 
 
 class StreamingModule(nn.Module):
+    """Wrap a PyTorch module for tiled streaming inference and backward passes.
+
+    ``StreamingModule`` constructs a streaming representation of ``stream_network``
+    with :class:`lightstream.core.constructor.StreamingConstructor`, optionally
+    loading and saving tile statistics from a persistent cache. Cache entries are
+    validated with lightweight metadata that describes the model class, tile
+    shape, public output structure, internal streaming output count, and reducer
+    classes.
+
+    Parameters
+    ----------
+    stream_network : torch.nn.Module
+        Model or model fragment to convert into a streaming network.
+    tile_size : int
+        Spatial height and width of square NCHW tiles used by the streaming
+        constructor. The resulting tile shape is ``(1, 3, tile_size, tile_size)``.
+    tile_cache_path : str or pathlib.Path, optional
+        File path used to load and save tile cache data. If omitted, a default
+        cache file is created in the current working directory.
+    **kwargs
+        Additional keyword arguments forwarded to
+        :class:`lightstream.core.constructor.StreamingConstructor`.
+
+    Attributes
+    ----------
+    tile_cache_metadata : dict
+        Metadata signature for the current model and tile configuration.
+    constructor : StreamingConstructor
+        Constructor object used to build ``stream_network``.
+    stream_network : torch.nn.Module
+        Converted streaming network returned by the constructor.
+    copy_to_gpu : bool
+        Whether the constructor copies intermediate tile results to GPU.
+    """
+
     TILE_CACHE_METADATA_KEY = "tile_cache_metadata"
     TILE_CACHE_METADATA_VERSION = 1
 
     def __init__(self, stream_network: torch.nn.Module, tile_size, tile_cache_path: str | Path = None, **kwargs):
+        """Initialize the streaming wrapper and prepare tile-cache state.
+
+        Parameters
+        ----------
+        stream_network : torch.nn.Module
+            Model or model fragment to convert into a streaming network.
+        tile_size : int
+            Spatial height and width of square NCHW tiles.
+        tile_cache_path : str or pathlib.Path, optional
+            File path used to load and save tile cache data.
+        **kwargs
+            Additional keyword arguments forwarded to
+            :class:`lightstream.core.constructor.StreamingConstructor`.
+        """
         super().__init__()
         # StreamingCNN options
         self.tile_size = tile_size
@@ -37,10 +86,39 @@ class StreamingModule(nn.Module):
         self.save_tile_cache_if_needed(overwrite=self._tile_cache_was_ignored)
 
     def _default_tile_cache_fname(self) -> str:
+        """Return the default cache file name for the configured tile size.
+
+        Returns
+        -------
+        str
+            Default tile cache file name without a directory component.
+        """
         return "tile_cache_" + "1_3_" + str(self.tile_size) + "_" + str(self.tile_size)
 
     @classmethod
     def _flatten_output_structure(cls, output):
+        """Flatten a structured model output and describe its container layout.
+
+        Parameters
+        ----------
+        output : torch.Tensor or tuple or list or dict
+            Output produced by a model forward pass. Nested combinations of
+            tensors, tuples, lists, and dictionaries are supported.
+
+        Returns
+        -------
+        flat : list[torch.Tensor]
+            Tensors found in the output, ordered according to the output
+            structure. Dictionary keys are visited in sorted order.
+        spec : tuple
+            Recursive output-structure specification that can be compared across
+            model versions.
+
+        Raises
+        ------
+        TypeError
+            If ``output`` contains an unsupported object type.
+        """
         if isinstance(output, torch.Tensor):
             return [output], ("tensor", None)
         if isinstance(output, tuple):
@@ -71,6 +149,27 @@ class StreamingModule(nn.Module):
 
     @classmethod
     def _flatten_output_spec(cls, spec, path: str = "") -> list[str]:
+        """Convert a recursive output specification into stable path strings.
+
+        Parameters
+        ----------
+        spec : tuple
+            Recursive output specification returned by
+            :meth:`_flatten_output_structure`.
+        path : str, default=""
+            Path prefix used internally during recursion.
+
+        Returns
+        -------
+        list[str]
+            Flattened public output specification such as
+            ``["/tuple[0]:tensor", "/tuple[1]:tensor"]``.
+
+        Raises
+        ------
+        TypeError
+            If ``spec`` contains an unsupported spec kind.
+        """
         kind, payload = spec
         if kind == "tensor":
             return [f"{path}:tensor"]
@@ -90,17 +189,63 @@ class StreamingModule(nn.Module):
 
     @staticmethod
     def _set_reducer_passthrough(model: nn.Module, enabled: bool) -> None:
+        """Toggle reducer passthrough mode for every reducer in a model.
+
+        Parameters
+        ----------
+        model : torch.nn.Module
+            Model whose reducer modules should be updated.
+        enabled : bool
+            If ``True``, reducers expose their internal passthrough outputs for
+            metadata probing. If ``False``, reducers use their normal public
+            output behavior.
+        """
         for module in model.modules():
             if isinstance(module, BaseReducer):
                 module._streaming_passthrough = enabled
 
     @staticmethod
     def _restore_training_modes(model: nn.Module, training_modes: dict[nn.Module, bool]) -> None:
+        """Restore training/evaluation mode for modules after probing.
+
+        Parameters
+        ----------
+        model : torch.nn.Module
+            Model containing the modules to restore. The parameter is retained
+            for call-site readability and future extension.
+        training_modes : dict[torch.nn.Module, bool]
+            Mapping from module object to the ``training`` value it had before
+            metadata probing started.
+        """
         for module, was_training in training_modes.items():
             module.train(was_training)
 
     def build_tile_cache_metadata(self, stream_network: torch.nn.Module) -> dict:
-        """Build a compact model signature used to validate persisted tile caches."""
+        """Build the metadata signature used to validate tile cache files.
+
+        The signature captures model-level properties that affect whether a
+        persisted tile cache can be safely reused. The method performs small
+        no-gradient probe forwards to record both the public output structure and
+        the internal output count exposed when reducers are in passthrough mode.
+
+        Parameters
+        ----------
+        stream_network : torch.nn.Module
+            Model to inspect before it is converted into a streaming network.
+
+        Returns
+        -------
+        dict
+            Metadata dictionary containing ``version``, ``model_class_name``,
+            ``tile_shape``, ``flattened_public_output_spec``,
+            ``flattened_internal_output_count``, and ``reducer_class_names``.
+
+        Notes
+        -----
+        The probe tile is capped at 64x64 pixels to avoid allocating very large
+        tensors while still exercising output/reducer structure. The persisted
+        ``tile_shape`` continues to record the configured tile size.
+        """
         reducer_class_names = [
             module.__class__.__name__ for module in stream_network.modules() if isinstance(module, BaseReducer)
         ]
@@ -144,6 +289,20 @@ class StreamingModule(nn.Module):
         return metadata
 
     def _metadata_mismatches(self, cached_metadata: dict | None) -> list[str]:
+        """Compare loaded cache metadata with the current metadata signature.
+
+        Parameters
+        ----------
+        cached_metadata : dict or None
+            Metadata loaded from a tile cache file. ``None`` represents a legacy
+            cache file that predates metadata support.
+
+        Returns
+        -------
+        list[str]
+            Human-readable mismatch descriptions. An empty list means the cache
+            metadata matches the current model.
+        """
         if cached_metadata is None:
             return ["cache has no metadata"]
         mismatches = []
@@ -154,17 +313,24 @@ class StreamingModule(nn.Module):
         return mismatches
 
     def save_tile_cache_if_needed(self, overwrite: bool = False):
-        """
-        Writes the tile cache to a file, so it does not have to be recomputed
+        """Save tile cache data and validation metadata when needed.
 
-        The tile cache is normally calculated for each run.
-        However, this can take a long time. By writing it to a file it can be reloaded without the need
-        for recomputation.
+        Parameters
+        ----------
+        overwrite : bool, default=False
+            If ``True``, replace an existing cache file. If ``False``, leave an
+            existing cache file untouched.
 
-        Limitations:
-        This only works for the exact same model and for a single tile size. If the streaming part of the model
-        changes, or if the tile size is changed, it will no longer work.
+        Raises
+        ------
+        NotADirectoryError
+            If the configured cache directory does not exist.
 
+        Notes
+        -----
+        Tile caches are valid only for the same model layout and tile size. This
+        method stores cache metadata alongside the streaming statistics so stale
+        caches can be detected on future loads.
         """
         if self.tile_cache_fname is None:
             self.tile_cache_fname = self._default_tile_cache_fname()
@@ -184,18 +350,25 @@ class StreamingModule(nn.Module):
             raise NotADirectoryError(f"Did not find {self.tile_cache_dir} or does not exist")
 
     def load_tile_cache_if_needed(self, use_tile_cache: bool = True):
-        """
-        Load the tile cache for the model from the read_dir
+        """Load a compatible tile cache from disk when available.
 
         Parameters
         ----------
-        use_tile_cache : bool
-            Whether to use the tile cache file and load it into the streaming module
+        use_tile_cache : bool, default=True
+            Whether to attempt loading the configured tile cache file.
 
         Returns
-        ---------
-        state_dict : torch.state_dict | None
-            The state dict if present
+        -------
+        dict or None
+            Loaded tile cache state dictionary when a compatible cache exists;
+            otherwise ``None`` so the constructor recomputes tile statistics.
+
+        Notes
+        -----
+        Cache files without metadata, or with metadata that differs from the
+        current model signature, are treated as stale. Stale caches are ignored,
+        a warning is printed, and the cache is marked for overwrite after
+        recomputation.
         """
 
         if self.tile_cache_fname is None:
@@ -225,7 +398,32 @@ class StreamingModule(nn.Module):
         return state_dict
 
     def forward(self, x, mask=None):
+        """Run a streaming forward pass.
+
+        Parameters
+        ----------
+        x : torch.Tensor
+            Input tensor to process with the streaming network.
+        mask : torch.Tensor, optional
+            Optional spatial mask forwarded to reducer-aware streaming models.
+
+        Returns
+        -------
+        torch.Tensor or tuple or list or dict
+            Output produced by ``self.stream_network``.
+        """
         return self.stream_network(x, mask=mask)
 
     def backward_streaming(self, image, grad, mask=None):
+        """Run the streaming backward pass for a previously computed gradient.
+
+        Parameters
+        ----------
+        image : torch.Tensor
+            Original full-resolution input image used for the forward pass.
+        grad : torch.Tensor or tuple or list or dict
+            Gradient with respect to the streaming network output.
+        mask : torch.Tensor, optional
+            Optional spatial mask forwarded to the streaming backward routine.
+        """
         self.stream_network.backward(image, grad, mask=mask)

--- a/lightstream/modules/streaming.py
+++ b/lightstream/modules/streaming.py
@@ -1,11 +1,19 @@
-import torch
-import torch.nn as nn
+from __future__ import annotations
+
+import copy
 from pathlib import Path
 
+import torch
+import torch.nn as nn
+
 from lightstream.core.constructor import StreamingConstructor
+from lightstream.core.reducer import BaseReducer
 
 
 class StreamingModule(nn.Module):
+    TILE_CACHE_METADATA_KEY = "tile_cache_metadata"
+    TILE_CACHE_METADATA_VERSION = 1
+
     def __init__(self, stream_network: torch.nn.Module, tile_size, tile_cache_path: str | Path = None, **kwargs):
         super().__init__()
         # StreamingCNN options
@@ -13,6 +21,8 @@ class StreamingModule(nn.Module):
         self.tile_cache_path = Path(tile_cache_path) if tile_cache_path else None
         self.tile_cache_dir = Path.cwd() if tile_cache_path is None else self.tile_cache_path.parent
         self.tile_cache_fname = None if tile_cache_path is None else self.tile_cache_path.stem
+        self.tile_cache_metadata = self.build_tile_cache_metadata(stream_network)
+        self._tile_cache_was_ignored = False
         tile_cache = self.load_tile_cache_if_needed()  # Load tile cache if present
 
         # Initialize the streaming network
@@ -24,7 +34,124 @@ class StreamingModule(nn.Module):
         )
         self.copy_to_gpu = self.constructor.copy_to_gpu
         self.stream_network = self.constructor.prepare_streaming_model()
-        self.save_tile_cache_if_needed()
+        self.save_tile_cache_if_needed(overwrite=self._tile_cache_was_ignored)
+
+    def _default_tile_cache_fname(self) -> str:
+        return "tile_cache_" + "1_3_" + str(self.tile_size) + "_" + str(self.tile_size)
+
+    @classmethod
+    def _flatten_output_structure(cls, output):
+        if isinstance(output, torch.Tensor):
+            return [output], ("tensor", None)
+        if isinstance(output, tuple):
+            flat = []
+            children = []
+            for item in output:
+                child_flat, child_spec = cls._flatten_output_structure(item)
+                flat.extend(child_flat)
+                children.append(child_spec)
+            return flat, ("tuple", children)
+        if isinstance(output, list):
+            flat = []
+            children = []
+            for item in output:
+                child_flat, child_spec = cls._flatten_output_structure(item)
+                flat.extend(child_flat)
+                children.append(child_spec)
+            return flat, ("list", children)
+        if isinstance(output, dict):
+            flat = []
+            children = []
+            for key in sorted(output.keys()):
+                child_flat, child_spec = cls._flatten_output_structure(output[key])
+                flat.extend(child_flat)
+                children.append((key, child_spec))
+            return flat, ("dict", children)
+        raise TypeError(f"Unsupported output type for streaming cache metadata: {type(output)}")
+
+    @classmethod
+    def _flatten_output_spec(cls, spec, path: str = "") -> list[str]:
+        kind, payload = spec
+        if kind == "tensor":
+            return [f"{path}:tensor"]
+        if kind in {"tuple", "list"}:
+            flat_spec = []
+            for index, child in enumerate(payload):
+                child_path = f"{path}/{kind}[{index}]"
+                flat_spec.extend(cls._flatten_output_spec(child, child_path))
+            return flat_spec
+        if kind == "dict":
+            flat_spec = []
+            for key, child in payload:
+                child_path = f"{path}/dict[{key!r}]"
+                flat_spec.extend(cls._flatten_output_spec(child, child_path))
+            return flat_spec
+        raise TypeError(f"Unsupported output spec kind for streaming cache metadata: {kind}")
+
+    @staticmethod
+    def _set_reducer_passthrough(model: nn.Module, enabled: bool) -> None:
+        for module in model.modules():
+            if isinstance(module, BaseReducer):
+                module._streaming_passthrough = enabled
+
+    @staticmethod
+    def _restore_training_modes(model: nn.Module, training_modes: dict[nn.Module, bool]) -> None:
+        for module, was_training in training_modes.items():
+            module.train(was_training)
+
+    def build_tile_cache_metadata(self, stream_network: torch.nn.Module) -> dict:
+        """Build a compact model signature used to validate persisted tile caches."""
+        reducer_class_names = [
+            module.__class__.__name__ for module in stream_network.modules() if isinstance(module, BaseReducer)
+        ]
+        metadata = {
+            "version": self.TILE_CACHE_METADATA_VERSION,
+            "model_class_name": stream_network.__class__.__name__,
+            "tile_shape": (1, 3, self.tile_size, self.tile_size),
+            "flattened_public_output_spec": None,
+            "flattened_internal_output_count": None,
+            "reducer_class_names": reducer_class_names,
+        }
+
+        try:
+            first_parameter = next(stream_network.parameters())
+            device = first_parameter.device
+            dtype = first_parameter.dtype
+        except StopIteration:
+            device = torch.device("cpu")
+            dtype = torch.get_default_dtype()
+
+        training_modes = {module: module.training for module in stream_network.modules()}
+        try:
+            stream_network.eval()
+            probe_tile_size = min(int(self.tile_size), 64)
+            tile = torch.ones((1, 3, probe_tile_size, probe_tile_size), dtype=dtype, device=device)
+            with torch.no_grad():
+                self._set_reducer_passthrough(stream_network, False)
+                public_output = stream_network(tile)
+                _, public_output_spec = self._flatten_output_structure(public_output)
+
+                self._set_reducer_passthrough(stream_network, True)
+                internal_output = stream_network(tile)
+                internal_outputs, _ = self._flatten_output_structure(internal_output)
+
+            metadata["flattened_public_output_spec"] = self._flatten_output_spec(public_output_spec)
+            metadata["flattened_internal_output_count"] = len(internal_outputs)
+        finally:
+            self._set_reducer_passthrough(stream_network, False)
+            self._restore_training_modes(stream_network, training_modes)
+
+        return metadata
+
+    def _metadata_mismatches(self, cached_metadata: dict | None) -> list[str]:
+        if cached_metadata is None:
+            return ["cache has no metadata"]
+        mismatches = []
+        for key, expected_value in self.tile_cache_metadata.items():
+            cached_value = cached_metadata.get(key)
+            if cached_value != expected_value:
+                mismatches.append(f"{key}: cached={cached_value!r}, expected={expected_value!r}")
+        return mismatches
 
     def save_tile_cache_if_needed(self, overwrite: bool = False):
         """
@@ -40,7 +167,7 @@ class StreamingModule(nn.Module):
 
         """
         if self.tile_cache_fname is None:
-            self.tile_cache_fname = "tile_cache_" + "1_3_" + str(self.tile_size) + "_" + str(self.tile_size)
+            self.tile_cache_fname = self._default_tile_cache_fname()
         write_path = Path(self.tile_cache_dir) / Path(self.tile_cache_fname)
 
         if Path(self.tile_cache_dir).exists():
@@ -49,7 +176,9 @@ class StreamingModule(nn.Module):
 
             else:
                 print(f"writing streaming cache file to {str(write_path)}")
-                torch.save(self.stream_network.get_tile_cache(), str(write_path))
+                tile_cache = self.stream_network.get_tile_cache()
+                tile_cache[self.TILE_CACHE_METADATA_KEY] = copy.deepcopy(self.tile_cache_metadata)
+                torch.save(tile_cache, str(write_path))
 
         else:
             raise NotADirectoryError(f"Did not find {self.tile_cache_dir} or does not exist")
@@ -70,7 +199,7 @@ class StreamingModule(nn.Module):
         """
 
         if self.tile_cache_fname is None:
-            self.tile_cache_fname = "tile_cache_" + "1_3_" + str(self.tile_size) + "_" + str(self.tile_size)
+            self.tile_cache_fname = self._default_tile_cache_fname()
 
         tile_cache_loc = Path(self.tile_cache_dir) / Path(self.tile_cache_fname)
 
@@ -81,6 +210,14 @@ class StreamingModule(nn.Module):
                 map_location=lambda storage, loc: storage,
                 weights_only=False,
             )
+            mismatches = self._metadata_mismatches(state_dict.get(self.TILE_CACHE_METADATA_KEY))
+            if mismatches:
+                print(
+                    "Warning: ignoring stale tile cache metadata for "
+                    f"{tile_cache_loc}: " + "; ".join(mismatches)
+                )
+                self._tile_cache_was_ignored = True
+                state_dict = None
         else:
             print("No tile cache found, calculating it now")
             state_dict = None


### PR DESCRIPTION
### Motivation
- Prevent silent reuse of incompatible/stale tile caches that can misconfigure streaming models. 
- Record a compact signature for a model’s streaming layout to detect incompatible caches (tile shape, outputs and reducers).

### Description
- Add metadata generation in `StreamingModule.build_tile_cache_metadata()` capturing `model_class_name`, `tile_shape`, flattened public output spec, flattened internal output count, and `reducer_class_names`.
- Persist the metadata into the saved tile-cache dictionary under the key `tile_cache_metadata` when writing caches in `save_tile_cache_if_needed()`.
- Validate loaded caches in `load_tile_cache_if_needed()` and ignore stale/legacy caches when metadata mismatches, printing a warning and marking the cache to be recomputed/overwritten.
- Add helpers to safely probe/flatten output specs (`_flatten_output_spec`) and to avoid large probe tiles by capping the probe size when building metadata.

### Testing
- Compiled updated modules with `python -m py_compile lightstream/modules/streaming.py lightstream/models/segment/streamingwss.py`, which succeeded.  
- Performed an import smoke-check (`import lightstream.modules.streaming`) which could not be fully exercised in this environment due to a missing external dependency (`lightning`), so runtime integration was not validated here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1988df55ec8330a86f6431b0582547)