### PR TITLE
Fix streaming AttentionGeM backward surrogate

### DIFF
--- a/lightstream/core/reducer/attention_gem.py
+++ b/lightstream/core/reducer/attention_gem.py
@@ -215,10 +215,15 @@ class StreamingAttentionGeMReducer(BaseStreamingGlobalReducer):
 
     def extra_state_for_backward(self) -> dict[str, torch.Tensor | int | float | None]:
         acc_dtype = resolve_accumulator_dtype(self.accumulator_dtype, self.running_shat.dtype)
+        zhat = self.running_zhat.to(dtype=acc_dtype).clamp_min(self.eps)
+        mean = self.running_shat.to(dtype=acc_dtype) / zhat
+        r = self.current_r.to(device=self.running_shat.device, dtype=acc_dtype)
         return {
             "m": self.running_m.to(dtype=acc_dtype),
-            "zhat": self.running_zhat.to(dtype=acc_dtype).clamp_min(self.eps),
-            "r": self.current_r.to(device=self.running_shat.device, dtype=acc_dtype),
+            "zhat": zhat,
+            "mean": mean,
+            "y": mean.clamp_min(self.eps).pow(1.0 / r),
+            "r": r,
         }
 
     def reduce_tile_for_backward(self, trimmed_output, valid_mask: torch.Tensor | None, global_context):
@@ -232,11 +237,18 @@ class StreamingAttentionGeMReducer(BaseStreamingGlobalReducer):
         m = global_context["m"].to(device=x_tile.device, dtype=acc_dtype)
         zhat = global_context["zhat"].to(device=x_tile.device, dtype=acc_dtype).clamp_min(self.eps)
 
+        global_mean = global_context["mean"].to(device=x_tile.device, dtype=acc_dtype)
+
         valid4d = valid_mask[None, None].to(device=x_tile.device, dtype=torch.bool)
+        x_pow = x.pow(r)
         weights_unnorm = torch.exp(logits - m)
         weights_unnorm = torch.where(valid4d, weights_unnorm, torch.zeros_like(weights_unnorm))
-        weighted = streaming_reduce_tile(weights_unnorm * x.pow(r), valid_mask, zhat)
-        return weighted.clamp_min(self.eps).pow(1.0 / r).to(dtype=x_tile.dtype)
+        local_s_over_z = streaming_reduce_tile(weights_unnorm * x_pow, valid_mask, zhat)
+        local_z_over_z = streaming_reduce_tile(weights_unnorm, valid_mask, zhat)
+
+        scale = (1.0 / r) * global_mean.clamp_min(self.eps).pow(1.0 / r - 1.0)
+        surrogate = scale.detach() * (local_s_over_z - global_mean.detach() * local_z_over_z)
+        return surrogate.to(dtype=x_tile.dtype)
 
     def to_reducer(self) -> AttentionGeMReducer:
         reducer = AttentionGeMReducer(

--- a/tests/test_streaming_reducer.py
+++ b/tests/test_streaming_reducer.py
@@ -297,6 +297,19 @@ class AttentionGeMHeadNet(nn.Module):
         return self.reducer(self.feat_head(feat), self.logit_head(feat))
 
 
+class AttentionGeMBiasHeadNet(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.backbone = nn.Sequential(nn.Conv2d(3, 4, kernel_size=3, padding=1, bias=False), nn.ReLU())
+        self.feat_head = nn.Conv2d(4, 3, kernel_size=1, bias=False)
+        self.logit_head = nn.Conv2d(4, 1, kernel_size=1, bias=True)
+        self.reducer = AttentionGeMReducer(r_init=2.7, eps=1e-6)
+
+    def forward(self, x):
+        feat = self.backbone(x)
+        return self.reducer(self.feat_head(feat), self.logit_head(feat))
+
+
 def test_public_output_indices_skip_attention_gem_aux_payloads():
     scnn = StreamingCNN.__new__(StreamingCNN)
     scnn._tile_output_shapes = [torch.Size((1, 1, 1, 1)) for _ in range(8)]
@@ -537,3 +550,31 @@ def test_streaming_attention_gem_backward_parity_x_and_logits():
         assert name in stream_grads
         assert name in ref_grads
         assert torch.allclose(stream_grads[name], ref_grads[name], atol=2e-5, rtol=2e-4), name
+
+
+def test_streaming_attention_gem_logit_bias_gradient_matches_reference():
+    torch.manual_seed(23)
+    model = AttentionGeMBiasHeadNet().eval()
+    reference = AttentionGeMBiasHeadNet().eval()
+    reference.load_state_dict(model.state_dict())
+
+    image = (torch.rand(1, 3, 9, 11) + 0.05).requires_grad_(True)
+    ref_image = image.detach().clone().requires_grad_(True)
+    grad_out = torch.tensor([[[[0.19]], [[-0.31]], [[0.43]]]], dtype=image.dtype)
+
+    ref_out = reference(ref_image)
+    torch.autograd.backward(ref_out, grad_out)
+
+    scnn = _make_streaming(model, tile_size=4)
+    scnn.debug_reducer_replay = True
+    stream_out = scnn.forward(image.detach().clone())
+    assert torch.allclose(stream_out, ref_out.detach(), atol=1e-5, rtol=1e-4)
+    scnn.backward(image.detach().clone(), grad_out.detach().clone())
+
+    stream_bias_grad = scnn.stream_module.logit_head.bias.grad
+    ref_bias_grad = reference.logit_head.bias.grad
+
+    assert stream_bias_grad is not None
+    assert ref_bias_grad is not None
+    assert torch.allclose(stream_bias_grad, ref_bias_grad, atol=2e-6, rtol=2e-5)
+    assert stream_bias_grad.abs().max() < 2e-6


### PR DESCRIPTION
### Motivation
- Ensure backward replay for streaming AttentionGeM uses a global-softmax surrogate whose derivatives match the full (non-streaming) AttentionGeM, so attention-logit bias gradients cancel correctly.
- Remove the previous tile-local GeM replay that produced mismatched logit/bias gradients during streaming backward replay.

### Description
- Update `StreamingAttentionGeMReducer.extra_state_for_backward()` to expose `zhat`, the global weighted `mean`, the GeM output `y`, and the replay `r` in a stable accumulator dtype for replay use.
- Replace the old tile-local GeM replay in `StreamingAttentionGeMReducer.reduce_tile_for_backward()` with the global-softmax surrogate: compute `x_pow = x.pow(r)`, `weights_unnorm = exp(logits - m)` masked by `valid_mask`, compute `local_s_over_z` and `local_z_over_z` via `streaming_reduce_tile`, compute the detached derivative `scale = (1.0/r) * global_mean.clamp_min(eps).pow(1.0/r - 1.0)`, and return `surrogate = scale.detach() * (local_s_over_z - global_mean.detach() * local_z_over_z)` converted back to the tile dtype.
- Add a regression test `test_streaming_attention_gem_logit_bias_gradient_matches_reference()` and the `AttentionGeMBiasHeadNet` fixture to `tests/test_streaming_reducer.py` which checks that streaming logit-bias gradients match the non-streaming reference and are numerically near zero.

### Testing
- Ran `python -m py_compile lightstream/core/reducer/attention_gem.py tests/test_streaming_reducer.py`, which succeeded without syntax errors.
- Executed an isolated parity script that constructs `AttentionGeMReducer` and `StreamingAttentionGeMReducer`, accumulates tiles, runs the new `reduce_tile_for_backward()` surrogate, and validated that value/logit gradients and the logit-bias cancellation match the non-streaming reference (passed).
- Attempts to run the targeted `pytest` in this environment encountered collection/runtime issues due to missing external test dependencies (`lightning`, `numpy`, `torchvision`) and CUDA initialization in the test harness, so full `pytest` runs were not completed here; please run the test suite in CI or a local environment with `numpy`, `torchvision`, and `lightning` installed (or stubbed) to verify all tests end-to-end.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a19923b08c8833098a7ea0cd240dc32)