### PR TITLE
Enforce streaming reducer backward-replay contract

### DIFF
--- a/lightstream/core/reducer/attention_gem.py
+++ b/lightstream/core/reducer/attention_gem.py
@@ -246,6 +246,10 @@ class StreamingAttentionGeMReducer(BaseStreamingGlobalReducer):
         local_s_over_z = streaming_reduce_tile(weights_unnorm * x_pow, valid_mask, zhat)
         local_z_over_z = streaming_reduce_tile(weights_unnorm, valid_mask, zhat)
 
+        # Backward replay uses this as a surrogate for the derivative of the
+        # finalized global reducer output y = (global_S / global_Z) ** (1/r).
+        # Do not finalize each tile independently; the summed tile gradients must
+        # match the gradient of that single global expression.
         scale = (1.0 / r) * global_mean.clamp_min(self.eps).pow(1.0 / r - 1.0)
         surrogate = scale.detach() * (local_s_over_z - global_mean.detach() * local_z_over_z)
         return surrogate.to(dtype=x_tile.dtype)

--- a/lightstream/core/reducer/base.py
+++ b/lightstream/core/reducer/base.py
@@ -342,9 +342,24 @@ class BaseStreamingGlobalReducer(nn.Module, ABC):
 
     @abstractmethod
     def reduce_tile_for_backward(self, trimmed_output: torch.Tensor | Sequence[torch.Tensor], valid_mask: torch.Tensor | None, global_context: dict[str, torch.Tensor | int | float | None]) -> torch.Tensor:
-        """Build tile-local reduced output used for backward replay.
+        """Build a tile-local replay expression for reducer backward.
 
         ``trimmed_output`` may be a single tensor or structured tuple/list payload.
+
+        The returned tensor is consumed only by backward replay and is allowed to be
+        a derivative surrogate. It does not need to numerically equal the tile's
+        final forward contribution, and for nonlinear global reducers such as GeM
+        it generally should not finalize each tile independently. Instead, the
+        implementation contract is gradient equivalence: when the same upstream
+        reducer gradient is applied to every replay tile and those per-tile input
+        gradients are summed over all tiles, the result must match the gradient of
+        the finalized global reducer output with respect to the original full
+        input(s).
+
+        Avoid applying nonlinear finalization (for example, ``pow(1.0 / r)``) to
+        each tile contribution unless the math has been derived to be equivalent
+        under this gradient-summing contract. Use ``global_context`` for finalized
+        global state needed to build an equivalent replay expression.
         """
 
     def extra_state_for_backward(self) -> dict[str, torch.Tensor | int | float | None]:

--- a/lightstream/core/reducer/gem.py
+++ b/lightstream/core/reducer/gem.py
@@ -143,7 +143,11 @@ class StreamingGeMReducer(BaseStreamingGlobalReducer):
 
         x_pow = x_clamped.pow(r)
         m_tile = streaming_reduce_tile(x_pow, valid_mask, n)
-        return m_tile.clamp_min(self.eps).pow(1.0 / r).to(dtype=trimmed_output.dtype)
+
+        global_m = global_context["m"].to(device=trimmed_output.device, dtype=acc_dtype)
+        scale = (1.0 / r) * global_m.clamp_min(self.eps).pow(1.0 / r - 1.0)
+        surrogate = scale.detach() * m_tile
+        return surrogate.to(dtype=trimmed_output.dtype)
 
     def to_reducer(self) -> GeMReducer:
         reducer = GeMReducer(

--- a/tests/test_streaming_reducer.py
+++ b/tests/test_streaming_reducer.py
@@ -269,6 +269,38 @@ def test_streaming_gem_backward_input_grad_parity():
     assert torch.allclose(grad_x_stream, x_ref.grad, atol=1e-5, rtol=1e-4)
 
 
+def test_streaming_gem_backward_replay_surrogate_matches_global_gradient():
+    torch.manual_seed(31)
+    x = (torch.rand(1, 2, 4, 6) + 0.05).requires_grad_(True)
+    x_ref = x.detach().clone().requires_grad_(True)
+    mask = torch.tensor(
+        [
+            [1, 0, 1, 1, 0, 1],
+            [1, 1, 0, 1, 1, 0],
+            [0, 1, 1, 0, 1, 1],
+            [1, 0, 1, 1, 0, 1],
+        ],
+        dtype=torch.bool,
+    )
+    upstream = torch.tensor([[[[0.17]], [[-0.29]]]], dtype=x.dtype)
+    sides = type("S", (), dict(top=False, left=False, right=False, bottom=False))()
+
+    reducer = StreamingGeMReducer(r_init=3.2, eps=1e-6)
+    reducer.start_stream(output_height=4, output_width=6, batch_size=1, channels=2, device=x.device, dtype=x.dtype)
+    reducer.accumulate_stream_tile(x[:, :, :, :3], 0, 0, sides, (0, 4, 0, 3), user_mask=mask[:, :3])
+    reducer.accumulate_stream_tile(x[:, :, :, 3:], 0, 1, sides, (0, 4, 3, 6), user_mask=mask[:, 3:])
+
+    global_context = reducer.extra_state_for_backward()
+    replay_left = reducer.reduce_tile_for_backward(x[:, :, :, :3], mask[:, :3], global_context)
+    replay_right = reducer.reduce_tile_for_backward(x[:, :, :, 3:], mask[:, 3:], global_context)
+    torch.autograd.backward((replay_left, replay_right), (upstream, upstream))
+
+    y_ref = _gem_reference(x_ref, mask, reducer.current_r.to(dtype=x_ref.dtype), reducer.eps)
+    torch.autograd.backward(y_ref, upstream)
+
+    assert torch.allclose(x.grad, x_ref.grad, atol=1e-5, rtol=1e-4)
+
+
 def test_streaming_gem_fp16_stability_accumulator_fp32():
     torch.manual_seed(11)
     reducer = StreamingGeMReducer(r_init=4.0)


### PR DESCRIPTION
### Motivation
- Clarify and enforce the intended contract for replay-time tile reductions so backward replay produces correct input gradients for nonlinear global reducers (e.g., GeM).

### Description
- Update `BaseStreamingGlobalReducer.reduce_tile_for_backward()` docstring to state the returned tensor may be a derivative surrogate and that implementations must satisfy gradient-equivalence when summing replay tile gradients. 
- Change `StreamingGeMReducer.reduce_tile_for_backward()` to return a surrogate scaled by the finalized global mean derivative instead of applying per-tile `pow(1.0 / r)` finalization. 
- Add explanatory comments to `StreamingAttentionGeMReducer.reduce_tile_for_backward()` that the expression is a surrogate for the derivative of `y = (global_S / global_Z) ** (1/r)` and warn against per-tile nonlinear finalization. 
- Add a regression test `test_streaming_gem_backward_replay_surrogate_matches_global_gradient` that verifies summed replay tile gradients match the gradient of the global GeM output.

### Testing
- Successfully type-checked changed sources with `python -m py_compile lightstream/core/reducer/base.py lightstream/core/reducer/gem.py lightstream/core/reducer/attention_gem.py tests/test_streaming_reducer.py`.
- Ran `pytest -q tests/test_streaming_reducer.py -k 'gem_backward_replay_surrogate or streaming_gem_backward_input_grad or attention_gem_backward_parity'` but test collection failed due to missing external dependency (`lightning`) in the environment, blocking full pytest execution.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a199b9988108330902b501b371c0fe6)