### PR TITLE
Fix mask semantics in StreamingAttentionGeMReducer and add masked parity test

### DIFF
--- a/lightstream/core/reducer/attention_gem.py
+++ b/lightstream/core/reducer/attention_gem.py
@@ -241,6 +241,8 @@ class StreamingAttentionGeMReducer(BaseStreamingGlobalReducer):
 
         valid4d = valid_mask[None, None].to(device=x_tile.device, dtype=torch.bool)
         x_pow = x.pow(r)
+        neg_inf = torch.finfo(acc_dtype).min
+        logits = torch.where(valid4d, logits, torch.full_like(logits, neg_inf))
         weights_unnorm = torch.exp(logits - m)
         weights_unnorm = torch.where(valid4d, weights_unnorm, torch.zeros_like(weights_unnorm))
         local_s_over_z = streaming_reduce_tile(weights_unnorm * x_pow, valid_mask, zhat)

--- a/tests/test_streaming_reducer.py
+++ b/tests/test_streaming_reducer.py
@@ -386,6 +386,97 @@ class AttentionGeMBiasHeadNet(nn.Module):
         return self.reducer(self.feat_head(feat), self.logit_head(feat))
 
 
+def test_streaming_attention_gem_masked_forward_and_backward_replay_match_non_streaming():
+    torch.manual_seed(43)
+    image = torch.randn(1, 3, 4, 6, dtype=torch.float32)
+    x_weight = torch.randn(2, 3, 1, 1, dtype=torch.float32) * 0.2
+    logit_weight = torch.randn(1, 3, 1, 1, dtype=torch.float32) * 0.3
+    logit_bias = torch.tensor([0.17], dtype=torch.float32)
+    mask = torch.tensor(
+        [
+            [1, 0, 1, 1, 0, 1],
+            [0, 1, 1, 0, 1, 1],
+            [1, 1, 0, 1, 1, 0],
+            [1, 0, 1, 0, 1, 1],
+        ],
+        dtype=torch.bool,
+    )
+    invalid_logit_boost = (~mask).to(dtype=image.dtype)[None, None] * 8.0
+    upstream = torch.tensor([[[[0.23]], [[-0.37]]]], dtype=image.dtype)
+    sides = type("S", (), dict(top=False, left=False, right=False, bottom=False))()
+    tiles = (
+        (slice(0, 2), slice(0, 3), (0, 2, 0, 3)),
+        (slice(0, 2), slice(3, 6), (0, 2, 3, 6)),
+        (slice(2, 4), slice(0, 3), (2, 4, 0, 3)),
+        (slice(2, 4), slice(3, 6), (2, 4, 3, 6)),
+    )
+
+    ref_image = image.detach().clone().requires_grad_(True)
+    ref_x_weight = x_weight.detach().clone().requires_grad_(True)
+    ref_logit_weight = logit_weight.detach().clone().requires_grad_(True)
+    ref_logit_bias = logit_bias.detach().clone().requires_grad_(True)
+    ref_x = torch.nn.functional.conv2d(ref_image, ref_x_weight).sigmoid() + 0.05
+    ref_x.retain_grad()
+    ref_logits = torch.nn.functional.conv2d(ref_image, ref_logit_weight, ref_logit_bias) + invalid_logit_boost
+    ref_logits.retain_grad()
+    ref_reducer = AttentionGeMReducer(r_init=2.4, eps=1e-6)
+    ref_out = ref_reducer(ref_x, ref_logits, mask=mask)
+    torch.autograd.backward(ref_out, upstream)
+
+    stream_image = image.detach().clone().requires_grad_(True)
+    stream_x_weight = x_weight.detach().clone().requires_grad_(True)
+    stream_logit_weight = logit_weight.detach().clone().requires_grad_(True)
+    stream_logit_bias = logit_bias.detach().clone().requires_grad_(True)
+    stream_x = torch.nn.functional.conv2d(stream_image, stream_x_weight).sigmoid() + 0.05
+    stream_x.retain_grad()
+    stream_logits = torch.nn.functional.conv2d(stream_image, stream_logit_weight, stream_logit_bias) + invalid_logit_boost
+    stream_logits.retain_grad()
+    stream_reducer = StreamingAttentionGeMReducer(r_init=2.4, eps=1e-6)
+    stream_reducer.start_stream(
+        output_height=image.shape[-2],
+        output_width=image.shape[-1],
+        batch_size=image.shape[0],
+        channels=stream_x.shape[1],
+        device=image.device,
+        dtype=image.dtype,
+    )
+
+    with torch.no_grad():
+        for tile_idx, (ys, xs, dst_box) in enumerate(tiles):
+            stream_reducer.accumulate_stream_tile(
+                (stream_x.detach()[:, :, ys, xs], stream_logits.detach()[:, :, ys, xs]),
+                tile_idx // 2,
+                tile_idx % 2,
+                sides,
+                dst_box,
+                user_mask=mask[ys, xs],
+            )
+        stream_out = stream_reducer.finish_stream()
+
+    assert torch.allclose(stream_out, ref_out.detach(), atol=1e-6, rtol=1e-5)
+
+    global_context = stream_reducer.extra_state_for_backward()
+    replay_outputs = []
+    replay_grads = []
+    for ys, xs, _dst_box in tiles:
+        replay_outputs.append(
+            stream_reducer.reduce_tile_for_backward(
+                (stream_x[:, :, ys, xs], stream_logits[:, :, ys, xs]),
+                mask[ys, xs],
+                global_context,
+            )
+        )
+        replay_grads.append(upstream)
+    torch.autograd.backward(tuple(replay_outputs), tuple(replay_grads))
+
+    assert torch.allclose(stream_image.grad, ref_image.grad, atol=2e-5, rtol=2e-4)
+    assert torch.allclose(stream_logits.grad, ref_logits.grad, atol=2e-5, rtol=2e-4)
+    assert torch.allclose(stream_x.grad, ref_x.grad, atol=2e-5, rtol=2e-4)
+    assert torch.allclose(stream_x_weight.grad, ref_x_weight.grad, atol=2e-5, rtol=2e-4)
+    assert torch.allclose(stream_logit_weight.grad, ref_logit_weight.grad, atol=2e-5, rtol=2e-4)
+    assert torch.allclose(stream_logit_bias.grad, ref_logit_bias.grad, atol=2e-5, rtol=2e-4)
+
+
 def test_streaming_attention_gem_uniform_bias_backward_replay_matches_non_streaming():
     torch.manual_seed(41)
     x = torch.tensor(


### PR DESCRIPTION
### Motivation
- Ensure `StreamingAttentionGeMReducer` uses the same `valid_mask` semantics in forward accumulation and backward replay so replayed tile contributions match the globally-finalized expression.
- Add a nontrivial spatial-mask test to catch mismatches in forward outputs and gradients when some spatial locations are invalid.

### Description
- In `reduce_tile_for_backward()` apply `valid4d` to `logits` (replace invalid logits with `neg_inf`) before exponentiation so masking matches forward softmax preprocessing (`weights_unnorm` is still masked after `exp`).
- Keep masking `weights_unnorm` and then call `streaming_reduce_tile` for both the local numerator (`local_s_over_z`) and denominator (`local_z_over_z`) replay reductions.
- Add `test_streaming_attention_gem_masked_forward_and_backward_replay_match_non_streaming` which uses a nontrivial 2D spatial mask and compares streaming vs non-streaming: forward outputs, input-image gradients, attention-logit gradients, the `x`-branch gradients, and relevant parameter gradients.

### Testing
- `python -m py_compile lightstream/core/reducer/attention_gem.py tests/test_streaming_reducer.py` succeeded.
- A direct importlib-based parity script exercising the new masked attention GeM scenario was run and passed locally (used to validate parity because full pytest collection was blocked by optional deps).
- Running the test with `pytest` in this environment was blocked due to missing optional dependencies (`ModuleNotFoundError: No module named 'lightning'` / `numpy`), so the repo-level `pytest` run could not collect the test in this CI environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a19a20d16008330bfd5829fe09fc570)