### PR TITLE
Refactor reducer mask handling: defer spatial validation and add reducer-domain slicing helper

### DIFF
--- a/lightstream/core/scnn/scnn.py
+++ b/lightstream/core/scnn/scnn.py
@@ -150,27 +150,66 @@ class StreamingCNN(torch.nn.Module):
             self.load_tile_cache(state_dict)
 
     def _normalize_reducer_mask(self, mask: torch.Tensor | None, image: torch.Tensor) -> torch.Tensor | None:
+        """Normalize reducer masks for rank, device, and dtype.
+
+        Spatial compatibility is intentionally deferred until a concrete
+        reducer tile is sliced because reducer heads may operate in a reduced
+        feature-space instead of the original input-image space. 3D [N,H,W]
+        and 4D [N,C,H,W] masks keep the existing streaming behavior: all batch
+        and channel planes are collapsed to one 2D reducer-domain mask with
+        ``torch.any(...)``. Per-sample masks would require keeping these axes
+        and extending the reducer APIs.
+        """
         if mask is None:
             return None
         if mask.ndim == 2:
-            if mask.shape != image.shape[-2:]:
-                raise ValueError(
-                    f"2D mask shape {tuple(mask.shape)} must match image spatial shape {tuple(image.shape[-2:])}"
-                )
             return mask.to(device=self.device, dtype=torch.bool)
         if mask.ndim == 3:
-            if mask.shape[0] != image.shape[0] or mask.shape[-2:] != image.shape[-2:]:
+            if mask.shape[0] != image.shape[0]:
                 raise ValueError(
-                    f"3D mask shape {tuple(mask.shape)} must be [N,H,W] with N={image.shape[0]} and H/W={tuple(image.shape[-2:])}"
+                    f"3D mask shape {tuple(mask.shape)} must be [N,H,W] with N={image.shape[0]}; "
+                    "H/W must align with the reducer/reduced feature spatial domain."
                 )
             return torch.any(mask.to(device=self.device, dtype=torch.bool), dim=0)
         if mask.ndim == 4:
-            if mask.shape[0] != image.shape[0] or mask.shape[-2:] != image.shape[-2:]:
+            if mask.shape[0] != image.shape[0]:
                 raise ValueError(
-                    f"4D mask shape {tuple(mask.shape)} must be [N,C,H,W] with N={image.shape[0]} and H/W={tuple(image.shape[-2:])}"
+                    f"4D mask shape {tuple(mask.shape)} must be [N,C,H,W] with N={image.shape[0]}; "
+                    "H/W must align with the reducer/reduced feature spatial domain."
                 )
             return torch.any(mask.to(device=self.device, dtype=torch.bool), dim=(0, 1))
-        raise ValueError(f"mask must be 2D/3D/4D tensor, got shape={tuple(mask.shape)}")
+        raise ValueError(f"mask must be 2D [H,W], 3D [N,H,W], or 4D [N,C,H,W], got shape={tuple(mask.shape)}")
+
+    def _slice_reducer_mask(
+        self,
+        mask: torch.Tensor | None,
+        y0: int,
+        y1: int,
+        x0: int,
+        x1: int,
+        *,
+        context: str,
+        expected_shape: tuple[int, int],
+    ) -> torch.Tensor | None:
+        if mask is None:
+            return None
+
+        y0, y1, x0, x1 = int(y0), int(y1), int(x0), int(x1)
+        mask_h, mask_w = int(mask.shape[-2]), int(mask.shape[-1])
+        if y0 < 0 or x0 < 0 or y1 > mask_h or x1 > mask_w or y1 < y0 or x1 < x0:
+            raise ValueError(
+                f"Reducer mask slice {context} ({y0}:{y1}, {x0}:{x1}) is outside mask bounds "
+                f"{tuple(mask.shape[-2:])}. The mask must align with the reducer/reduced feature spatial domain, "
+                "not necessarily the original input image."
+            )
+
+        sliced = mask[y0:y1, x0:x1]
+        if tuple(sliced.shape) != tuple(expected_shape):
+            raise ValueError(
+                f"Reducer mask slice {context} produced shape {tuple(sliced.shape)}, expected {tuple(expected_shape)}. "
+                "The mask must align with the reducer/reduced feature spatial domain, not necessarily the original input image."
+            )
+        return sliced
 
     def _configure(self):
         # Save current model and cudnn flags, since we need to change them and restore later
@@ -864,13 +903,22 @@ class StreamingCNN(torch.nn.Module):
         dst_x0 = int(output_loc.x)
         dst_x1 = int(output_loc.x + ref.shape[W_DIM])
         payload = trimmed_payload[0] if len(trimmed_payload) == 1 else tuple(trimmed_payload)
+        tile_mask = self._slice_reducer_mask(
+            user_mask,
+            dst_y0,
+            dst_y1,
+            dst_x0,
+            dst_x1,
+            context=f"forward reducer head {head_idx}",
+            expected_shape=(ref.shape[H_DIM], ref.shape[W_DIM]),
+        )
         self._reducer_head_map[head_idx].accumulate_stream_tile(
             trimmed_output=payload,
             tile_y=int(tile_input_y),
             tile_x=int(tile_input_x),
             sides=sides,
             dst_box=(dst_y0, dst_y1, dst_x0, dst_x1),
-            user_mask=None if user_mask is None else user_mask[dst_y0:dst_y1, dst_x0:dst_x1],
+            user_mask=tile_mask,
         )
 
     def _stitch_forward_outputs(self, outputs, tile_outputs, tile_input_y, tile_input_x, sides, user_mask):
@@ -1328,12 +1376,15 @@ class StreamingCNN(torch.nn.Module):
         output_x,
     ):
         reducer = self._reducer_head_map[head_idx]
-        valid_mask = None
-        if self._active_reducer_mask is not None:
-            valid_mask = self._active_reducer_mask[
-                output_y : output_y + trimmed_output.shape[H_DIM],
-                output_x : output_x + trimmed_output.shape[W_DIM],
-            ]
+        valid_mask = self._slice_reducer_mask(
+            self._active_reducer_mask,
+            output_y,
+            output_y + trimmed_output.shape[H_DIM],
+            output_x,
+            output_x + trimmed_output.shape[W_DIM],
+            context=f"backward reducer head {head_idx}",
+            expected_shape=(trimmed_output.shape[H_DIM], trimmed_output.shape[W_DIM]),
+        )
 
         ordered_indices = self._reducer_input_indices.get(head_idx, (head_idx,))
         payload = trimmed_output

--- a/tests/test_scnn.py
+++ b/tests/test_scnn.py
@@ -30,6 +30,17 @@ class AllReducerHeadsNet(nn.Module):
         return self.sum_head(feat), self.mean_head(feat)
 
 
+class DownsampledReducerNet(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.down = nn.Conv2d(3, 4, kernel_size=3, stride=2, padding=1, bias=False)
+        self.reducer = MeanReducer()
+
+    def forward(self, x, mask: torch.Tensor | None = None):
+        feat = self.down(x)
+        return self.reducer(feat, mask=mask)
+
+
 class MixedHeadsNet(nn.Module):
     def __init__(self):
         super().__init__()
@@ -390,6 +401,53 @@ def test_scnn_single_input_reducers_compatibility_unchanged():
 
     assert torch.allclose(streamed_sum, expected_sum, atol=1e-5, rtol=1e-4)
     assert torch.allclose(streamed_mean, expected_mean, atol=1e-5, rtol=1e-4)
+
+
+def test_scnn_input_resolution_mask_for_input_resolution_reducer():
+    torch.manual_seed(115)
+    model = AllReducerHeadsNet().eval()
+    image = torch.randn(1, 3, 8, 10)
+    mask = ((torch.arange(8)[:, None] + 2 * torch.arange(10)[None, :]) % 4 != 0).to(torch.float32)
+
+    with torch.no_grad():
+        feat = model.backbone(image)
+        expected_sum = model.sum_head[1](model.sum_head[0](feat), mask=mask.to(torch.bool))
+        expected_mean = model.mean_head[1](model.mean_head[0](feat), mask=mask.to(torch.bool))
+
+    scnn = _make_streaming(model, tile_size=4)
+    with torch.no_grad():
+        streamed_sum, streamed_mean = scnn.forward(image, mask=mask)
+
+    assert torch.allclose(streamed_sum, expected_sum, atol=1e-5, rtol=1e-4)
+    assert torch.allclose(streamed_mean, expected_mean, atol=1e-5, rtol=1e-4)
+
+
+def test_scnn_downsampled_reducer_mask_matches_reduced_feature_map():
+    torch.manual_seed(117)
+    model = DownsampledReducerNet().eval()
+    image = torch.randn(1, 3, 9, 11)
+    mask = (torch.arange(5)[:, None] + torch.arange(6)[None, :]) % 2 == 0
+
+    with torch.no_grad():
+        expected = model(image, mask=mask)
+
+    scnn = _make_streaming(model, tile_size=5)
+    with torch.no_grad():
+        streamed = scnn.forward(image, mask=mask)
+
+    assert torch.allclose(streamed, expected, atol=1e-5, rtol=1e-4)
+
+
+def test_scnn_too_small_reducer_mask_fails_at_reducer_slice_site():
+    torch.manual_seed(119)
+    model = DownsampledReducerNet().eval()
+    image = torch.randn(1, 3, 9, 11)
+    mask = torch.ones((4, 6), dtype=torch.bool)
+
+    scnn = _make_streaming(model, tile_size=5)
+    with pytest.raises(ValueError, match="reducer/reduced feature spatial domain"):
+        with torch.no_grad():
+            scnn.forward(image, mask=mask)
 
 
 def test_scnn_multi_input_reducer_failure_on_shape_mismatch():


### PR DESCRIPTION
### Motivation
- Normalize user-provided reducer masks for rank/device/dtype early while deferring spatial-size alignment until a reducer tile is actually sliced because reducer heads may operate in a downsampled/reduced spatial domain. 
- Preserve current streaming semantics for 3D/4D masks (collapse batch/channel planes with `torch.any(...)`) and make error messages reference the reducer/reduced feature spatial domain. 

### Description
- Change `_normalize_reducer_mask` to only validate rank/batch and to move masks to the streaming device as boolean tensors while removing the strict `mask.shape[-2:] == image.shape[-2:]` spatial check. 
- Add `StreamingCNN._slice_reducer_mask(mask, y0, y1, x0, x1, *, context, expected_shape)` which validates slice bounds and ensures the sliced mask matches the expected reducer-tile spatial shape, and returns the sliced mask or `None`. 
- Use the new `_slice_reducer_mask` in forward reducer accumulation (`_accumulate_reducer_forward_tile`) and backward reducer replay (`_build_reducer_backward_pair`) so spatial validation happens at the tile slice site and error messages refer to the reducer domain. 
- Update and extend tests in `tests/test_scnn.py` with a `DownsampledReducerNet` and three tests that cover input-resolution masks, downsampled reducer masks matching reduced feature maps, and a too-small/misaligned mask failing at the reducer slice site. 

### Testing
- Static sanity checks passed via `python -m py_compile lightstream/core/scnn/scnn.py tests/test_scnn.py` and `git diff --check`. 
- Running the full `pytest -q tests/test_scnn.py` was blocked during collection by a missing `lightning` dependency in the environment. 
- Targeted runs of the new mask tests in the CI-like environment produced failures due to environment constraints (attempts to stub/mimic missing deps exposed CUDA/device initialization issues and produced 3 failing mask-related tests); these failures appear to be caused by the test environment rather than the code changes themselves.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1c6c6731088330b45897a0f5350d3d)