### PR TITLE
Coordinate distributed tile-cache creation

### DIFF
--- a/lightstream/modules/streaming.py
+++ b/lightstream/modules/streaming.py
@@ -74,7 +74,65 @@ class StreamingModule(nn.Module):
         self._tile_cache_was_ignored = False
         tile_cache = self.load_tile_cache_if_needed()  # Load tile cache if present
 
-        # Initialize the streaming network
+        # Initialize the streaming network. When a distributed job starts with no
+        # compatible cache, rank zero computes and saves it while the remaining
+        # ranks wait and then reload the freshly written cache.
+        if tile_cache is not None:
+            self._prepare_streaming_model(stream_network, tile_cache, **kwargs)
+            self.save_tile_cache_if_needed(overwrite=self._tile_cache_was_ignored)
+        elif self._distributed_is_initialized() and self._distributed_world_size() > 1:
+            rank = self._distributed_rank()
+            if rank == 0:
+                self._prepare_streaming_model(stream_network, tile_cache=None, **kwargs)
+                self.save_tile_cache_if_needed(overwrite=self._tile_cache_was_ignored)
+
+            self._distributed_barrier()
+
+            if rank != 0:
+                tile_cache = self.load_tile_cache_if_needed()
+                if tile_cache is None:
+                    raise RuntimeError(
+                        "Rank "
+                        f"{rank} could not load a compatible tile cache after waiting for rank 0. "
+                        f"Expected cache path: {self._tile_cache_location()}"
+                    )
+                self._prepare_streaming_model(stream_network, tile_cache, **kwargs)
+        else:
+            self._prepare_streaming_model(stream_network, tile_cache=None, **kwargs)
+            self.save_tile_cache_if_needed(overwrite=self._tile_cache_was_ignored)
+
+    @staticmethod
+    def _distributed_is_initialized() -> bool:
+        """Return whether ``torch.distributed`` is available and initialized."""
+        distributed = getattr(torch, "distributed", None)
+        return (
+            distributed is not None
+            and distributed.is_available()
+            and distributed.is_initialized()
+        )
+
+    @staticmethod
+    def _distributed_rank() -> int:
+        """Return the current distributed rank."""
+        return torch.distributed.get_rank()
+
+    @staticmethod
+    def _distributed_world_size() -> int:
+        """Return the current distributed world size."""
+        return torch.distributed.get_world_size()
+
+    @staticmethod
+    def _distributed_barrier() -> None:
+        """Synchronize all initialized distributed ranks."""
+        torch.distributed.barrier()
+
+    def _prepare_streaming_model(
+        self,
+        stream_network: torch.nn.Module,
+        tile_cache: dict | None,
+        **kwargs,
+    ) -> None:
+        """Construct and prepare the streaming network with an optional tile cache."""
         self.constructor = StreamingConstructor(
             stream_network,
             self.tile_size,
@@ -83,7 +141,12 @@ class StreamingModule(nn.Module):
         )
         self.copy_to_gpu = self.constructor.copy_to_gpu
         self.stream_network = self.constructor.prepare_streaming_model()
-        self.save_tile_cache_if_needed(overwrite=self._tile_cache_was_ignored)
+
+    def _tile_cache_location(self) -> Path:
+        """Return the configured cache path, assigning the default file name if needed."""
+        if self.tile_cache_fname is None:
+            self.tile_cache_fname = self._default_tile_cache_fname()
+        return Path(self.tile_cache_dir) / Path(self.tile_cache_fname)
 
     def _default_tile_cache_fname(self) -> str:
         """Return the default cache file name for the configured tile size.
@@ -332,9 +395,7 @@ class StreamingModule(nn.Module):
         method stores cache metadata alongside the streaming statistics so stale
         caches can be detected on future loads.
         """
-        if self.tile_cache_fname is None:
-            self.tile_cache_fname = self._default_tile_cache_fname()
-        write_path = Path(self.tile_cache_dir) / Path(self.tile_cache_fname)
+        write_path = self._tile_cache_location()
 
         if Path(self.tile_cache_dir).exists():
             if write_path.exists() and not overwrite:
@@ -371,10 +432,7 @@ class StreamingModule(nn.Module):
         recomputation.
         """
 
-        if self.tile_cache_fname is None:
-            self.tile_cache_fname = self._default_tile_cache_fname()
-
-        tile_cache_loc = Path(self.tile_cache_dir) / Path(self.tile_cache_fname)
+        tile_cache_loc = self._tile_cache_location()
 
         if tile_cache_loc.exists() and use_tile_cache:
             print("Loading tile cache from", tile_cache_loc)

--- a/tests/test_streaming_module_distributed_cache.py
+++ b/tests/test_streaming_module_distributed_cache.py
@@ -1,0 +1,196 @@
+import importlib.util
+import sys
+import types
+from pathlib import Path
+
+import pytest
+import torch.nn as nn
+
+
+def _load_streaming_module():
+    module_path = (
+        Path(__file__).resolve().parents[1]
+        / "lightstream"
+        / "modules"
+        / "streaming.py"
+    )
+    stub_names = [
+        "lightstream",
+        "lightstream.core",
+        "lightstream.core.constructor",
+        "lightstream.core.reducer",
+    ]
+    previous_modules = {name: sys.modules.get(name) for name in stub_names}
+
+    lightstream = types.ModuleType("lightstream")
+    lightstream.__path__ = []
+    lightstream_core = types.ModuleType("lightstream.core")
+    lightstream_core.__path__ = []
+    constructor_module = types.ModuleType("lightstream.core.constructor")
+    constructor_module.StreamingConstructor = None
+    reducer_module = types.ModuleType("lightstream.core.reducer")
+    reducer_module.BaseReducer = nn.Module
+
+    sys.modules["lightstream"] = lightstream
+    sys.modules["lightstream.core"] = lightstream_core
+    sys.modules["lightstream.core.constructor"] = constructor_module
+    sys.modules["lightstream.core.reducer"] = reducer_module
+
+    try:
+        spec = importlib.util.spec_from_file_location(
+            "_streaming_module_under_test",
+            module_path,
+        )
+        module = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(module)
+    finally:
+        for name, previous_module in previous_modules.items():
+            if previous_module is None:
+                sys.modules.pop(name, None)
+            else:
+                sys.modules[name] = previous_module
+
+    return module
+
+
+streaming_module = _load_streaming_module()
+StreamingModule = streaming_module.StreamingModule
+
+
+class DummyPreparedNetwork:
+    def get_tile_cache(self):
+        return {"computed": True}
+
+
+class DummyConstructor:
+    calls = []
+
+    def __init__(self, stream_network, tile_size, tile_cache=None, **kwargs):
+        self.copy_to_gpu = kwargs.get("copy_to_gpu", False)
+        self.tile_cache = tile_cache
+        DummyConstructor.calls.append(
+            {
+                "stream_network": stream_network,
+                "tile_size": tile_size,
+                "tile_cache": tile_cache,
+                "kwargs": kwargs,
+            }
+        )
+
+    def prepare_streaming_model(self):
+        return DummyPreparedNetwork()
+
+
+@pytest.fixture(autouse=True)
+def _reset_dummy_constructor(monkeypatch):
+    DummyConstructor.calls = []
+    monkeypatch.setattr(streaming_module, "StreamingConstructor", DummyConstructor)
+    monkeypatch.setattr(
+        StreamingModule,
+        "build_tile_cache_metadata",
+        lambda self, stream_network: {},
+    )
+
+
+def test_distributed_rank_zero_computes_and_saves_missing_cache(monkeypatch, tmp_path):
+    saves = []
+    barriers = []
+
+    monkeypatch.setattr(StreamingModule, "load_tile_cache_if_needed", lambda self: None)
+    monkeypatch.setattr(
+        StreamingModule,
+        "save_tile_cache_if_needed",
+        lambda self, overwrite=False: saves.append(overwrite),
+    )
+    monkeypatch.setattr(StreamingModule, "_distributed_is_initialized", staticmethod(lambda: True))
+    monkeypatch.setattr(StreamingModule, "_distributed_world_size", staticmethod(lambda: 2))
+    monkeypatch.setattr(StreamingModule, "_distributed_rank", staticmethod(lambda: 0))
+    monkeypatch.setattr(
+        StreamingModule,
+        "_distributed_barrier",
+        staticmethod(lambda: barriers.append("barrier")),
+    )
+
+    StreamingModule(nn.Identity(), 8, tile_cache_path=tmp_path / "cache", copy_to_gpu=True)
+
+    assert [call["tile_cache"] for call in DummyConstructor.calls] == [None]
+    assert DummyConstructor.calls[0]["kwargs"] == {"copy_to_gpu": True}
+    assert saves == [False]
+    assert barriers == ["barrier"]
+
+
+def test_distributed_rank_zero_overwrites_stale_cache(monkeypatch, tmp_path):
+    saves = []
+    barriers = []
+
+    def load_stale_cache(self):
+        self._tile_cache_was_ignored = True
+        return None
+
+    monkeypatch.setattr(StreamingModule, "load_tile_cache_if_needed", load_stale_cache)
+    monkeypatch.setattr(
+        StreamingModule,
+        "save_tile_cache_if_needed",
+        lambda self, overwrite=False: saves.append(overwrite),
+    )
+    monkeypatch.setattr(StreamingModule, "_distributed_is_initialized", staticmethod(lambda: True))
+    monkeypatch.setattr(StreamingModule, "_distributed_world_size", staticmethod(lambda: 2))
+    monkeypatch.setattr(StreamingModule, "_distributed_rank", staticmethod(lambda: 0))
+    monkeypatch.setattr(
+        StreamingModule,
+        "_distributed_barrier",
+        staticmethod(lambda: barriers.append("barrier")),
+    )
+
+    StreamingModule(nn.Identity(), 8, tile_cache_path=tmp_path / "cache")
+
+    assert [call["tile_cache"] for call in DummyConstructor.calls] == [None]
+    assert saves == [True]
+    assert barriers == ["barrier"]
+
+
+def test_distributed_nonzero_rank_waits_then_loads_cache(monkeypatch, tmp_path):
+    loads = iter([None, {"cached": True}])
+    saves = []
+    barriers = []
+
+    monkeypatch.setattr(StreamingModule, "load_tile_cache_if_needed", lambda self: next(loads))
+    monkeypatch.setattr(
+        StreamingModule,
+        "save_tile_cache_if_needed",
+        lambda self, overwrite=False: saves.append(overwrite),
+    )
+    monkeypatch.setattr(StreamingModule, "_distributed_is_initialized", staticmethod(lambda: True))
+    monkeypatch.setattr(StreamingModule, "_distributed_world_size", staticmethod(lambda: 2))
+    monkeypatch.setattr(StreamingModule, "_distributed_rank", staticmethod(lambda: 1))
+    monkeypatch.setattr(
+        StreamingModule,
+        "_distributed_barrier",
+        staticmethod(lambda: barriers.append("barrier")),
+    )
+
+    StreamingModule(nn.Identity(), 8, tile_cache_path=tmp_path / "cache")
+
+    assert [call["tile_cache"] for call in DummyConstructor.calls] == [{"cached": True}]
+    assert saves == []
+    assert barriers == ["barrier"]
+
+
+def test_distributed_nonzero_rank_errors_when_cache_missing_after_barrier(monkeypatch, tmp_path):
+    cache_path = tmp_path / "cache"
+
+    monkeypatch.setattr(StreamingModule, "load_tile_cache_if_needed", lambda self: None)
+    monkeypatch.setattr(
+        StreamingModule,
+        "save_tile_cache_if_needed",
+        lambda self, overwrite=False: None,
+    )
+    monkeypatch.setattr(StreamingModule, "_distributed_is_initialized", staticmethod(lambda: True))
+    monkeypatch.setattr(StreamingModule, "_distributed_world_size", staticmethod(lambda: 2))
+    monkeypatch.setattr(StreamingModule, "_distributed_rank", staticmethod(lambda: 1))
+    monkeypatch.setattr(StreamingModule, "_distributed_barrier", staticmethod(lambda: None))
+
+    with pytest.raises(RuntimeError, match=f"Rank 1.*Expected cache path: {cache_path}"):
+        StreamingModule(nn.Identity(), 8, tile_cache_path=cache_path)
+
+    assert DummyConstructor.calls == []


### PR DESCRIPTION
### Motivation
- Ensure only a single distributed rank (rank 0) computes and writes a missing or stale tile cache to avoid duplicated work and race conditions. 
- Allow nonzero ranks to wait for rank 0 to finish cache creation and then reuse the saved cache so they skip expensive recomputation. 
- Preserve single-process behavior and the existing fast path when a valid cache already exists. 

### Description
- Added distributed helper methods `._distributed_is_initialized()`, `._distributed_rank()`, `._distributed_world_size()`, and `._distributed_barrier()` to encapsulate `torch.distributed` checks and synchronization. 
- Refactored model initialization to use a helper `._prepare_streaming_model(...)` and added `._tile_cache_location()` for a single canonical cache path used by save/load and error messages. 
- Updated `StreamingModule.__init__` to keep the initial `load_tile_cache_if_needed()` fast path, and when no cache exists and a distributed job has `world_size > 1`, have rank 0 compute and save the cache, call a barrier, and have nonzero ranks reload the cache and error with an explicit message (including expected path) if loading fails. 
- Kept metadata-based stale-cache detection so rank 0 will overwrite stale caches while other ranks reuse the new cache after the barrier. 

### Testing
- Ran `pytest -q tests/test_streaming_module_distributed_cache.py`, which exercised rank-zero creation, stale-cache overwrite by rank zero, nonzero-rank reload after barrier, and post-barrier failure behavior, and all tests passed. 
- Ran `python -m py_compile lightstream/modules/streaming.py tests/test_streaming_module_distributed_cache.py` to validate syntax, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1c9c8ab5c483309803e13535f81dcd)