### PR TITLE
Protect distributed tile cache generation with lock

### DIFF
--- a/lightstream/modules/streaming.py
+++ b/lightstream/modules/streaming.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
 import copy
+import fcntl
+from contextlib import contextmanager
 from pathlib import Path
 
 import torch
@@ -83,8 +85,13 @@ class StreamingModule(nn.Module):
         elif self._distributed_is_initialized() and self._distributed_world_size() > 1:
             rank = self._distributed_rank()
             if rank == 0:
-                self._prepare_streaming_model(stream_network, tile_cache=None, **kwargs)
-                self.save_tile_cache_if_needed(overwrite=self._tile_cache_was_ignored)
+                with self._exclusive_tile_cache_lock():
+                    tile_cache = self.load_tile_cache_if_needed()
+                    if tile_cache is not None:
+                        self._prepare_streaming_model(stream_network, tile_cache, **kwargs)
+                    else:
+                        self._prepare_streaming_model(stream_network, tile_cache=None, **kwargs)
+                        self.save_tile_cache_if_needed(overwrite=self._tile_cache_was_ignored)
 
             self._distributed_barrier()
 
@@ -147,6 +154,21 @@ class StreamingModule(nn.Module):
         if self.tile_cache_fname is None:
             self.tile_cache_fname = self._default_tile_cache_fname()
         return Path(self.tile_cache_dir) / Path(self.tile_cache_fname)
+
+    def _tile_cache_lock_location(self) -> Path:
+        """Return the filesystem lock path associated with the tile cache file."""
+        return Path(str(self._tile_cache_location()) + ".lock")
+
+    @contextmanager
+    def _exclusive_tile_cache_lock(self):
+        """Hold an exclusive filesystem lock for cache generation."""
+        lock_path = self._tile_cache_lock_location()
+        with open(lock_path, "a", encoding="utf-8") as lock_file:
+            fcntl.flock(lock_file, fcntl.LOCK_EX)
+            try:
+                yield
+            finally:
+                fcntl.flock(lock_file, fcntl.LOCK_UN)
 
     def _default_tile_cache_fname(self) -> str:
         """Return the default cache file name for the configured tile size.

--- a/tests/test_streaming_module_distributed_cache.py
+++ b/tests/test_streaming_module_distributed_cache.py
@@ -149,6 +149,51 @@ def test_distributed_rank_zero_overwrites_stale_cache(monkeypatch, tmp_path):
     assert barriers == ["barrier"]
 
 
+def test_distributed_rank_zero_reloads_cache_after_lock(monkeypatch, tmp_path):
+    loads = iter([None, {"cached": True}])
+    saves = []
+    barriers = []
+    lock_events = []
+
+    class RecordingLock:
+        def __enter__(self):
+            lock_events.append("acquire")
+
+        def __exit__(self, exc_type, exc, tb):
+            lock_events.append("release")
+
+    monkeypatch.setattr(StreamingModule, "load_tile_cache_if_needed", lambda self: next(loads))
+    monkeypatch.setattr(
+        StreamingModule,
+        "save_tile_cache_if_needed",
+        lambda self, overwrite=False: saves.append(overwrite),
+    )
+    monkeypatch.setattr(StreamingModule, "_exclusive_tile_cache_lock", lambda self: RecordingLock())
+    monkeypatch.setattr(StreamingModule, "_distributed_is_initialized", staticmethod(lambda: True))
+    monkeypatch.setattr(StreamingModule, "_distributed_world_size", staticmethod(lambda: 2))
+    monkeypatch.setattr(StreamingModule, "_distributed_rank", staticmethod(lambda: 0))
+    monkeypatch.setattr(
+        StreamingModule,
+        "_distributed_barrier",
+        staticmethod(lambda: barriers.append("barrier")),
+    )
+
+    StreamingModule(nn.Identity(), 8, tile_cache_path=tmp_path / "cache")
+
+    assert [call["tile_cache"] for call in DummyConstructor.calls] == [{"cached": True}]
+    assert saves == []
+    assert lock_events == ["acquire", "release"]
+    assert barriers == ["barrier"]
+
+
+def test_tile_cache_lock_path_is_next_to_cache_file(tmp_path):
+    module = StreamingModule.__new__(StreamingModule)
+    module.tile_cache_dir = tmp_path
+    module.tile_cache_fname = "cache"
+
+    assert module._tile_cache_lock_location() == tmp_path / "cache.lock"
+
+
 def test_distributed_nonzero_rank_waits_then_loads_cache(monkeypatch, tmp_path):
     loads = iter([None, {"cached": True}])
     saves = []


### PR DESCRIPTION
### Motivation
- Prevent multiple distributed rank-0 processes from concurrently generating and writing the same tile cache which can lead to wasted work or races. 
- Ensure rank 0 re-checks for a cache created by another process before expensive SCNN statistics generation. 

### Description
- Add an exclusive filesystem lock next to the cache file (`<tile_cache_path>.lock`) using `fcntl.flock` and a context manager exposed as `_exclusive_tile_cache_lock`. 
- Wrap the rank-zero cache-generation section so rank 0 acquires the lock, calls `load_tile_cache_if_needed()` again, and skips statistics generation when a compatible cache is found; otherwise it generates and saves the cache while holding the lock. 
- Add `_tile_cache_lock_location()` helper to derive the lock path and two unit tests `test_distributed_rank_zero_reloads_cache_after_lock` and `test_tile_cache_lock_path_is_next_to_cache_file` to exercise the new behavior. 

### Testing
- Ran `pytest tests/test_streaming_module_distributed_cache.py` which passed (`6 passed`).
- Verified `git diff --check` and local file diffs for the change. 
- Attempting to run the full `pytest` collection failed due to missing runtime/dev dependencies in the environment (e.g. `numpy` and `lightning`), so the entire test suite was not executed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1ca155fda4833091839c987ffe62cd)