### PR TITLE
Implement fused attention GeM streaming alignment

### DIFF
--- a/lightstream/core/reducer/fused_attention_gem.py
+++ b/lightstream/core/reducer/fused_attention_gem.py
@@ -81,9 +81,10 @@ class FusedAttentionGeMReducer(BaseReducer):
         logits = _normalize_three_logits(logits1, logits2, logits3, y1)
 
         if self._streaming_passthrough:
-            self._last_inputs = (y1, y2, y3, logits1, logits2, logits3)
-            self._last_output = y1
-            return (y1, y2, y3, logits1, logits2, logits3)
+            passthrough = tuple(t.view_as(t) for t in (y1, y2, y3, *logits))
+            self._last_inputs = passthrough
+            self._last_output = passthrough[0]
+            return passthrough
 
         acc_dtype = resolve_accumulator_dtype(self.accumulator_dtype, y1.dtype)
         vw = self.value_weights.to(device=y1.device, dtype=acc_dtype)
@@ -168,10 +169,11 @@ class StreamingFusedAttentionGeMReducer(BaseStreamingGlobalReducer):
         mask: torch.Tensor | None = None,
     ) -> tuple[torch.Tensor, ...]:
         _validate_value_maps(y1, y2, y3)
-        _normalize_three_logits(logits1, logits2, logits3, y1)
-        self._last_inputs = (y1, y2, y3, logits1, logits2, logits3)
-        self._last_output = y1
-        return (y1, y2, y3, logits1, logits2, logits3)
+        logits = _normalize_three_logits(logits1, logits2, logits3, y1)
+        passthrough = tuple(t.view_as(t) for t in (y1, y2, y3, *logits))
+        self._last_inputs = passthrough
+        self._last_output = passthrough[0]
+        return passthrough
 
     def accumulate_stream_tile(self, trimmed_output, tile_y: int, tile_x: int, sides, dst_box, user_mask: torch.Tensor | None = None):
         payload = self._parse_multi_input_payload(trimmed_output)
@@ -278,6 +280,9 @@ class StreamingFusedAttentionGeMReducer(BaseStreamingGlobalReducer):
         r = self.current_r.to(device=self.running_shat.device, dtype=acc_dtype)
         aw = self.attention_weights.to(device=self.running_shat.device, dtype=acc_dtype)
         branch_means = self.running_shat.to(dtype=acc_dtype) / self.running_zhat.to(dtype=acc_dtype).clamp_min(self.eps)
+        # Sum_j attention_weights[j] * E_{softmax(att_j)}[fused_y ** r],
+        # which is equivalent to GeM over fused_y weighted by
+        # fused_a = sum_j attention_weights[j] * softmax(att_j).
         weighted_mean = (branch_means * aw.view(1, 3, 1, 1, 1)).sum(dim=1)
         output_dtype = self._stream_output_dtype or self.running_shat.dtype
         return weighted_mean.clamp_min(self.eps).pow(1.0 / r).to(dtype=output_dtype)

--- a/lightstream/core/scnn/scnn.py
+++ b/lightstream/core/scnn/scnn.py
@@ -604,7 +604,9 @@ class StreamingCNN(torch.nn.Module):
         if self._reducer_head_map or not self._streaming_reducers:
             return
 
-        output_id_to_index = {id(tensor): idx for idx, tensor in enumerate(flat_outputs)}
+        output_id_to_index = {}
+        for idx, tensor in enumerate(flat_outputs):
+            output_id_to_index.setdefault(id(tensor), idx)
         for reducer in self._streaming_reducers:
             reducer_inputs = getattr(reducer, "_last_inputs", None)
             if reducer_inputs is not None:
@@ -883,11 +885,85 @@ class StreamingCNN(torch.nn.Module):
         trimmed_output = self._trim_head_output(head_output, head_lost)
         return head_lost, output_loc, trimmed_output
 
+    def _build_common_aligned_reducer_payload(
+        self,
+        *,
+        head_idx,
+        tile_outputs,
+        ordered_indices,
+        tile_input_y,
+        tile_input_x,
+        sides,
+    ):
+        if not ordered_indices or ordered_indices[0] != head_idx:
+            raise RuntimeError(f"Reducer head {head_idx} input index order mismatch: indices={ordered_indices}")
+
+        payload_entries = []
+        previous_idx = -1
+        for reducer_input_idx in ordered_indices:
+            if reducer_input_idx <= previous_idx or reducer_input_idx >= len(tile_outputs):
+                raise RuntimeError(
+                    f"Reducer head {head_idx} input index order mismatch: "
+                    f"indices={ordered_indices} over outputs={len(tile_outputs)}"
+                )
+            previous_idx = reducer_input_idx
+            _, input_loc, input_trimmed = self._build_stitched_tile_output(
+                head_idx=reducer_input_idx,
+                head_output=tile_outputs[reducer_input_idx],
+                tile_input_y=tile_input_y,
+                tile_input_x=tile_input_x,
+                sides=sides,
+            )
+            if input_trimmed.ndim != 4:
+                raise RuntimeError(
+                    f"Reducer head {head_idx} tile input {reducer_input_idx} must be NCHW, "
+                    f"got {tuple(input_trimmed.shape)}"
+                )
+            payload_entries.append((reducer_input_idx, input_loc, input_trimmed))
+
+        common_y0 = max(int(loc.y) for _, loc, _ in payload_entries)
+        common_x0 = max(int(loc.x) for _, loc, _ in payload_entries)
+        common_y1 = min(int(loc.y) + int(tensor.shape[H_DIM]) for _, loc, tensor in payload_entries)
+        common_x1 = min(int(loc.x) + int(tensor.shape[W_DIM]) for _, loc, tensor in payload_entries)
+        if common_y1 <= common_y0 or common_x1 <= common_x0:
+            boxes = [
+                (idx, int(loc.y), int(loc.y) + int(tensor.shape[H_DIM]), int(loc.x), int(loc.x) + int(tensor.shape[W_DIM]))
+                for idx, loc, tensor in payload_entries
+            ]
+            raise RuntimeError(f"Reducer head {head_idx} inputs have no common valid intersection: boxes={boxes}")
+
+        cropped_payload = []
+        ref_batch = None
+        common_h = common_y1 - common_y0
+        common_w = common_x1 - common_x0
+        for input_pos, (reducer_input_idx, input_loc, input_trimmed) in enumerate(payload_entries):
+            if ref_batch is None:
+                ref_batch = input_trimmed.shape[B_DIM]
+            elif input_trimmed.shape[B_DIM] != ref_batch:
+                raise RuntimeError(
+                    f"Reducer head {head_idx} tile input batch mismatch at position {input_pos}: "
+                    f"expected N={ref_batch}, got shape={tuple(input_trimmed.shape)}"
+                )
+            src_y0 = common_y0 - int(input_loc.y)
+            src_y1 = src_y0 + common_h
+            src_x0 = common_x0 - int(input_loc.x)
+            src_x1 = src_x0 + common_w
+            cropped = input_trimmed[:, :, src_y0:src_y1, src_x0:src_x1]
+            if cropped.shape[H_DIM] != common_h or cropped.shape[W_DIM] != common_w:
+                raise RuntimeError(
+                    f"Reducer head {head_idx} common crop failed for input {reducer_input_idx}: "
+                    f"crop={tuple(cropped.shape)} expected spatial=({common_h}, {common_w})"
+                )
+            cropped_payload.append(cropped)
+
+        common_loc = Box(common_y0, -1, common_x0, -1, sides)
+        return cropped_payload, common_loc, (common_y0, common_y1, common_x0, common_x1)
+
     def _accumulate_reducer_forward_tile(
         self,
         head_idx,
         trimmed_payload,
-        output_loc,
+        dst_box,
         tile_input_y,
         tile_input_x,
         sides,
@@ -901,13 +977,10 @@ class StreamingCNN(torch.nn.Module):
                 raise RuntimeError(f"Reducer head {head_idx} tile input {i} must be NCHW, got {tuple(t.shape)}")
             if t.shape[0] != ref.shape[0] or t.shape[H_DIM] != ref.shape[H_DIM] or t.shape[W_DIM] != ref.shape[W_DIM]:
                 raise RuntimeError(
-                    f"Reducer head {head_idx} tile input spatial mismatch after trimming: "
+                    f"Reducer head {head_idx} tile input spatial mismatch after common crop: "
                     f"input0={tuple(ref.shape)} input{i}={tuple(t.shape)}; expected same [N,*,H,W]."
                 )
-        dst_y0 = int(output_loc.y)
-        dst_y1 = int(output_loc.y + ref.shape[H_DIM])
-        dst_x0 = int(output_loc.x)
-        dst_x1 = int(output_loc.x + ref.shape[W_DIM])
+        dst_y0, dst_y1, dst_x0, dst_x1 = (int(v) for v in dst_box)
         payload = trimmed_payload[0] if len(trimmed_payload) == 1 else tuple(trimmed_payload)
         tile_mask = self._slice_reducer_mask(
             user_mask,
@@ -944,28 +1017,18 @@ class StreamingCNN(torch.nn.Module):
                 expected_indices = self._reducer_input_indices.get(head_idx, (head_idx,))
                 if expected_indices[0] != head_idx:
                     continue
-                reducer_payload = [trimmed_output]
-                for extra_idx in expected_indices[1:]:
-                    if extra_idx <= head_idx or extra_idx >= len(tile_outputs):
-                        raise RuntimeError(
-                            f"Reducer head {head_idx} input index order mismatch: indices={expected_indices} over outputs={len(tile_outputs)}"
-                        )
-                    _, extra_loc, extra_trimmed = self._build_stitched_tile_output(
-                        head_idx=extra_idx,
-                        head_output=tile_outputs[extra_idx],
-                        tile_input_y=tile_input_y,
-                        tile_input_x=tile_input_x,
-                        sides=sides,
-                    )
-                    if extra_loc.y != output_loc.y or extra_loc.x != output_loc.x:
-                        raise RuntimeError(
-                            f"Reducer head {head_idx} input alignment mismatch: base=({output_loc.y},{output_loc.x}) vs input[{extra_idx}]=({extra_loc.y},{extra_loc.x})"
-                        )
-                    reducer_payload.append(extra_trimmed)
+                reducer_payload, _common_loc, common_dst_box = self._build_common_aligned_reducer_payload(
+                    head_idx=head_idx,
+                    tile_outputs=tile_outputs,
+                    ordered_indices=expected_indices,
+                    tile_input_y=tile_input_y,
+                    tile_input_x=tile_input_x,
+                    sides=sides,
+                )
                 self._accumulate_reducer_forward_tile(
                     head_idx=head_idx,
                     trimmed_payload=reducer_payload,
-                    output_loc=output_loc,
+                    dst_box=common_dst_box,
                     tile_input_y=tile_input_y,
                     tile_input_x=tile_input_x,
                     sides=sides,
@@ -1385,47 +1448,38 @@ class StreamingCNN(torch.nn.Module):
         output_x,
     ):
         reducer = self._reducer_head_map[head_idx]
+        ordered_indices = self._reducer_input_indices.get(head_idx, (head_idx,))
+        if len(ordered_indices) == 1:
+            payload = trimmed_output
+            common_dst_box = (
+                int(output_y),
+                int(output_y + trimmed_output.shape[H_DIM]),
+                int(output_x),
+                int(output_x + trimmed_output.shape[W_DIM]),
+            )
+        else:
+            trimmed_payload, _common_loc, common_dst_box = self._build_common_aligned_reducer_payload(
+                head_idx=head_idx,
+                tile_outputs=tile_outputs,
+                ordered_indices=ordered_indices,
+                tile_input_y=tile_input_y,
+                tile_input_x=tile_input_x,
+                sides=sides,
+            )
+            payload = tuple(t.to(self.device, non_blocking=True) for t in trimmed_payload)
+
+        dst_y0, dst_y1, dst_x0, dst_x1 = common_dst_box
+        ref = payload[0] if isinstance(payload, (tuple, list)) else payload
         valid_mask = self._slice_reducer_mask(
             self._active_reducer_mask,
-            output_y,
-            output_y + trimmed_output.shape[H_DIM],
-            output_x,
-            output_x + trimmed_output.shape[W_DIM],
+            dst_y0,
+            dst_y1,
+            dst_x0,
+            dst_x1,
             context=f"backward reducer head {head_idx}",
-            expected_shape=(trimmed_output.shape[H_DIM], trimmed_output.shape[W_DIM]),
+            expected_shape=(ref.shape[H_DIM], ref.shape[W_DIM]),
         )
 
-        ordered_indices = self._reducer_input_indices.get(head_idx, (head_idx,))
-        payload = trimmed_output
-        if len(ordered_indices) > 1:
-            trimmed_payload = []
-            for pos, reducer_input_idx in enumerate(ordered_indices):
-                if reducer_input_idx < len(tile_outputs):
-                    source = tile_outputs[reducer_input_idx]
-                    lost_idx = reducer_input_idx
-                else:
-                    reducer_last_inputs = getattr(reducer, "_last_inputs", None)
-                    if not isinstance(reducer_last_inputs, (tuple, list)) or pos >= len(reducer_last_inputs):
-                        raise RuntimeError(
-                            f"Reducer head {head_idx} backward payload index {reducer_input_idx} is unavailable "
-                            f"(tile_outputs={len(tile_outputs)}; has_last_inputs={isinstance(reducer_last_inputs, (tuple, list))})."
-                        )
-                    source = reducer_last_inputs[pos]
-                    lost_idx = ordered_indices[0]
-                in_lost = self._get_tile_lost_for_sides(sides, self._tile_output_lost[lost_idx])
-                in_trimmed = self._trim_head_output(source, in_lost).to(self.device, non_blocking=True)
-                if pos == 0:
-                    ref_shape = (in_trimmed.shape[0], in_trimmed.shape[H_DIM], in_trimmed.shape[W_DIM])
-                elif (in_trimmed.shape[0], in_trimmed.shape[H_DIM], in_trimmed.shape[W_DIM]) != ref_shape:
-                    if in_trimmed.shape[0] == ref_shape[0] and in_trimmed.shape[H_DIM] >= ref_shape[1] and in_trimmed.shape[W_DIM] >= ref_shape[2]:
-                        in_trimmed = in_trimmed[:, :, : ref_shape[1], : ref_shape[2]]
-                    else:
-                        raise RuntimeError(
-                            f"Reducer head {head_idx} backward payload shape mismatch at position {pos}: "
-                            f"expected [N,*,H,W]={ref_shape}, got {tuple(in_trimmed.shape)}"
-                        )
-                trimmed_payload.append(in_trimmed)
-            payload = tuple(trimmed_payload)
         reduced_output, reduced_grad = reducer.build_backward_pair(
             payload,
             gradient,

--- a/lightstream/models/segment/model.py
+++ b/lightstream/models/segment/model.py
@@ -75,7 +75,12 @@ class WSS(nn.Module):
         att2 = self.att2(x2)
         att3 = self.att3(x3)
 
-        return self.red1(y1, att1, mask=mask), self.red2(y2, att2, mask=mask), self.red3(y3, att3, mask=mask), self.red4(y1,y2,y3,att1,att2,att3,mask=mask)
+        return (
+            self.red1(y1, att1, mask=mask),
+            self.red2(y2, att2, mask=mask),
+            self.red3(y3, att3, mask=mask),
+            self.red4(y1, y2, y3, att1, att2, att3, mask=mask),
+        )
 
 if __name__ == "__main__":
     print(" is cuda available? ", torch.cuda.is_available())


### PR DESCRIPTION
### Motivation
- Ensure multi-input reducer payloads (e.g. fused attention GeM) are spatially aligned across inputs so forward streaming accumulation and backward replay operate on the same destination-space rectangle.
- Preserve explicit multi-input reducer API (six-input fused reducer) so alignment and mask slicing remain correct and transparent to callers.
- Make the streaming fused-attention GeM math deterministic and consistent between streaming accumulation and finalization (branch-wise softmax accumulation, attention-weighted mixture, then GeM root).

### Description
- Add `_build_common_aligned_reducer_payload` in `lightstream/core/scnn/scnn.py` to compute the common destination-space intersection across all reducer inputs, crop each input to that common rectangle, and return the cropped payload plus the common dst-box.
- Wire the common-crop helper into forward accumulation and backward replay by updating `_stitch_forward_outputs`, `_accumulate_reducer_forward_tile`, and `_build_reducer_backward_pair` to use the cropped payload and the common destination box, and to slice reducer masks from that common crop.
- Update reducer identity resolution in `StreamingCNN._resolve_reducer_head_map` to deterministically prefer the first flattened-output occurrence when mapping reducer inputs/outputs.
- In `lightstream/core/reducer/fused_attention_gem.py` normalize the passthrough outputs used for streaming: return shape-normalized view tensors, set `_last_inputs` and `_last_output` to the exact tensors returned, and keep three separate streaming softmax branches (`running_m`, `running_zhat`, `running_shat`).
- Finalization math in `StreamingFusedAttentionGeMReducer.finalize_from_state` explicitly forms branch means, computes the attention-weighted branch mixture, and applies the GeM root; `reduce_tile_for_backward` mirrors the same branch-wise math for correct backward replay.
- Keep model call site in `lightstream/models/segment/model.py` using the six-input signature `self.red4(y1, y2, y3, att1, att2, att3, mask=mask)` and wrap its return as a tuple for consistency.

### Testing
- Compiled modified files successfully with `python -m py_compile lightstream/core/scnn/scnn.py lightstream/core/reducer/fused_attention_gem.py lightstream/models/segment/model.py`.
- Attempted to run the streaming reducer unit tests (`pytest` subset) that exercise fused attention GeM forward/backward parity, but test collection failed in the environment with `ModuleNotFoundError: No module named 'lightning'`, so full pytest verification was blocked by a missing test dependency in the execution environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1df5e8932c8330be7cb303ea781ec7)