### PR TITLE
Add public StreamingEngine API and compiled plan/session state

### DIFF
--- a/lightstream/core/engine/__init__.py
+++ b/lightstream/core/engine/__init__.py
@@ -1,5 +1,21 @@
 """Streaming engine package."""
-from .config import BackwardContext, ForwardContext, StreamingConfig, TileSpec
+from .config import BackwardContext, CompiledPlan, ForwardContext, StreamingConfig, TileSpec
 from .scnn import StreamingCNN
 
-__all__ = ["BackwardContext", "ForwardContext", "StreamingCNN", "StreamingConfig", "TileSpec"]
+__all__ = [
+    "BackwardContext",
+    "CompiledPlan",
+    "ForwardContext",
+    "StreamingCNN",
+    "StreamingConfig",
+    "StreamingEngine",
+    "TileSpec",
+]
+
+
+def __getattr__(name):
+    if name == "StreamingEngine":
+        from .api import StreamingEngine
+
+        return StreamingEngine
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/lightstream/core/engine/api.py
+++ b/lightstream/core/engine/api.py
@@ -1,0 +1,125 @@
+"""Public streaming engine API."""
+from __future__ import annotations
+
+from typing import Any
+
+import torch
+import torch.nn as nn
+
+from lightstream.core.constructor import StreamingConstructor
+
+from .config import CompiledPlan, StreamingConfig
+
+
+class StreamingEngine:
+    """Compile and execute a model with tiled streaming semantics.
+
+    Example
+    -------
+    >>> config = StreamingConfig(tile_shape=(1, 3, 512, 512))
+    >>> engine = StreamingEngine(model, config)
+    >>> engine.compile()
+    >>> y = engine.forward(image, mask=mask)
+    >>> engine.backward(image, grad, mask=mask)
+    """
+
+    def __init__(self, model: nn.Module, config: StreamingConfig):
+        self.model = model
+        self.config = config
+        self.constructor: StreamingConstructor | None = None
+        self.plan: CompiledPlan | None = None
+
+    @property
+    def stream_network(self) -> nn.Module | None:
+        """Return the compiled streaming network, if compilation has run."""
+        return None if self.plan is None else self.plan.stream_network
+
+    def compile(self, input_spec: Any = None, cache: dict | None = None) -> CompiledPlan:
+        """Compile the wrapped model into a streaming execution plan.
+
+        Parameters
+        ----------
+        input_spec : Any, optional
+            Reserved for future shape-aware compilation. The current engine uses
+            ``config.tile_shape`` as the tile input specification.
+        cache : dict, optional
+            Tile cache previously produced by :meth:`get_tile_cache` or
+            :meth:`state_dict`.
+        """
+        del input_spec
+        tile_shape = self.config.tile_shape
+        if len(tile_shape) != 4:
+            raise ValueError(f"StreamingConfig.tile_shape must be an NCHW tuple, got {tile_shape!r}")
+        if tile_shape[2] != tile_shape[3]:
+            raise ValueError("StreamingEngine currently requires square spatial tiles")
+
+        self.constructor = StreamingConstructor(
+            self.model,
+            tile_size=int(tile_shape[2]),
+            verbose=self.config.verbose,
+            deterministic=self.config.deterministic,
+            saliency=self.config.saliency,
+            copy_to_gpu=self.config.copy_to_gpu,
+            statistics_on_cpu=self.config.statistics_on_cpu,
+            normalize_on_gpu=self.config.normalize_on_gpu,
+            mean=self.config.mean,
+            std=self.config.std,
+            tile_cache=cache,
+            add_keep_modules=self.config.add_keep_modules,
+            before_streaming_init_callbacks=self.config.before_streaming_init_callbacks,
+            after_streaming_init_callbacks=self.config.after_streaming_init_callbacks,
+        )
+        stream_network = self.constructor.prepare_streaming_model()
+        self.plan = stream_network.compiled_plan
+        self.plan.stream_network = stream_network
+        return self.plan
+
+    def _require_stream_network(self) -> nn.Module:
+        stream_network = self.stream_network
+        if stream_network is None:
+            raise RuntimeError("StreamingEngine.compile() must be called before execution")
+        return stream_network
+
+    def forward(self, image: torch.Tensor, *, mask: torch.Tensor | None = None, result_device=None):
+        """Run a streaming forward pass."""
+        stream_network = self._require_stream_network()
+        result_on_cpu = result_device is not None and torch.device(result_device).type == "cpu"
+        output = stream_network.forward(image, result_on_cpu=result_on_cpu, mask=mask)
+        if result_device is None or result_on_cpu:
+            return output
+        return self._move_output(output, torch.device(result_device))
+
+    def backward(self, image: torch.Tensor, grad, *, mask: torch.Tensor | None = None) -> None:
+        """Run a streaming backward pass."""
+        self._require_stream_network().backward(image, grad, mask=mask)
+
+    def get_tile_cache(self) -> dict:
+        """Return the compiled tile-cache state."""
+        return self._require_stream_network().get_tile_cache()
+
+    def load_tile_cache(self, state: dict) -> None:
+        """Load tile-cache state into an already compiled engine."""
+        self._require_stream_network().load_tile_cache(state)
+
+    def state_dict(self) -> dict:
+        """Alias for :meth:`get_tile_cache` for cache-oriented lifecycle usage."""
+        return self.get_tile_cache()
+
+    def load_state_dict(self, state: dict) -> None:
+        """Alias for :meth:`load_tile_cache`."""
+        self.load_tile_cache(state)
+
+    @classmethod
+    def _move_output(cls, output, device: torch.device):
+        if isinstance(output, torch.Tensor):
+            return output.to(device)
+        if isinstance(output, tuple):
+            return tuple(cls._move_output(item, device) for item in output)
+        if isinstance(output, list):
+            return [cls._move_output(item, device) for item in output]
+        if isinstance(output, dict):
+            return {key: cls._move_output(value, device) for key, value in output.items()}
+        return output
+
+
+__all__ = ["CompiledPlan", "StreamingConfig", "StreamingEngine"]

--- a/lightstream/core/engine/config.py
+++ b/lightstream/core/engine/config.py
@@ -1,6 +1,6 @@
 """Shared runtime configuration and tile context types for the streaming engine."""
-from dataclasses import dataclass
-from typing import Any, TypeAlias
+from dataclasses import dataclass, field
+from typing import Any, Callable, Optional, TypeAlias
 
 import torch
 
@@ -20,6 +20,41 @@ class StreamingConfig:
     copy_to_gpu: bool = True
     statistics_on_cpu: bool = False
     normalize_on_gpu: bool = False
+    mean: Optional[tuple[float, float, float]] = None
+    std: Optional[tuple[float, float, float]] = None
+    add_keep_modules: Optional[list[type[torch.nn.Module]]] = None
+    before_streaming_init_callbacks: Optional[list[Callable[..., Any]]] = None
+    after_streaming_init_callbacks: Optional[list[Callable[..., Any]]] = None
+
+
+@dataclass
+class StreamingPlanState:
+    """Mutable statistics captured by compilation and reused by tile execution."""
+
+    tile_output_shape: Any = None
+    tile_output_shapes: Any = None
+    tile_output_lost: Any = None
+    output_stride_per_output: Any = None
+    output_spec: Any = None
+
+
+@dataclass
+class StreamingSessionState:
+    """Mutable state that belongs to a single forward/backward streaming session."""
+
+    reducer_head_map: dict[int, Any] = field(default_factory=dict)
+    reducer_input_indices: dict[int, Any] = field(default_factory=dict)
+    last_forward_tiles: list[Any] = field(default_factory=list)
+    active_reducer_mask: Any = None
+
+
+@dataclass
+class CompiledPlan:
+    """Compiled streaming execution plan and per-session mutable state."""
+
+    stream_network: Any = None
+    plan_state: StreamingPlanState = field(default_factory=StreamingPlanState)
+    session_state: StreamingSessionState = field(default_factory=StreamingSessionState)
 
 
 @dataclass(frozen=True)

--- a/lightstream/core/engine/scnn.py
+++ b/lightstream/core/engine/scnn.py
@@ -11,7 +11,7 @@ from lightstream.core.scnn.streamingconv import StreamingConv2d
 from lightstream.core.scnn.streamingupsample import StreamingUpsample2d
 
 from .backward import BackwardMixin
-from .config import BackwardContext, ForwardContext, StreamingConfig, TileSpec
+from .config import BackwardContext, CompiledPlan, ForwardContext, StreamingConfig, TileSpec
 from .conversion import ConversionMixin
 from .forward import ForwardMixin
 from .planner import PlannerMixin
@@ -84,6 +84,7 @@ class StreamingCNN(
 
         self.should_normalize = normalize_on_gpu
 
+        self.compiled_plan = CompiledPlan(stream_network=self)
         self._tile_output_shape = None
         self._tile_output_shapes = None
         self._tile_output_lost = None
@@ -104,6 +105,79 @@ class StreamingCNN(
             self._configure()
         else:
             self.load_tile_cache(state_dict)
+
+
+    @property
+    def _tile_output_shape(self):
+        return self.compiled_plan.plan_state.tile_output_shape
+
+    @_tile_output_shape.setter
+    def _tile_output_shape(self, value):
+        self.compiled_plan.plan_state.tile_output_shape = value
+
+    @property
+    def _tile_output_shapes(self):
+        return self.compiled_plan.plan_state.tile_output_shapes
+
+    @_tile_output_shapes.setter
+    def _tile_output_shapes(self, value):
+        self.compiled_plan.plan_state.tile_output_shapes = value
+
+    @property
+    def _tile_output_lost(self):
+        return self.compiled_plan.plan_state.tile_output_lost
+
+    @_tile_output_lost.setter
+    def _tile_output_lost(self, value):
+        self.compiled_plan.plan_state.tile_output_lost = value
+
+    @property
+    def _output_stride_per_output(self):
+        return self.compiled_plan.plan_state.output_stride_per_output
+
+    @_output_stride_per_output.setter
+    def _output_stride_per_output(self, value):
+        self.compiled_plan.plan_state.output_stride_per_output = value
+
+    @property
+    def _output_spec(self):
+        return self.compiled_plan.plan_state.output_spec
+
+    @_output_spec.setter
+    def _output_spec(self, value):
+        self.compiled_plan.plan_state.output_spec = value
+
+    @property
+    def _reducer_head_map(self):
+        return self.compiled_plan.session_state.reducer_head_map
+
+    @_reducer_head_map.setter
+    def _reducer_head_map(self, value):
+        self.compiled_plan.session_state.reducer_head_map = value
+
+    @property
+    def _reducer_input_indices(self):
+        return self.compiled_plan.session_state.reducer_input_indices
+
+    @_reducer_input_indices.setter
+    def _reducer_input_indices(self, value):
+        self.compiled_plan.session_state.reducer_input_indices = value
+
+    @property
+    def _last_forward_tiles(self):
+        return self.compiled_plan.session_state.last_forward_tiles
+
+    @_last_forward_tiles.setter
+    def _last_forward_tiles(self, value):
+        self.compiled_plan.session_state.last_forward_tiles = value
+
+    @property
+    def _active_reducer_mask(self):
+        return self.compiled_plan.session_state.active_reducer_mask
+
+    @_active_reducer_mask.setter
+    def _active_reducer_mask(self, value):
+        self.compiled_plan.session_state.active_reducer_mask = value
 
     def _print_verbose(self, *args: object, **kwargs: object) -> None:
         if self.verbose:

--- a/lightstream/modules/streaming.py
+++ b/lightstream/modules/streaming.py
@@ -8,7 +8,7 @@ from pathlib import Path
 import torch
 import torch.nn as nn
 
-from lightstream.core.constructor import StreamingConstructor
+from lightstream.core.engine.api import StreamingConfig, StreamingEngine
 from lightstream.core.reducer import BaseReducer
 
 
@@ -140,14 +140,29 @@ class StreamingModule(nn.Module):
         **kwargs,
     ) -> None:
         """Construct and prepare the streaming network with an optional tile cache."""
-        self.constructor = StreamingConstructor(
-            stream_network,
-            self.tile_size,
-            tile_cache=tile_cache,
-            **kwargs,
+        config_kwargs = dict(kwargs)
+        config = StreamingConfig(
+            tile_shape=(1, 3, self.tile_size, self.tile_size),
+            verbose=config_kwargs.pop("verbose", True),
+            deterministic=config_kwargs.pop("deterministic", False),
+            saliency=config_kwargs.pop("saliency", False),
+            copy_to_gpu=config_kwargs.pop("copy_to_gpu", False),
+            statistics_on_cpu=config_kwargs.pop("statistics_on_cpu", True),
+            normalize_on_gpu=config_kwargs.pop("normalize_on_gpu", True),
+            mean=config_kwargs.pop("mean", None),
+            std=config_kwargs.pop("std", None),
+            add_keep_modules=config_kwargs.pop("add_keep_modules", None),
+            before_streaming_init_callbacks=config_kwargs.pop("before_streaming_init_callbacks", None),
+            after_streaming_init_callbacks=config_kwargs.pop("after_streaming_init_callbacks", None),
         )
-        self.copy_to_gpu = self.constructor.copy_to_gpu
-        self.stream_network = self.constructor.prepare_streaming_model()
+        if config_kwargs:
+            unexpected = ", ".join(sorted(config_kwargs))
+            raise TypeError(f"Unexpected StreamingModule option(s): {unexpected}")
+        self.engine = StreamingEngine(stream_network, config)
+        self.engine.compile(cache=tile_cache)
+        self.constructor = self.engine.constructor
+        self.copy_to_gpu = config.copy_to_gpu
+        self.stream_network = self.engine.stream_network
 
     def _tile_cache_location(self) -> Path:
         """Return the configured cache path, assigning the default file name if needed."""
@@ -492,7 +507,7 @@ class StreamingModule(nn.Module):
         torch.Tensor or tuple or list or dict
             Output produced by ``self.stream_network``.
         """
-        return self.stream_network(x, mask=mask)
+        return self.engine.forward(x, mask=mask)
 
     def backward_streaming(self, image, grad, mask=None):
         """Run the streaming backward pass for a previously computed gradient.
@@ -506,4 +521,4 @@ class StreamingModule(nn.Module):
         mask : torch.Tensor, optional
             Optional spatial mask forwarded to the streaming backward routine.
         """
-        self.stream_network.backward(image, grad, mask=mask)
+        self.engine.backward(image, grad, mask=mask)


### PR DESCRIPTION
### Motivation
- Provide a public, explicit engine API for compiling and running tiled streaming workflows with lifecycle methods (`compile`, `forward`, `backward`, cache/state management). 
- Encapsulate previously-mutable planning and per-session fields into explicit plan/session containers to make compilation vs runtime state clear. 
- Decouple `StreamingModule` construction so it delegates to a `StreamingEngine` and uses a `StreamingConfig` to centralize options.

### Description
- Add `lightstream/core/engine/api.py` implementing `StreamingEngine` with `compile(input_spec=None, cache=None)`, `forward(...)`, `backward(...)`, `get_tile_cache() / load_tile_cache()` and `state_dict() / load_state_dict()` helpers. 
- Extend `lightstream/core/engine/config.py` with `CompiledPlan`, `StreamingPlanState`, and `StreamingSessionState`, and extend `StreamingConfig` with additional configuration fields such as `mean`, `std`, and callback/keep-module options. 
- Update `lightstream/core/engine/scnn.py` to hold a `compiled_plan` and route mutable fields through the plan/session containers via property proxies (moved fields include `_tile_output_shape`, `_tile_output_shapes`, `_tile_output_lost`, `_output_stride_per_output`, `_output_spec`, `_reducer_head_map`, `_reducer_input_indices`, `_last_forward_tiles`, `_active_reducer_mask`). 
- Update `lightstream/modules/streaming.py` to construct a `StreamingConfig`, instantiate a `StreamingEngine`, call `engine.compile(cache=...)`, and delegate forward/backward calls to the engine while preserving prior cache behavior and constructor exposure. 
- Export `CompiledPlan` from the engine package and provide lazy access to `StreamingEngine` from the package root to avoid import cycles.

### Testing
- Ran static compile checks with `python -m py_compile lightstream/core/engine/__init__.py lightstream/core/engine/api.py lightstream/core/engine/config.py lightstream/core/engine/scnn.py lightstream/modules/streaming.py` which succeeded. 
- Performed a smoke import/runtime check by stubbing optional `lightning` modules and importing `StreamingEngine`, `StreamingConfig`, `CompiledPlan`, and `StreamingModule`; the smoke test completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1eee5e81408330bf51241c37659a45)