### PR TITLE
Add compiled streaming execution plan and plan metadata dataclasses

### DIFF
--- a/lightstream/core/engine/__init__.py
+++ b/lightstream/core/engine/__init__.py
@@ -1,13 +1,31 @@
 """Streaming engine package."""
-from .config import BackwardContext, CompiledPlan, ForwardContext, StreamingConfig, TileSpec
+from .config import (
+    BackwardContext,
+    CompiledPlan,
+    ForwardContext,
+    InputSpec,
+    LayerPlan,
+    OutputLayout,
+    ReducerNode,
+    StreamingConfig,
+    TensorSpec,
+    TilePlan,
+    TileSpec,
+)
 from .scnn import StreamingCNN
 
 __all__ = [
     "BackwardContext",
     "CompiledPlan",
     "ForwardContext",
+    "InputSpec",
+    "LayerPlan",
+    "OutputLayout",
+    "ReducerNode",
     "StreamingCNN",
     "StreamingConfig",
+    "TensorSpec",
+    "TilePlan",
     "StreamingEngine",
     "TileSpec",
 ]

--- a/lightstream/core/engine/api.py
+++ b/lightstream/core/engine/api.py
@@ -71,7 +71,6 @@ class StreamingEngine:
         )
         stream_network = self.constructor.prepare_streaming_model()
         self.plan = stream_network.compiled_plan
-        self.plan.stream_network = stream_network
         return self.plan
 
     def _require_stream_network(self) -> nn.Module:
@@ -85,21 +84,29 @@ class StreamingEngine:
         stream_network = self._require_stream_network()
         result_on_cpu = result_device is not None and torch.device(result_device).type == "cpu"
         output = stream_network.forward(image, result_on_cpu=result_on_cpu, mask=mask)
+        self.plan = stream_network.compiled_plan
         if result_device is None or result_on_cpu:
             return output
         return self._move_output(output, torch.device(result_device))
 
     def backward(self, image: torch.Tensor, grad, *, mask: torch.Tensor | None = None) -> None:
         """Run a streaming backward pass."""
-        self._require_stream_network().backward(image, grad, mask=mask)
+        stream_network = self._require_stream_network()
+        stream_network.backward(image, grad, mask=mask)
+        self.plan = stream_network.compiled_plan
 
     def get_tile_cache(self) -> dict:
         """Return the compiled tile-cache state."""
-        return self._require_stream_network().get_tile_cache()
+        stream_network = self._require_stream_network()
+        cache = stream_network.get_tile_cache()
+        self.plan = stream_network.compiled_plan
+        return cache
 
     def load_tile_cache(self, state: dict) -> None:
         """Load tile-cache state into an already compiled engine."""
-        self._require_stream_network().load_tile_cache(state)
+        stream_network = self._require_stream_network()
+        stream_network.load_tile_cache(state)
+        self.plan = stream_network.compiled_plan
 
     def state_dict(self) -> dict:
         """Alias for :meth:`get_tile_cache` for cache-oriented lifecycle usage."""

--- a/lightstream/core/engine/backward.py
+++ b/lightstream/core/engine/backward.py
@@ -143,8 +143,11 @@ class BackwardMixin:
         if mask is not None:
             self._active_reducer_mask = self._normalize_reducer_mask(mask, image)
 
-        tile_height = self.tile_shape[H_DIM]
-        tile_width = self.tile_shape[W_DIM]
+        plan = self.compiled_plan
+        tile_shape = plan.tile_plan.tile_shape if plan.tile_plan is not None else self.tile_shape
+        output_spec = plan.public_output_spec if plan.public_output_spec is not None else self._output_spec
+        tile_height = tile_shape[H_DIM]
+        tile_width = tile_shape[W_DIM]
 
         valid_output_heights, valid_output_widths = self._compute_valid_output_sizes()
         output_heights, output_widths = self._compute_full_output_sizes(image)
@@ -159,7 +162,7 @@ class BackwardMixin:
         )
 
         grad_tensors, grad_spec = self._flatten_output_structure(grad)
-        if grad_spec != self._output_spec:
+        if grad_spec != output_spec:
             raise ValueError("Gradient output structure does not match streaming output structure")
 
         public_indices = self._public_output_indices()
@@ -195,6 +198,7 @@ class BackwardMixin:
             tile_width=tile_width,
             output_heights=output_heights,
             output_widths=output_widths,
+            compiled_plan=plan,
         )
 
         if self.debug_reducer_replay:

--- a/lightstream/core/engine/config.py
+++ b/lightstream/core/engine/config.py
@@ -27,9 +27,73 @@ class StreamingConfig:
     after_streaming_init_callbacks: Optional[list[Callable[..., Any]]] = None
 
 
+@dataclass(frozen=True)
+class TensorSpec:
+    """Serializable metadata for one tensor produced by the compiled tile graph."""
+
+    shape: tuple[int, ...]
+    dtype: str | None = None
+    device: str | None = None
+
+
+@dataclass(frozen=True)
+class InputSpec:
+    """Input tensor contract used to compile the streaming plan."""
+
+    tensor: TensorSpec
+    model_signature: tuple[tuple[str, str], ...] = ()
+
+
+@dataclass(frozen=True)
+class TilePlan:
+    """Tile-level geometry shared by forward and backward replay."""
+
+    tile_shape: tuple[int, int, int, int]
+    tile_output_shape: tuple[int, ...] | None = None
+    tile_output_shapes: tuple[tuple[int, ...], ...] = ()
+    tile_output_lost: tuple[Any, ...] = ()
+    tile_gradient_lost: Any = None
+    output_stride_per_output: tuple[Any, ...] = ()
+    output_stride: Any = None
+
+
+@dataclass(frozen=True)
+class LayerPlan:
+    """Streamability metadata for a converted streaming layer."""
+
+    name: str
+    module_type: str
+    streamable: bool
+    output_stride: Any = None
+    lost: Any = None
+    grad_lost: Any = None
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass(frozen=True)
+class ReducerNode:
+    """Compiled metadata for a streaming reducer node."""
+
+    name: str
+    reducer_type: str
+    output_index: int | None = None
+    input_indices: tuple[int, ...] = ()
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass(frozen=True)
+class OutputLayout:
+    """Flattened internal output layout and public structure metadata."""
+
+    tensor_specs: tuple[TensorSpec, ...]
+    output_structure: object
+    public_indices: tuple[int, ...] = ()
+    reducer_auxiliary_indices: tuple[int, ...] = ()
+
+
 @dataclass
 class StreamingPlanState:
-    """Mutable statistics captured by compilation and reused by tile execution."""
+    """Mutable statistics captured while compilation is in progress."""
 
     tile_output_shape: Any = None
     tile_output_shapes: Any = None
@@ -48,13 +112,19 @@ class StreamingSessionState:
     active_reducer_mask: Any = None
 
 
-@dataclass
+@dataclass(frozen=True)
 class CompiledPlan:
-    """Compiled streaming execution plan and per-session mutable state."""
+    """Immutable compiled streaming execution plan plus mutable per-session replay state."""
 
+    input_spec: InputSpec | None = None
+    tile_plan: TilePlan | None = None
+    output_layout: OutputLayout | None = None
+    layer_plans: tuple[LayerPlan, ...] = ()
+    reducer_nodes: tuple[ReducerNode, ...] = ()
+    public_output_spec: object = None
     stream_network: Any = None
-    plan_state: StreamingPlanState = field(default_factory=StreamingPlanState)
-    session_state: StreamingSessionState = field(default_factory=StreamingSessionState)
+    session_state: StreamingSessionState = field(default_factory=StreamingSessionState, compare=False)
+    plan_state: StreamingPlanState = field(default_factory=StreamingPlanState, compare=False)
 
 
 @dataclass(frozen=True)
@@ -80,6 +150,7 @@ class ForwardContext:
     n_rows: int
     n_cols: int
     result_device: torch.device
+    compiled_plan: CompiledPlan | None = None
 
 
 @dataclass(frozen=True)
@@ -90,3 +161,4 @@ class BackwardContext:
     tile_width: int
     output_heights: list
     output_widths: list
+    compiled_plan: CompiledPlan | None = None

--- a/lightstream/core/engine/forward.py
+++ b/lightstream/core/engine/forward.py
@@ -213,8 +213,11 @@ class ForwardMixin:
             image = image.to(self.device, non_blocking=True)
         self._active_reducer_mask = self._normalize_reducer_mask(mask, image)
 
-        tile_height = self.tile_shape[H_DIM]
-        tile_width = self.tile_shape[W_DIM]
+        plan = self.compiled_plan
+        tile_shape = plan.tile_plan.tile_shape if plan.tile_plan is not None else self.tile_shape
+        output_spec = plan.public_output_spec if plan.public_output_spec is not None else self._output_spec
+        tile_height = tile_shape[H_DIM]
+        tile_width = tile_shape[W_DIM]
 
         valid_output_heights, valid_output_widths = self._compute_valid_output_sizes()
         output_heights, output_widths = self._compute_full_output_sizes(image)
@@ -253,6 +256,7 @@ class ForwardMixin:
             n_rows=n_rows,
             n_cols=n_cols,
             result_device=result_device,
+            compiled_plan=plan,
         )
         self._reducer_head_map = {}
         self._reducer_input_indices = {}
@@ -313,6 +317,7 @@ class ForwardMixin:
         )
 
         self._validate_reducer_head_map_resolved()
+        self._refresh_compiled_plan()
 
         del image
         self._saved_tensors = {}
@@ -321,7 +326,7 @@ class ForwardMixin:
 
         public_indices = self._public_output_indices()
         self._validate_public_output_indices(public_indices)
-        expected_flat_outputs = self._count_tensors_in_spec(self._output_spec)
+        expected_flat_outputs = self._count_tensors_in_spec(output_spec)
         if len(public_indices) != expected_flat_outputs:
             raise RuntimeError(
                 f"Public output index count mismatch: expected={expected_flat_outputs}, "
@@ -330,7 +335,7 @@ class ForwardMixin:
         self._validate_public_forward_outputs(outputs, public_indices)
         materialized_outputs = [outputs[idx] for idx in public_indices]
 
-        output, final_idx = self._unflatten_output_structure(materialized_outputs, self._output_spec)
+        output, final_idx = self._unflatten_output_structure(materialized_outputs, output_spec)
         assert final_idx == len(materialized_outputs)
         return output
 

--- a/lightstream/core/engine/scnn.py
+++ b/lightstream/core/engine/scnn.py
@@ -1,17 +1,24 @@
 """Streaming CNN engine orchestration."""
 import copy
 import logging
-
 import torch
 import torch.backends
 
-from lightstream.core.reducer import BaseReducer
+from lightstream.core.reducer import BaseReducer, BaseStreamingGlobalReducer
 from lightstream.core.scnn.utils import H_DIM, W_DIM
 from lightstream.core.scnn.streamingconv import StreamingConv2d
 from lightstream.core.scnn.streamingupsample import StreamingUpsample2d
 
 from .backward import BackwardMixin
-from .config import BackwardContext, CompiledPlan, ForwardContext, StreamingConfig, TileSpec
+from .config import (
+    CompiledPlan,
+    InputSpec,
+    LayerPlan,
+    OutputLayout,
+    ReducerNode,
+    TensorSpec,
+    TilePlan,
+)
 from .conversion import ConversionMixin
 from .forward import ForwardMixin
 from .planner import PlannerMixin
@@ -179,6 +186,114 @@ class StreamingCNN(
     def _active_reducer_mask(self, value):
         self.compiled_plan.session_state.active_reducer_mask = value
 
+
+    def _shape_tuple(self, shape):
+        return tuple(int(v) for v in shape) if shape is not None else None
+
+    def _tensor_spec_from_shape(self, shape, *, dtype=None, device=None):
+        return TensorSpec(
+            shape=self._shape_tuple(shape) or (),
+            dtype=str(dtype) if dtype is not None else None,
+            device=str(device) if device is not None else None,
+        )
+
+    def _model_signature(self):
+        return tuple((name, type(module).__qualname__) for name, module in self.stream_module.named_modules())
+
+    def _build_layer_plans(self):
+        layer_plans = []
+        for name, module in self.stream_module.named_modules():
+            if not name:
+                continue
+            stats = self._module_stats.get(module, {})
+            streamable = isinstance(module, (StreamingConv2d, StreamingUpsample2d, BaseReducer, BaseStreamingGlobalReducer)) or bool(stats)
+            if not streamable:
+                continue
+            metadata = {
+                key: value
+                for key, value in stats.items()
+                if key not in {"module", "lost", "grad_lost", "output_stride"}
+            }
+            layer_plans.append(
+                LayerPlan(
+                    name=name,
+                    module_type=type(module).__qualname__,
+                    streamable=streamable,
+                    output_stride=stats.get("output_stride", getattr(module, "output_stride", None)),
+                    lost=stats.get("lost"),
+                    grad_lost=stats.get("grad_lost", getattr(module, "grad_lost", None)),
+                    metadata=metadata,
+                )
+            )
+        return tuple(layer_plans)
+
+    def _build_reducer_nodes(self):
+        module_names = {module: name for name, module in self.stream_module.named_modules()}
+        reducer_nodes = []
+        for reducer in self._streaming_reducers:
+            output_index = None
+            input_indices = ()
+            for candidate_output_index, candidate_reducer in self._reducer_head_map.items():
+                if candidate_reducer is reducer:
+                    output_index = int(candidate_output_index)
+                    input_indices = tuple(int(v) for v in self._reducer_input_indices.get(candidate_output_index, ()))
+                    break
+            reducer_nodes.append(
+                ReducerNode(
+                    name=module_names.get(reducer, ""),
+                    reducer_type=type(reducer).__qualname__,
+                    output_index=output_index,
+                    input_indices=input_indices,
+                    metadata={"debug_replay": bool(getattr(reducer, "_debug_replay_enabled", False))},
+                )
+            )
+        return tuple(reducer_nodes)
+
+    def _build_output_layout(self):
+        tensor_specs = tuple(
+            self._tensor_spec_from_shape(shape, dtype=self.dtype, device=self.device)
+            for shape in (self._tile_output_shapes or [])
+        )
+        reducer_aux_indices = tuple(sorted(self._reducer_aux_indices())) if self._reducer_input_indices else ()
+        public_indices = tuple(
+            idx for idx in range(len(tensor_specs)) if idx not in set(reducer_aux_indices)
+        )
+        return OutputLayout(
+            tensor_specs=tensor_specs,
+            output_structure=self._output_spec,
+            public_indices=public_indices,
+            reducer_auxiliary_indices=reducer_aux_indices,
+        )
+
+    def _build_tile_plan(self):
+        return TilePlan(
+            tile_shape=tuple(int(v) for v in self.tile_shape),
+            tile_output_shape=self._shape_tuple(self._tile_output_shape),
+            tile_output_shapes=tuple(self._shape_tuple(shape) or () for shape in (self._tile_output_shapes or [])),
+            tile_output_lost=tuple(self._tile_output_lost or ()),
+            tile_gradient_lost=getattr(self, "tile_gradient_lost", None),
+            output_stride_per_output=tuple(self._output_stride_per_output or ()),
+            output_stride=getattr(self, "output_stride", None),
+        )
+
+    def _refresh_compiled_plan(self):
+        """Publish a coherent immutable plan snapshot from current compile/session metadata."""
+        session_state = self.compiled_plan.session_state
+        plan_state = self.compiled_plan.plan_state
+        tensor_spec = self._tensor_spec_from_shape(self.tile_shape, dtype=self.dtype, device=self.device)
+        self.compiled_plan = CompiledPlan(
+            input_spec=InputSpec(tensor=tensor_spec, model_signature=self._model_signature()),
+            tile_plan=self._build_tile_plan(),
+            output_layout=self._build_output_layout(),
+            layer_plans=self._build_layer_plans(),
+            reducer_nodes=self._build_reducer_nodes(),
+            public_output_spec=self._output_spec,
+            stream_network=self,
+            session_state=session_state,
+            plan_state=plan_state,
+        )
+        return self.compiled_plan
+
     def _print_verbose(self, *args: object, **kwargs: object) -> None:
         if self.verbose:
             print(*args, **kwargs)
@@ -236,6 +351,7 @@ class StreamingCNN(
                 param.grad.data.zero_()
 
         self._set_cudnn_flags(old_deterministic_flag, old_benchmark_flag)
+        self._refresh_compiled_plan()
         del state_dict
 
     def _capture_public_output_spec(self) -> None:

--- a/lightstream/core/engine/statistics.py
+++ b/lightstream/core/engine/statistics.py
@@ -384,6 +384,15 @@ class StatisticsMixin:
         named_stats["tile_output_shapes"] = self._tile_output_shapes  # type:ignore
         named_stats["output_stride_per_output"] = self._output_stride_per_output  # type:ignore
         named_stats["output_spec"] = self._output_spec
+        self._refresh_compiled_plan()
+        named_stats["compiled_plan"] = self.compiled_plan
+        named_stats["plan_metadata"] = {
+            "tile_shape": self.compiled_plan.tile_plan.tile_shape if self.compiled_plan.tile_plan is not None else tuple(self.tile_shape),
+            "model_signature": self.compiled_plan.input_spec.model_signature if self.compiled_plan.input_spec is not None else (),
+            "output_structure": self.compiled_plan.output_layout.output_structure if self.compiled_plan.output_layout is not None else self._output_spec,
+            "reducer_nodes": self.compiled_plan.reducer_nodes,
+            "layer_plans": self.compiled_plan.layer_plans,
+        }
         return named_stats
 
     def load_tile_cache(self, state):
@@ -407,3 +416,4 @@ class StatisticsMixin:
                 self._module_stats[module] = state["net_stats"][name]
 
         self.enable()
+        self._refresh_compiled_plan()


### PR DESCRIPTION
### Motivation
- Provide an immutable snapshot representation of the compiled streaming plan so execution can consume deterministic metadata (tile geometry, output layout, reducer/layer metadata, model signature) instead of recalculating or mutating internals at runtime.
- Make tile-cache persistence richer and verifiable by saving plan metadata required to validate and reload caches.
- Allow forward/backward replay to read a single coherent plan so replay is stable and cacheable across processes.

### Description
- Added frozen dataclasses in `lightstream/core/engine/config.py` for `TensorSpec`, `InputSpec`, `TilePlan`, `LayerPlan`, `ReducerNode`, `OutputLayout` and expanded `CompiledPlan` to carry the compiled snapshot and per-session mutable state via `plan_state` and `session_state`.
- Implemented plan assembly in `StreamingCNN` (`_build_*` helpers and `_refresh_compiled_plan`) to capture model signature, tile geometry, per-layer streamability, reducer nodes, and flattened output layout; the plan is refreshed after configuration, reducer resolution during forward, and after cache load.
- Updated execution paths to consume the `CompiledPlan`: forward and backward now source tile shape and public output spec from `plan.tile_plan` / `plan.public_output_spec` and pass `compiled_plan` into `ForwardContext` and `BackwardContext` for use by downstream logic.
- Persisted plan and metadata into tile-cache exports by adding `compiled_plan` and `plan_metadata` to `get_tile_cache` and refresh plan on `load_tile_cache`/enable flows so cache metadata includes `tile_shape`, `model_signature`, `output_structure`, `reducer_nodes`, and `layer_plans`.
- Kept `StreamingEngine.plan` synchronized by updating API hooks to refresh the public `plan` after `compile`, `forward`, `backward`, `get_tile_cache`, and `load_tile_cache` flows, and exported new dataclasses from the engine package (`__init__.py`).

### Testing
- Ran `python3 -m compileall lightstream/core/engine` to ensure all modified modules compile successfully (passed).
- Performed smoke tests using a small `torch.nn.Sequential` model exercising `StreamingCNN` compile/forward/backward and tile-cache save/load flows (forward/backward/cache smoke tests executed and succeeded).
- Verified that `get_tile_cache` output contains `compiled_plan` and `plan_metadata` keys and that a new `StreamingCNN` instance can be constructed successfully from the saved cache (cache load smoke test succeeded).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1efbcc58348330987ec210689934e3)