### PR TITLE
Add streaming extension point base types and composition-based engine collaborators

### DIFF
--- a/lightstream/core/engine/__init__.py
+++ b/lightstream/core/engine/__init__.py
@@ -1,14 +1,22 @@
 """Streaming engine package."""
+from .adapters import AdapterRegistry, StreamableLayerAdapter
 from .config import BackwardContext, CompiledPlan, ForwardContext, StreamingConfig, TileSpec
+from .orchestration import BackwardExecutor, ForwardExecutor, ReducerRuntime, TilePlanner
 from .scnn import StreamingCNN
 
 __all__ = [
+    "AdapterRegistry",
     "BackwardContext",
+    "BackwardExecutor",
     "CompiledPlan",
     "ForwardContext",
+    "ForwardExecutor",
     "StreamingCNN",
+    "ReducerRuntime",
+    "StreamableLayerAdapter",
     "StreamingConfig",
     "StreamingEngine",
+    "TilePlanner",
     "TileSpec",
 ]
 

--- a/lightstream/core/engine/adapters.py
+++ b/lightstream/core/engine/adapters.py
@@ -1,0 +1,56 @@
+"""Layer-adapter extension points for streaming conversion."""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Protocol, TypeVar, runtime_checkable
+
+import torch.nn as nn
+
+ModuleT = TypeVar("ModuleT", bound=nn.Module)
+
+
+@runtime_checkable
+class StreamableLayerAdapter(Protocol):
+    """Protocol for user-defined layer conversion adapters.
+
+    Adapters are intentionally small operator-level extension points.  They
+    describe how one layer type is translated to and from an equivalent
+    streaming implementation, while the streaming engine remains responsible for
+    orchestration through composition.
+    """
+
+    def can_adapt(self, module: nn.Module) -> bool:
+        """Return ``True`` when this adapter can convert ``module``."""
+
+    def to_streaming(self, module: nn.Module, *, context: dict[str, Any] | None = None) -> nn.Module:
+        """Convert a regular layer to its streaming equivalent."""
+
+    def from_streaming(self, module: nn.Module, *, context: dict[str, Any] | None = None) -> nn.Module:
+        """Convert a streaming layer back to a regular PyTorch layer."""
+
+
+@dataclass
+class AdapterRegistry:
+    """Ordered registry of streamable layer adapters.
+
+    The registry is owned by :class:`~lightstream.core.engine.api.StreamingEngine`
+    so future conversion paths can be configured without introducing a large
+    engine inheritance hierarchy.  The first adapter whose ``can_adapt`` method
+    accepts a module is selected.
+    """
+
+    adapters: list[StreamableLayerAdapter] = field(default_factory=list)
+
+    def register(self, adapter: StreamableLayerAdapter) -> StreamableLayerAdapter:
+        """Register ``adapter`` and return it for decorator-style usage."""
+        if not isinstance(adapter, StreamableLayerAdapter):
+            raise TypeError("adapter must implement StreamableLayerAdapter")
+        self.adapters.append(adapter)
+        return adapter
+
+    def find(self, module: nn.Module) -> StreamableLayerAdapter | None:
+        """Find the first adapter that can convert ``module``."""
+        for adapter in self.adapters:
+            if adapter.can_adapt(module):
+                return adapter
+        return None

--- a/lightstream/core/engine/api.py
+++ b/lightstream/core/engine/api.py
@@ -8,7 +8,9 @@ import torch.nn as nn
 
 from lightstream.core.constructor import StreamingConstructor
 
+from .adapters import AdapterRegistry, StreamableLayerAdapter
 from .config import CompiledPlan, StreamingConfig
+from .orchestration import BackwardExecutor, EngineCollaborators, ForwardExecutor, ReducerRuntime, TilePlanner
 
 
 class StreamingEngine:
@@ -23,9 +25,25 @@ class StreamingEngine:
     >>> engine.backward(image, grad, mask=mask)
     """
 
-    def __init__(self, model: nn.Module, config: StreamingConfig):
+    def __init__(
+        self,
+        model: nn.Module,
+        config: StreamingConfig,
+        *,
+        tile_planner: TilePlanner | None = None,
+        forward_executor: ForwardExecutor | None = None,
+        backward_executor: BackwardExecutor | None = None,
+        reducer_runtime: ReducerRuntime | None = None,
+        adapter_registry: AdapterRegistry | None = None,
+    ):
         self.model = model
         self.config = config
+        collaborators = EngineCollaborators.create_default()
+        self.tile_planner = tile_planner or collaborators.tile_planner
+        self.forward_executor = forward_executor or collaborators.forward_executor
+        self.backward_executor = backward_executor or collaborators.backward_executor
+        self.reducer_runtime = reducer_runtime or collaborators.reducer_runtime
+        self.adapter_registry = adapter_registry or collaborators.adapter_registry
         self.constructor: StreamingConstructor | None = None
         self.plan: CompiledPlan | None = None
 
@@ -47,31 +65,11 @@ class StreamingEngine:
             :meth:`state_dict`.
         """
         del input_spec
-        tile_shape = self.config.tile_shape
-        if len(tile_shape) != 4:
-            raise ValueError(f"StreamingConfig.tile_shape must be an NCHW tuple, got {tile_shape!r}")
-        if tile_shape[2] != tile_shape[3]:
-            raise ValueError("StreamingEngine currently requires square spatial tiles")
-
-        self.constructor = StreamingConstructor(
-            self.model,
-            tile_size=int(tile_shape[2]),
-            verbose=self.config.verbose,
-            deterministic=self.config.deterministic,
-            saliency=self.config.saliency,
-            copy_to_gpu=self.config.copy_to_gpu,
-            statistics_on_cpu=self.config.statistics_on_cpu,
-            normalize_on_gpu=self.config.normalize_on_gpu,
-            mean=self.config.mean,
-            std=self.config.std,
-            tile_cache=cache,
-            add_keep_modules=self.config.add_keep_modules,
-            before_streaming_init_callbacks=self.config.before_streaming_init_callbacks,
-            after_streaming_init_callbacks=self.config.after_streaming_init_callbacks,
-        )
+        self.constructor = self.tile_planner.build_constructor(self.model, self.config, cache=cache)
         stream_network = self.constructor.prepare_streaming_model()
         self.plan = stream_network.compiled_plan
         self.plan.stream_network = stream_network
+        self.reducer_runtime.bind_plan(self.plan)
         return self.plan
 
     def _require_stream_network(self) -> nn.Module:
@@ -82,16 +80,11 @@ class StreamingEngine:
 
     def forward(self, image: torch.Tensor, *, mask: torch.Tensor | None = None, result_device=None):
         """Run a streaming forward pass."""
-        stream_network = self._require_stream_network()
-        result_on_cpu = result_device is not None and torch.device(result_device).type == "cpu"
-        output = stream_network.forward(image, result_on_cpu=result_on_cpu, mask=mask)
-        if result_device is None or result_on_cpu:
-            return output
-        return self._move_output(output, torch.device(result_device))
+        return self.forward_executor.run(self, image, mask=mask, result_device=result_device)
 
     def backward(self, image: torch.Tensor, grad, *, mask: torch.Tensor | None = None) -> None:
         """Run a streaming backward pass."""
-        self._require_stream_network().backward(image, grad, mask=mask)
+        self.backward_executor.run(self, image, grad, mask=mask)
 
     def get_tile_cache(self) -> dict:
         """Return the compiled tile-cache state."""
@@ -122,4 +115,14 @@ class StreamingEngine:
         return output
 
 
-__all__ = ["CompiledPlan", "StreamingConfig", "StreamingEngine"]
+__all__ = [
+    "AdapterRegistry",
+    "BackwardExecutor",
+    "CompiledPlan",
+    "ForwardExecutor",
+    "ReducerRuntime",
+    "StreamableLayerAdapter",
+    "StreamingConfig",
+    "StreamingEngine",
+    "TilePlanner",
+]

--- a/lightstream/core/engine/orchestration.py
+++ b/lightstream/core/engine/orchestration.py
@@ -1,0 +1,117 @@
+"""Composition collaborators for the public streaming engine."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, TYPE_CHECKING
+
+import torch
+import torch.nn as nn
+
+from .adapters import AdapterRegistry
+from .config import CompiledPlan, StreamingConfig
+
+if TYPE_CHECKING:  # pragma: no cover
+    from lightstream.core.constructor import StreamingConstructor
+
+    from .api import StreamingEngine
+
+
+@dataclass
+class TilePlanner:
+    """Compile-time tile planning collaborator.
+
+    ``StreamingEngine`` delegates tile-shape validation and constructor creation
+    here rather than inheriting planning behavior from a base engine class.
+    """
+
+    def validate_config(self, config: StreamingConfig) -> None:
+        tile_shape = config.tile_shape
+        if len(tile_shape) != 4:
+            raise ValueError(f"StreamingConfig.tile_shape must be an NCHW tuple, got {tile_shape!r}")
+        if tile_shape[2] != tile_shape[3]:
+            raise ValueError("StreamingEngine currently requires square spatial tiles")
+
+    def build_constructor(self, model: nn.Module, config: StreamingConfig, cache: dict | None = None) -> StreamingConstructor:
+        from lightstream.core.constructor import StreamingConstructor
+
+        self.validate_config(config)
+        return StreamingConstructor(
+            model,
+            tile_size=int(config.tile_shape[2]),
+            verbose=config.verbose,
+            deterministic=config.deterministic,
+            saliency=config.saliency,
+            copy_to_gpu=config.copy_to_gpu,
+            statistics_on_cpu=config.statistics_on_cpu,
+            normalize_on_gpu=config.normalize_on_gpu,
+            mean=config.mean,
+            std=config.std,
+            tile_cache=cache,
+            add_keep_modules=config.add_keep_modules,
+            before_streaming_init_callbacks=config.before_streaming_init_callbacks,
+            after_streaming_init_callbacks=config.after_streaming_init_callbacks,
+        )
+
+
+@dataclass
+class ReducerRuntime:
+    """Reducer orchestration collaborator for compiled streaming plans."""
+
+    def bind_plan(self, plan: CompiledPlan) -> None:
+        """Hook for reducer-runtime setup after compilation.
+
+        Current reducer execution is implemented by the compiled streaming
+        network.  This collaborator keeps reducer orchestration as composition
+        state owned by the public engine, ready for custom runtimes without a
+        ``BaseStreamingEngine`` hierarchy.
+        """
+        del plan
+
+
+@dataclass
+class ForwardExecutor:
+    """Forward-pass executor collaborator."""
+
+    def run(
+        self,
+        engine: StreamingEngine,
+        image: torch.Tensor,
+        *,
+        mask: torch.Tensor | None = None,
+        result_device=None,
+    ):
+        stream_network = engine._require_stream_network()
+        result_on_cpu = result_device is not None and torch.device(result_device).type == "cpu"
+        output = stream_network.forward(image, result_on_cpu=result_on_cpu, mask=mask)
+        if result_device is None or result_on_cpu:
+            return output
+        return engine._move_output(output, torch.device(result_device))
+
+
+@dataclass
+class BackwardExecutor:
+    """Backward-pass executor collaborator."""
+
+    def run(self, engine: StreamingEngine, image: torch.Tensor, grad: Any, *, mask: torch.Tensor | None = None) -> None:
+        engine._require_stream_network().backward(image, grad, mask=mask)
+
+
+@dataclass
+class EngineCollaborators:
+    """Bundle of collaborators owned by ``StreamingEngine``."""
+
+    tile_planner: TilePlanner
+    forward_executor: ForwardExecutor
+    backward_executor: BackwardExecutor
+    reducer_runtime: ReducerRuntime
+    adapter_registry: AdapterRegistry
+
+    @classmethod
+    def create_default(cls) -> EngineCollaborators:
+        return cls(
+            tile_planner=TilePlanner(),
+            forward_executor=ForwardExecutor(),
+            backward_executor=BackwardExecutor(),
+            reducer_runtime=ReducerRuntime(),
+            adapter_registry=AdapterRegistry(),
+        )

--- a/lightstream/core/reducer/__init__.py
+++ b/lightstream/core/reducer/__init__.py
@@ -2,13 +2,17 @@ from .base import BaseStreamingGlobalReducer, StreamingReducer
 from .attention_gem import AttentionGeMReducer, StreamingAttentionGeMReducer
 from .gem import GeMReducer, StreamingGeMReducer
 from .mean import MeanReducer, StreamingMeanReducer
-from .reducer_base import BaseReducer
+from .reducer_base import BaseReducer, ManualBackwardReducer, ManualVJPReducer, MultiInputSpatialReducer, SpatialReducer
 from .sum import StreamingSumReducer, SumReducer
 
 __all__ = [
     "MeanReducer",
     "SumReducer",
     "BaseReducer",
+    "SpatialReducer",
+    "MultiInputSpatialReducer",
+    "ManualVJPReducer",
+    "ManualBackwardReducer",
     "BaseStreamingGlobalReducer",
     "StreamingReducer",
     "StreamingMeanReducer",

--- a/lightstream/core/reducer/attention_gem.py
+++ b/lightstream/core/reducer/attention_gem.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import torch
 
 from .base import BaseStreamingGlobalReducer, streaming_reduce_tile
-from .reducer_base import BaseReducer
+from .reducer_base import ManualVJPReducer, MultiInputSpatialReducer
 from .utils import normalize_spatial_mask, resolve_accumulator_dtype
 
 
@@ -32,7 +32,7 @@ def _normalize_logits(logits: torch.Tensor, x: torch.Tensor) -> torch.Tensor:
     raise ValueError(f"logits must be 3D/4D spatial tensor, got shape={tuple(logits.shape)}")
 
 
-class AttentionGeMReducer(BaseReducer):
+class AttentionGeMReducer(MultiInputSpatialReducer):
     """Apply attention-weighted global GeM reduction on NCHW tensors."""
 
     def __init__(self, r_init: float = 4.0, eps: float = 1e-6, accumulator_dtype: torch.dtype | None = None):
@@ -95,7 +95,7 @@ class AttentionGeMReducer(BaseReducer):
         return reducer
 
 
-class StreamingAttentionGeMReducer(BaseStreamingGlobalReducer):
+class StreamingAttentionGeMReducer(ManualVJPReducer):
     """Streaming attention-weighted global GeM reducer with stable softmax accumulation."""
 
     def __init__(self, r_init: float = 4.0, eps: float = 1e-6, accumulator_dtype: torch.dtype | None = None):

--- a/lightstream/core/reducer/gem.py
+++ b/lightstream/core/reducer/gem.py
@@ -3,11 +3,11 @@
 import torch
 
 from .base import BaseStreamingGlobalReducer, streaming_reduce_tile
-from .reducer_base import BaseReducer
+from .reducer_base import ManualVJPReducer, SpatialReducer
 from .utils import normalize_spatial_mask, resolve_accumulator_dtype
 
 
-class GeMReducer(BaseReducer):
+class GeMReducer(SpatialReducer):
     """Apply global generalized-mean (GeM) reduction on NCHW tensors."""
 
     def __init__(
@@ -63,7 +63,7 @@ class GeMReducer(BaseReducer):
         return reducer
 
 
-class StreamingGeMReducer(BaseStreamingGlobalReducer):
+class StreamingGeMReducer(ManualVJPReducer):
     """Streaming global GeM reducer."""
 
     def __init__(

--- a/lightstream/core/reducer/mean.py
+++ b/lightstream/core/reducer/mean.py
@@ -3,12 +3,12 @@
 import torch
 
 from .base import BaseStreamingGlobalReducer, streaming_reduce_tile
-from .reducer_base import BaseReducer
+from .reducer_base import SpatialReducer
 from .sum import StreamingSumReducer
 from .utils import normalize_spatial_mask, resolve_accumulator_dtype
 
 
-class MeanReducer(BaseReducer):
+class MeanReducer(SpatialReducer):
     """Apply global spatial mean reduction on NCHW tensors."""
 
     def __init__(self, accumulator_dtype: torch.dtype | None = None):

--- a/lightstream/core/reducer/reducer_base.py
+++ b/lightstream/core/reducer/reducer_base.py
@@ -1,8 +1,9 @@
-"""Abstract base types for non-streaming global reducers."""
+"""Abstract base types for reducer extension points."""
 
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
+from collections.abc import Sequence
 
 import torch
 import torch.nn as nn
@@ -45,3 +46,91 @@ class BaseReducer(nn.Module, ABC):
     @abstractmethod
     def to_streaming(self) -> BaseStreamingGlobalReducer:
         """Create the equivalent streaming reducer implementation."""
+
+
+class SpatialReducer(BaseReducer, ABC):
+    """Base class for single-input spatial reducers.
+
+    Subclasses implement :meth:`reduce_spatial` for the math/operator behavior.
+    The engine can continue to treat reducers uniformly through ``BaseReducer``
+    while users get a focused inheritance point for custom NCHW spatial
+    reductions.
+    """
+
+    input_arity = 1
+
+    def forward(self, *inputs: torch.Tensor, mask: torch.Tensor | None = None) -> torch.Tensor:
+        x = self.require_single_nchw(inputs)
+        if self._streaming_passthrough:
+            return x
+        return self.reduce_spatial(x, mask=mask)
+
+    @staticmethod
+    def require_single_nchw(inputs: Sequence[torch.Tensor]) -> torch.Tensor:
+        """Validate and return the sole NCHW tensor input."""
+        if len(inputs) != 1:
+            raise ValueError(f"SpatialReducer expects exactly one tensor input, got {len(inputs)}.")
+        x = inputs[0]
+        if x.ndim != 4:
+            raise ValueError(f"SpatialReducer expects an NCHW tensor, got shape={tuple(x.shape)}")
+        return x
+
+    def reduce_spatial(self, x: torch.Tensor, *, mask: torch.Tensor | None = None) -> torch.Tensor:
+        """Reduce one NCHW tensor over its spatial dimensions."""
+        raise NotImplementedError(f"{type(self).__name__}.reduce_spatial() must be implemented")
+
+
+class MultiInputSpatialReducer(BaseReducer, ABC):
+    """Base class for reducers that consume multiple aligned spatial tensors.
+
+    ``expected_inputs`` may be set by subclasses to enforce arity.  Inputs are
+    validated as NCHW tensors with matching batch and spatial dimensions before
+    :meth:`reduce_spatial_inputs` is called.
+    """
+
+    expected_inputs: int | None = None
+
+    def forward(self, *inputs: torch.Tensor, mask: torch.Tensor | None = None) -> torch.Tensor:
+        tensors = self.require_aligned_nchw(inputs)
+        if self._streaming_passthrough:
+            return tensors[0]
+        return self.reduce_spatial_inputs(*tensors, mask=mask)
+
+    @classmethod
+    def require_aligned_nchw(cls, inputs: Sequence[torch.Tensor]) -> tuple[torch.Tensor, ...]:
+        """Validate multi-input NCHW arity and spatial alignment."""
+        if cls.expected_inputs is not None and len(inputs) != cls.expected_inputs:
+            raise ValueError(f"{cls.__name__} expects exactly {cls.expected_inputs} tensor inputs, got {len(inputs)}.")
+        if len(inputs) == 0:
+            raise ValueError(f"{cls.__name__} expects at least one tensor input.")
+        tensors = tuple(inputs)
+        first = tensors[0]
+        if first.ndim != 4:
+            raise ValueError(f"{cls.__name__} expects NCHW tensors, got shape={tuple(first.shape)}")
+        batch = first.shape[0]
+        spatial = first.shape[-2:]
+        for idx, tensor in enumerate(tensors[1:], start=1):
+            if tensor.ndim != 4:
+                raise ValueError(f"{cls.__name__} input {idx} must be NCHW, got shape={tuple(tensor.shape)}")
+            if tensor.shape[0] != batch or tensor.shape[-2:] != spatial:
+                raise ValueError(
+                    f"{cls.__name__} input {idx} must match batch/spatial dimensions "
+                    f"N={batch}, H/W={tuple(spatial)}, got shape={tuple(tensor.shape)}"
+                )
+        return tensors
+
+    def reduce_spatial_inputs(self, *inputs: torch.Tensor, mask: torch.Tensor | None = None) -> torch.Tensor:
+        """Reduce aligned NCHW tensor inputs over their spatial dimensions."""
+        raise NotImplementedError(f"{type(self).__name__}.reduce_spatial_inputs() must be implemented")
+
+
+class ManualVJPReducer(BaseStreamingGlobalReducer, ABC):
+    """Streaming reducer base for implementations with manual VJP replay.
+
+    Custom streaming reducers can inherit from this class when they provide a
+    reducer-specific :meth:`reduce_tile_for_backward` expression instead of
+    relying on a generic autograd reduction formula.
+    """
+
+
+ManualBackwardReducer = ManualVJPReducer

--- a/lightstream/core/reducer/sum.py
+++ b/lightstream/core/reducer/sum.py
@@ -3,11 +3,11 @@
 import torch
 
 from .base import BaseStreamingGlobalReducer, streaming_reduce_tile
-from .reducer_base import BaseReducer
+from .reducer_base import ManualVJPReducer, SpatialReducer
 from .utils import normalize_spatial_mask, resolve_accumulator_dtype
 
 
-class SumReducer(BaseReducer):
+class SumReducer(SpatialReducer):
     """Apply global spatial sum reduction on NCHW tensors."""
 
     def __init__(self, accumulator_dtype: torch.dtype | None = None):
@@ -33,7 +33,7 @@ class SumReducer(BaseReducer):
         return StreamingSumReducer(accumulator_dtype=self.accumulator_dtype)
 
 
-class StreamingSumReducer(BaseStreamingGlobalReducer):
+class StreamingSumReducer(ManualVJPReducer):
     """Streaming reducer configured for sum semantics."""
 
     def __init__(self, accumulator_dtype: torch.dtype | None = None):


### PR DESCRIPTION
### Motivation
- Provide clear user-extensible extension points for reducer math/operator behavior while keeping engine orchestration composition-based rather than via a large inheritance hierarchy.  
- Allow custom multi-input and manual-backward streaming reducers and small per-layer adapters to be registered without coupling to engine internals.  
- Keep `StreamingEngine` as a thin facade that owns collaborators responsible for planning, execution, reducer runtime, and adapter registry.

### Description
- Add reducer extension base classes: `SpatialReducer`, `MultiInputSpatialReducer`, and `ManualVJPReducer` (alias `ManualBackwardReducer`) in `lightstream/core/reducer/reducer_base.py`, and update concrete reducers to inherit these focused base types.  
- Add a `StreamableLayerAdapter` protocol and ordered `AdapterRegistry` in `lightstream/core/engine/adapters.py` to support pluggable layer conversion adapters.  
- Introduce composition collaborators (`TilePlanner`, `ForwardExecutor`, `BackwardExecutor`, `ReducerRuntime`) and an `EngineCollaborators` bundle in `lightstream/core/engine/orchestration.py` for compile/run responsibilities.  
- Refactor `StreamingEngine` (`lightstream/core/engine/api.py`) to own and default-initialize these collaborators and to delegate compile/forward/backward flows to them, and export the new types from package entry points for consumers.  

### Testing
- Ran `python3 -m compileall lightstream` to verify module-level syntax and imports, which completed successfully.  
- Executed custom Python smoke tests that import the new APIs, instantiate `StreamingEngine` with defaults, verify collaborator types, check reducer subclass relationships and alias (`ManualBackwardReducer is ManualVJPReducer`), and assert reducer forward shapes; all assertions passed.  
- Committed the changes after fixing minor import adjustments and re-running the compile checks successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1effa92a6083309f98e6203db4df54)