### PR TITLE
Refactor streaming reducer API to init/update/finalize contract

### DIFF
--- a/lightstream/core/engine/reducers.py
+++ b/lightstream/core/engine/reducers.py
@@ -163,10 +163,10 @@ class ReducerMixin:
         for idx, tensor in enumerate(flat_outputs):
             output_id_to_index.setdefault(id(tensor), idx)
         for reducer in self._streaming_reducers:
-            reducer_inputs = getattr(reducer, "_last_inputs", None)
+            reducer_inputs = getattr(reducer, "_passthrough_inputs", None)
             if reducer_inputs is not None:
                 if not isinstance(reducer_inputs, (tuple, list)):
-                    raise RuntimeError(f"Reducer {type(reducer).__name__} _last_inputs must be tuple/list, got {type(reducer_inputs)}")
+                    raise RuntimeError(f"Reducer {type(reducer).__name__} _passthrough_inputs must be tuple/list, got {type(reducer_inputs)}")
                 input_indices = []
                 for input_pos, inp in enumerate(reducer_inputs):
                     idx = output_id_to_index.get(id(inp))
@@ -175,16 +175,16 @@ class ReducerMixin:
                             f"Reducer {type(reducer).__name__} input {input_pos} is not present in flattened outputs; cannot resolve reducer head inputs."
                         )
                     input_indices.append(idx)
-                output_index = output_id_to_index.get(id(reducer._last_output))
+                output_index = output_id_to_index.get(id(reducer._passthrough_output))
                 if output_index is None:
                     raise RuntimeError(f"Reducer {type(reducer).__name__} output is not present in flattened outputs.")
                 self._reducer_head_map[output_index] = reducer
                 self._reducer_input_indices[output_index] = tuple(input_indices)
                 continue
 
-            if reducer._last_output is None:
+            if getattr(reducer, "_passthrough_output", None) is None:
                 continue
-            output_index = output_id_to_index.get(id(reducer._last_output))
+            output_index = output_id_to_index.get(id(reducer._passthrough_output))
             if output_index is not None:
                 self._reducer_head_map[output_index] = reducer
                 self._reducer_input_indices[output_index] = (output_index,)

--- a/lightstream/core/reducer/__init__.py
+++ b/lightstream/core/reducer/__init__.py
@@ -1,4 +1,4 @@
-from .base import BaseStreamingGlobalReducer, StreamingReducer
+from .base import BaseStreamingGlobalReducer, ReducerMeta, ReducerReplayRecord, ReducerTile, StreamingReducer
 from .attention_gem import AttentionGeMReducer, StreamingAttentionGeMReducer
 from .gem import GeMReducer, StreamingGeMReducer
 from .mean import MeanReducer, StreamingMeanReducer
@@ -14,6 +14,9 @@ __all__ = [
     "ManualVJPReducer",
     "ManualBackwardReducer",
     "BaseStreamingGlobalReducer",
+    "ReducerMeta",
+    "ReducerTile",
+    "ReducerReplayRecord",
     "StreamingReducer",
     "StreamingMeanReducer",
     "StreamingSumReducer",

--- a/lightstream/core/reducer/attention_gem.py
+++ b/lightstream/core/reducer/attention_gem.py
@@ -2,9 +2,11 @@
 
 from __future__ import annotations
 
+from dataclasses import dataclass
+
 import torch
 
-from .base import BaseStreamingGlobalReducer, streaming_reduce_tile
+from .base import BaseStreamingGlobalReducer, ReducerMeta, ReducerTile, streaming_reduce_tile
 from .reducer_base import ManualVJPReducer, MultiInputSpatialReducer
 from .utils import normalize_spatial_mask, resolve_accumulator_dtype
 
@@ -95,6 +97,13 @@ class AttentionGeMReducer(MultiInputSpatialReducer):
         return reducer
 
 
+@dataclass
+class AttentionGeMState:
+    running_m: torch.Tensor
+    running_zhat: torch.Tensor
+    running_shat: torch.Tensor
+
+
 class StreamingAttentionGeMReducer(ManualVJPReducer):
     """Streaming attention-weighted global GeM reducer with stable softmax accumulation."""
 
@@ -110,76 +119,19 @@ class StreamingAttentionGeMReducer(ManualVJPReducer):
     def current_r(self) -> torch.Tensor:
         return self.r
 
-    def forward(self, *inputs: torch.Tensor, mask: torch.Tensor | None = None) -> torch.Tensor | tuple[torch.Tensor, torch.Tensor]:
-        if len(inputs) != 2:
-            raise ValueError(f"StreamingAttentionGeMReducer expects exactly two inputs (x_tile, logits_tile), got {len(inputs)}.")
-        x_tile, logits_tile = inputs
-        self._last_inputs = (x_tile, logits_tile)
-        self._last_output = x_tile
-        return x_tile, logits_tile
+    def init_state(self, meta: ReducerMeta) -> "AttentionGeMState":
+        running_m = torch.full((meta.batch_size, 1, 1, 1), torch.finfo(meta.accumulator_dtype).min, device=meta.device, dtype=meta.accumulator_dtype)
+        running_zhat = torch.zeros((meta.batch_size, 1, 1, 1), device=meta.device, dtype=meta.accumulator_dtype)
+        running_shat = torch.zeros((meta.batch_size, meta.channels, 1, 1), device=meta.device, dtype=meta.accumulator_dtype)
+        self.running_m = running_m
+        self.running_zhat = running_zhat
+        self.running_shat = running_shat
+        return AttentionGeMState(running_m=running_m, running_zhat=running_zhat, running_shat=running_shat)
 
-    def accumulate_stream_tile(self, trimmed_output, tile_y: int, tile_x: int, sides, dst_box, user_mask: torch.Tensor | None = None):
-        payload = self._parse_multi_input_payload(trimmed_output)
-        if len(payload) != 2:
-            raise ValueError(f"StreamingAttentionGeMReducer expects payload arity=2, got {len(payload)}")
-        x_tile, _ = payload
-        dst_y0, dst_y1, dst_x0, dst_x1 = dst_box
-        seen_slice = self._stream_seen_mask[dst_y0:dst_y1, dst_x0:dst_x1]
-        new_mask = ~seen_slice
-        effective_mask = new_mask if user_mask is None else (new_mask & user_mask.to(dtype=torch.bool, device=new_mask.device))
-        if self._debug_replay_enabled:
-            if self._replay_assignments is None:
-                raise RuntimeError("Reducer replay assignments are not initialized.")
-            self._replay_assignments.append(
-                (
-                    int(tile_y),
-                    int(tile_x),
-                    bool(sides.top),
-                    bool(sides.left),
-                    bool(sides.right),
-                    bool(sides.bottom),
-                    int(x_tile.shape[-2]),
-                    int(x_tile.shape[-1]),
-                    int(dst_y0),
-                    int(dst_y1),
-                    int(dst_x0),
-                    int(dst_x1),
-                    len(payload),
-                )
-            )
-        if torch.any(effective_mask):
-            self.accumulate_valid_tile(payload, valid_mask=effective_mask)
-        seen_slice |= new_mask
-
-    def build_backward_pair(self, trimmed_output, gradient: torch.Tensor, *, input_y: int, input_x: int, sides, valid_mask: torch.Tensor | None = None):
-        payload = self._parse_multi_input_payload(trimmed_output)
-        x_tile = payload[0]
-        expected_h, expected_w = int(x_tile.shape[-2]), int(x_tile.shape[-1])
-        if self._debug_replay_enabled:
-            if self._replay_assignments is None or self._replay_cursor is None:
-                raise RuntimeError("Reducer replay state is not initialized. Call start_backward_replay() first.")
-            self._replay_cursor = self._validate_replay_assignment(
-                assignments=self._replay_assignments,
-                cursor=self._replay_cursor,
-                input_y=input_y,
-                input_x=input_x,
-                sides=sides,
-                expected_h=expected_h,
-                expected_w=expected_w,
-                expected_arity=len(payload),
-            )
-        reduced_output = self.reduce_tile_for_backward(payload, valid_mask=valid_mask, global_context=self.extra_state_for_backward())
-        return reduced_output, gradient
-
-    def init_reduction_state(self, *, batch_size: int, channels: int, device: torch.device, dtype: torch.dtype, accumulator_dtype: torch.dtype) -> None:
-        self.running_m = torch.full((batch_size, 1, 1, 1), torch.finfo(accumulator_dtype).min, device=device, dtype=accumulator_dtype)
-        self.running_zhat = torch.zeros((batch_size, 1, 1, 1), device=device, dtype=accumulator_dtype)
-        self.running_shat = torch.zeros((batch_size, channels, 1, 1), device=device, dtype=accumulator_dtype)
-
-    def accumulate_valid_tile(self, tile, valid_mask: torch.Tensor) -> None:
-        x_tile, logits_tile = self._parse_multi_input_payload(tile)
-        if self.running_shat.numel() == 0:
-            self.reset_stream_state(batch_size=x_tile.shape[0], channels=x_tile.shape[1], device=x_tile.device, dtype=x_tile.dtype)
+    def update(self, state: "AttentionGeMState", tile: ReducerTile) -> "AttentionGeMState":
+        if len(tile.tensors) != 2:
+            raise ValueError(f"StreamingAttentionGeMReducer expects payload arity=2, got {len(tile.tensors)}")
+        x_tile, logits_tile = tile.tensors
 
         acc_dtype = resolve_accumulator_dtype(self.accumulator_dtype, x_tile.dtype)
         x = x_tile.to(dtype=acc_dtype).clamp_min(self.eps)
@@ -188,7 +140,7 @@ class StreamingAttentionGeMReducer(ManualVJPReducer):
         x_pow = x.pow(r)
 
         neg_inf = torch.finfo(acc_dtype).min
-        valid4d = valid_mask[None, None].to(device=x_tile.device, dtype=torch.bool)
+        valid4d = tile.mask[None, None].to(device=x_tile.device, dtype=torch.bool)
         logits = torch.where(valid4d, logits, torch.full_like(logits, neg_inf))
 
         m_tile = logits.amax(dim=(-2, -1), keepdim=True)
@@ -201,17 +153,21 @@ class StreamingAttentionGeMReducer(ManualVJPReducer):
         alpha_prev = torch.exp(self.running_m.to(dtype=acc_dtype) - m_new)
         alpha_tile = torch.exp(m_tile - m_new)
 
-        self.running_zhat = self.running_zhat.to(dtype=acc_dtype) * alpha_prev + z_tile * alpha_tile
-        self.running_shat = self.running_shat.to(dtype=acc_dtype) * alpha_prev + s_tile * alpha_tile
-        self.running_m = m_new
+        state.running_zhat = state.running_zhat.to(dtype=acc_dtype) * alpha_prev + z_tile * alpha_tile
+        state.running_shat = state.running_shat.to(dtype=acc_dtype) * alpha_prev + s_tile * alpha_tile
+        state.running_m = m_new
+        self.running_zhat = state.running_zhat
+        self.running_shat = state.running_shat
+        self.running_m = state.running_m
+        return state
 
-    def finalize_from_state(self) -> torch.Tensor:
-        if self.running_shat.numel() == 0:
-            raise RuntimeError("StreamingAttentionGeMReducer state is empty, accumulate_stream_tile() was not called.")
-        acc_dtype = resolve_accumulator_dtype(self.accumulator_dtype, self.running_shat.dtype)
-        r = self.current_r.to(device=self.running_shat.device, dtype=acc_dtype)
-        weighted_mean = self.running_shat.to(dtype=acc_dtype) / self.running_zhat.to(dtype=acc_dtype).clamp_min(self.eps)
-        return weighted_mean.clamp_min(self.eps).pow(1.0 / r).to(dtype=self.running_shat.dtype)
+    def finalize(self, state: "AttentionGeMState") -> torch.Tensor:
+        if state.running_shat.numel() == 0:
+            raise RuntimeError("StreamingAttentionGeMReducer state is empty.")
+        acc_dtype = resolve_accumulator_dtype(self.accumulator_dtype, state.running_shat.dtype)
+        r = self.current_r.to(device=state.running_shat.device, dtype=acc_dtype)
+        weighted_mean = state.running_shat.to(dtype=acc_dtype) / state.running_zhat.to(dtype=acc_dtype).clamp_min(self.eps)
+        return weighted_mean.clamp_min(self.eps).pow(1.0 / r).to(dtype=state.running_shat.dtype)
 
     def extra_state_for_backward(self) -> dict[str, torch.Tensor | int | float | None]:
         acc_dtype = resolve_accumulator_dtype(self.accumulator_dtype, self.running_shat.dtype)
@@ -226,10 +182,10 @@ class StreamingAttentionGeMReducer(ManualVJPReducer):
             "r": r,
         }
 
-    def reduce_tile_for_backward(self, trimmed_output, valid_mask: torch.Tensor | None, global_context):
-        if valid_mask is None:
-            raise ValueError("StreamingAttentionGeMReducer backward replay requires a valid_mask.")
-        x_tile, logits_tile = self._parse_multi_input_payload(trimmed_output)
+    def reduce_tile_for_backward(self, tile: ReducerTile, global_context):
+        if tile.mask is None:
+            raise ValueError("StreamingAttentionGeMReducer backward replay requires a tile mask.")
+        x_tile, logits_tile = tile.tensors
         acc_dtype = resolve_accumulator_dtype(self.accumulator_dtype, x_tile.dtype)
         x = x_tile.to(dtype=acc_dtype).clamp_min(self.eps)
         logits = _normalize_logits(logits_tile, x_tile).to(dtype=acc_dtype)
@@ -239,14 +195,14 @@ class StreamingAttentionGeMReducer(ManualVJPReducer):
 
         global_mean = global_context["mean"].to(device=x_tile.device, dtype=acc_dtype)
 
-        valid4d = valid_mask[None, None].to(device=x_tile.device, dtype=torch.bool)
+        valid4d = tile.mask[None, None].to(device=x_tile.device, dtype=torch.bool)
         x_pow = x.pow(r)
         neg_inf = torch.finfo(acc_dtype).min
         logits = torch.where(valid4d, logits, torch.full_like(logits, neg_inf))
         weights_unnorm = torch.exp(logits - m)
         weights_unnorm = torch.where(valid4d, weights_unnorm, torch.zeros_like(weights_unnorm))
-        local_s_over_z = streaming_reduce_tile(weights_unnorm * x_pow, valid_mask, zhat)
-        local_z_over_z = streaming_reduce_tile(weights_unnorm, valid_mask, zhat)
+        local_s_over_z = streaming_reduce_tile(weights_unnorm * x_pow, tile.mask, zhat)
+        local_z_over_z = streaming_reduce_tile(weights_unnorm, tile.mask, zhat)
 
         # Backward replay uses this as a surrogate for the derivative of the
         # finalized global reducer output y = (global_S / global_Z) ** (1/r).

--- a/lightstream/core/reducer/base.py
+++ b/lightstream/core/reducer/base.py
@@ -1,42 +1,92 @@
+"""Streaming reducer runtime primitives.
+
+The public streaming reducer contract is intentionally small:
+
+``init_state(meta) -> state``
+``update(state, ReducerTile) -> state``
+``finalize(state) -> tensor``
+
+The engine-facing adapter in this module owns tile geometry, overlap-safe
+accounting, reducer mask slicing, replay metadata, and output placement hooks so
+reducer authors only implement reduction math.
+"""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from dataclasses import dataclass
+from typing import Any, Sequence
+
 import torch
 import torch.nn as nn
-from abc import ABC, abstractmethod
-from typing import Sequence
+
+from lightstream.core.scnn.utils import Box
 
 from .utils import resolve_accumulator_dtype
 
 
-class StreamingReducerTileF(torch.autograd.Function):
-    """Tile-local spatial reducer autograd primitive.
+@dataclass(frozen=True)
+class ReducerMeta:
+    """Metadata supplied by the engine when a reducer stream starts."""
 
-    This function computes a spatial sum (or normalized sum) for a single tile and
-    returns a tensor of shape ``[N, C, 1, 1]``. In backward, gradients are expanded
-    back to tile shape and masked when a valid mask is provided.
+    output_height: int
+    output_width: int
+    batch_size: int
+    channels: int
+    device: torch.device
+    dtype: torch.dtype
+    accumulator_dtype: torch.dtype
+
+
+@dataclass(frozen=True)
+class ReducerTile:
+    """Engine-normalized tile payload passed to user reducers.
+
+    Attributes
+    ----------
+    tensors:
+        One or more aligned NCHW tile tensors. Multi-input reducers receive a
+        tuple whose tensors share batch and spatial dimensions.
+    mask:
+        Effective 2D bool mask in reducer-output coordinates after overlap
+        accounting and optional user mask slicing. ``True`` pixels contribute.
+    box:
+        Tile placement in reducer-output coordinates.
+    is_new:
+        2D bool mask identifying pixels that have not been seen by earlier
+        overlapping tiles, before applying any user mask.
     """
 
+    tensors: tuple[torch.Tensor, ...]
+    mask: torch.Tensor | None
+    box: Box
+    is_new: torch.Tensor | None
+
+
+@dataclass(frozen=True)
+class ReducerReplayRecord:
+    """Engine-owned metadata used to validate reducer backward replay."""
+
+    tile_y: int
+    tile_x: int
+    top: bool
+    left: bool
+    right: bool
+    bottom: bool
+    height: int
+    width: int
+    dst_y0: int
+    dst_y1: int
+    dst_x0: int
+    dst_x1: int
+    arity: int
+
+
+class StreamingReducerTileF(torch.autograd.Function):
+    """Tile-local spatial reducer autograd primitive."""
+
     @staticmethod
-    def forward(
-        ctx,
-        tile_output: torch.Tensor,
-        valid_mask: torch.Tensor | None,
-        normalization: torch.Tensor | None,
-    ) -> torch.Tensor:
-        """Reduce one tile contribution.
-
-        Parameters
-        ----------
-        tile_output : torch.Tensor
-            Tile tensor with shape ``[N, C, H, W]``.
-        valid_mask : torch.Tensor | None
-            Optional spatial mask with shape ``[H, W]`` that marks valid pixels.
-        normalization : torch.Tensor | None
-            Optional divisor tensor, usually running counts for mean mode.
-
-        Returns
-        -------
-        torch.Tensor
-            Reduced tile output with shape ``[N, C, 1, 1]``.
-        """
+    def forward(ctx, tile_output: torch.Tensor, valid_mask: torch.Tensor | None, normalization: torch.Tensor | None) -> torch.Tensor:
         if tile_output.ndim != 4:
             raise ValueError(f"StreamingReducer expects NCHW tile, got shape={tuple(tile_output.shape)}")
 
@@ -68,34 +118,17 @@ class StreamingReducerTileF(torch.autograd.Function):
             reduced = masked.sum(dim=(-2, -1), keepdim=True, dtype=acc_dtype).to(dtype=tile_output.dtype)
             ctx.normalization = None
             ctx.has_normalization = False
-
         return reduced
 
     @staticmethod
     def backward(ctx, grad_output: torch.Tensor):
-        """Propagate gradients from reduced output back to tile layout.
-
-        Parameters
-        ----------
-        grad_output : torch.Tensor
-            Gradient at reduced output with shape ``[N, C, 1, 1]``.
-
-        Returns
-        -------
-        tuple[torch.Tensor, None, None]
-            Gradient for tile input and ``None`` for non-differentiable inputs.
-        """
         (mask_4d,) = ctx.saved_tensors
-
         grad_input = grad_output
         if ctx.has_normalization:
             grad_input = (grad_input.to(dtype=ctx.normalization.dtype) / ctx.normalization).to(dtype=grad_output.dtype)
-
         grad_input = grad_input.expand(-1, -1, ctx.input_height, ctx.input_width)
-
         if ctx.has_mask:
             grad_input = grad_input * mask_4d.to(dtype=grad_input.dtype, device=grad_input.device)
-
         return grad_input, None, None
 
 
@@ -103,64 +136,31 @@ streaming_reduce_tile = StreamingReducerTileF.apply
 
 
 class BaseStreamingGlobalReducer(nn.Module, ABC):
-    """Abstract base class for streaming global reducers.
+    """Engine adapter for the reducer ``init_state/update/finalize`` API.
 
-    This base class owns:
-    - stream lifecycle setup/reset (`start_stream`, `reset_stream_state`)
-    - overlap-safe tile orchestration (`accumulate_stream_tile`)
-    - stream finalization (`finish_stream`/`finalize_stream`)
-    - debug backward replay bookkeeping (`start_backward_replay`,
-      `build_backward_pair`, replay validation).
-
-    Subclasses must implement:
-    - `init_reduction_state(...)`
-    - `accumulate_valid_tile(tile, valid_mask)`
-    - `finalize_from_state()`
-    - `reduce_tile_for_backward(trimmed_output, valid_mask, global_context)`
-
-    Subclasses may override:
-    - `extra_state_for_backward()` to expose global tensors/scalars needed during
-      backward replay tile reduction.
-
-    Base guarantees:
-    - non-overlapping accounting across streamed tiles via `_stream_seen_mask`
-      semantics (parity with previous mean reducer behavior)
-    - centralized accumulator dtype policy helpers (minimum fp32 when unresolved
-      by caller/subclass through `resolve_accumulator_dtype`)
-    - consistent replay metadata validation between forward tile traversal and
-      backward replay traversal.
-
-    This class owns stream lifecycle, tile accumulation state, optional replay
-    bookkeeping, and final reduction output assembly.
-
-    Parameters
-    ----------
-    mode : str, default="mean"
-        Reduction mode. Must be ``"sum"`` or ``"mean"``.
-    accumulator_dtype : torch.dtype | None, default=None
-        Optional accumulator dtype for numerically stable reduction.
+    Subclasses implement the user-facing reducer lifecycle. This base class is
+    responsible for legacy engine integration, including overlap-safe tile
+    accounting, replay metadata, and passthrough bookkeeping used by the engine
+    to discover reducer heads and aligned multi-input payloads.
     """
 
-    @staticmethod
-    def _parse_single_input_payload(payload: torch.Tensor | Sequence[torch.Tensor]) -> torch.Tensor:
-        """Normalize reducer payload for legacy single-input reducers."""
-        if isinstance(payload, torch.Tensor):
-            return payload
-        if isinstance(payload, (tuple, list)):
-            if len(payload) != 1:
-                raise ValueError(
-                    "Legacy reducers expect a single tile tensor payload; "
-                    f"got structured payload with arity={len(payload)}."
-                )
-            tile = payload[0]
-            if not isinstance(tile, torch.Tensor):
-                raise TypeError(f"Expected tensor payload element, got {type(tile)!r}.")
-            return tile
-        raise TypeError(f"Expected tile payload to be tensor/tuple/list, got {type(payload)!r}.")
+    def __init__(self, mode: str = "mean", accumulator_dtype: torch.dtype | None = None):
+        super().__init__()
+        self.mode = mode
+        self.accumulator_dtype = accumulator_dtype
+        self._streaming_passthrough = False
+        self.register_buffer("running_sum", torch.zeros(0), persistent=False)
+        self.register_buffer("running_count", torch.zeros(0), persistent=False)
+        self.register_buffer("_stream_seen_mask", torch.zeros(0, dtype=torch.bool), persistent=False)
+        self._state: Any = None
+        self._passthrough_inputs: tuple[torch.Tensor, ...] | None = None
+        self._passthrough_output: torch.Tensor | None = None
+        self._debug_replay_enabled = False
+        self._replay_assignments: list[ReducerReplayRecord] | None = None
+        self._replay_cursor: int | None = None
 
     @staticmethod
     def _parse_multi_input_payload(payload: torch.Tensor | Sequence[torch.Tensor]) -> tuple[torch.Tensor, ...]:
-        """Normalize reducer payload into a tuple of tile tensors."""
         if isinstance(payload, torch.Tensor):
             return (payload,)
         if not isinstance(payload, (tuple, list)):
@@ -172,110 +172,87 @@ class BaseStreamingGlobalReducer(nn.Module, ABC):
             raise TypeError(f"Structured tile payload elements must be tensors; got {bad_type!r}.")
         return tuple(payload)
 
-    def __init__(self, mode: str = "mean", accumulator_dtype: torch.dtype | None = None):
-        super().__init__()
-        if mode not in {"sum", "mean"}:
-            raise ValueError(f"Unsupported reducer mode '{mode}', expected 'sum' or 'mean'.")
-        self.mode = mode
-        self.accumulator_dtype = accumulator_dtype
-        self._streaming_passthrough = False
-        self.register_buffer("running_sum", torch.zeros(0), persistent=False)
-        self.register_buffer("running_count", torch.zeros(0), persistent=False)
-        self.register_buffer("_stream_seen_mask", torch.zeros(0, dtype=torch.bool), persistent=False)
-        self._last_output = None
-        self._debug_replay_enabled = False
-        self._replay_assignments: list[tuple] | None = None
-        self._replay_cursor: int | None = None
+    @staticmethod
+    def _parse_single_input_payload(payload: torch.Tensor | Sequence[torch.Tensor]) -> torch.Tensor:
+        tensors = BaseStreamingGlobalReducer._parse_multi_input_payload(payload)
+        if len(tensors) != 1:
+            raise ValueError(f"Single-input reducer expected arity=1, got {len(tensors)}.")
+        return tensors[0]
 
-    def reset_stream_state(
-        self,
-        batch_size: int,
-        channels: int,
-        device: torch.device,
-        dtype: torch.dtype,
-        accumulator_dtype: torch.dtype | None = None,
-    ):
-        """Reset running reduction buffers.
-
-        Parameters
-        ----------
-        batch_size : int
-            Batch size ``N``.
-        channels : int
-            Channel count ``C``.
-        device : torch.device
-            Target buffer device.
-        dtype : torch.dtype
-            Output accumulation dtype for ``running_sum``.
-        accumulator_dtype : torch.dtype | None, default=None
-            Optional dtype override for ``running_count``.
-        """
-        self.running_sum = torch.zeros((batch_size, channels, 1, 1), device=device, dtype=dtype)
+    def reset_stream_state(self, batch_size: int, channels: int, device: torch.device, dtype: torch.dtype, accumulator_dtype: torch.dtype | None = None):
         resolved_acc_dtype = resolve_accumulator_dtype(accumulator_dtype or self.accumulator_dtype, dtype)
+        self.running_sum = torch.zeros((batch_size, channels, 1, 1), device=device, dtype=dtype)
         self.running_count = torch.zeros((batch_size, 1, 1, 1), device=device, dtype=resolved_acc_dtype)
-        self.init_reduction_state(batch_size=batch_size, channels=channels, device=device, dtype=dtype, accumulator_dtype=resolved_acc_dtype)
 
-    def start_stream(
-        self,
-        output_height: int,
-        output_width: int,
-        batch_size: int,
-        channels: int,
-        device: torch.device,
-        dtype: torch.dtype,
-        debug_replay: bool = False,
-    ):
-        """Initialize reducer state before tile traversal."""
-        self.reset_stream_state(batch_size=batch_size, channels=channels, device=device, dtype=dtype)
+    def start_stream(self, output_height: int, output_width: int, batch_size: int, channels: int, device: torch.device, dtype: torch.dtype, debug_replay: bool = False):
+        acc_dtype = resolve_accumulator_dtype(self.accumulator_dtype, dtype)
+        self.reset_stream_state(batch_size=batch_size, channels=channels, device=device, dtype=dtype, accumulator_dtype=acc_dtype)
         self._stream_seen_mask = torch.zeros((output_height, output_width), dtype=torch.bool, device=device)
         self._debug_replay_enabled = debug_replay
         self._replay_assignments = [] if debug_replay else None
         self._replay_cursor = None
+        self._state = self.init_state(
+            ReducerMeta(
+                output_height=int(output_height),
+                output_width=int(output_width),
+                batch_size=int(batch_size),
+                channels=int(channels),
+                device=device,
+                dtype=dtype,
+                accumulator_dtype=acc_dtype,
+            )
+        )
 
     def accumulate_stream_tile(self, trimmed_output: torch.Tensor | Sequence[torch.Tensor], tile_y: int, tile_x: int, sides, dst_box, user_mask: torch.Tensor | None = None):
-        """Accumulate one tile while enforcing non-overlapping pixel counting.
-
-        Parameters
-        ----------
-        trimmed_output : torch.Tensor | Sequence[torch.Tensor]
-            Tile payload. A single tensor uses the legacy single-input path.
-            Tuple/list payloads represent structured multi-input tiles.
-        """
-        tile_payload = self._parse_single_input_payload(trimmed_output)
-        dst_y0, dst_y1, dst_x0, dst_x1 = dst_box
+        tensors = self._parse_multi_input_payload(trimmed_output)
+        ref = tensors[0]
+        dst_y0, dst_y1, dst_x0, dst_x1 = (int(v) for v in dst_box)
         seen_slice = self._stream_seen_mask[dst_y0:dst_y1, dst_x0:dst_x1]
-        new_mask = ~seen_slice
-        effective_mask = new_mask if user_mask is None else (new_mask & user_mask.to(dtype=torch.bool, device=new_mask.device))
+        is_new = ~seen_slice
+        effective_mask = is_new if user_mask is None else (is_new & user_mask.to(dtype=torch.bool, device=is_new.device))
+        box = Box(dst_y0, -1, dst_x0, -1, sides)
+
         if self._debug_replay_enabled:
             if self._replay_assignments is None:
                 raise RuntimeError("Reducer replay assignments are not initialized.")
             self._replay_assignments.append(
-                (
-                    int(tile_y),
-                    int(tile_x),
-                    bool(sides.top),
-                    bool(sides.left),
-                    bool(sides.right),
-                    bool(sides.bottom),
-                    int(tile_payload.shape[-2]),
-                    int(tile_payload.shape[-1]),
-                    int(dst_y0),
-                    int(dst_y1),
-                    int(dst_x0),
-                    int(dst_x1),
-                    1,
+                ReducerReplayRecord(
+                    tile_y=int(tile_y),
+                    tile_x=int(tile_x),
+                    top=bool(sides.top),
+                    left=bool(sides.left),
+                    right=bool(sides.right),
+                    bottom=bool(sides.bottom),
+                    height=int(ref.shape[-2]),
+                    width=int(ref.shape[-1]),
+                    dst_y0=dst_y0,
+                    dst_y1=dst_y1,
+                    dst_x0=dst_x0,
+                    dst_x1=dst_x1,
+                    arity=len(tensors),
                 )
             )
+
         if torch.any(effective_mask):
-            self.accumulate_valid_tile(tile_payload, valid_mask=effective_mask)
-        seen_slice |= new_mask
+            self._state = self.update(self._state, ReducerTile(tensors=tensors, mask=effective_mask, box=box, is_new=is_new))
+        seen_slice |= is_new
 
     def finish_stream(self) -> torch.Tensor:
-        """Return finalized reduced output for current stream."""
         return self.finalize_stream()
 
+    def finalize_stream(self) -> torch.Tensor:
+        if self._state is None:
+            raise RuntimeError("Reducer stream state is empty. Call start_stream() first.")
+        return self.finalize(self._state)
+
+    def forward(self, *inputs: torch.Tensor, mask: torch.Tensor | None = None) -> torch.Tensor | tuple[torch.Tensor, ...]:
+        if len(inputs) == 0:
+            raise ValueError(f"{type(self).__name__} passthrough expects at least one tensor input.")
+        self._passthrough_inputs = tuple(inputs)
+        self._passthrough_output = inputs[0]
+        return inputs[0] if len(inputs) == 1 else tuple(inputs)
+
     def start_backward_replay(self):
-        """Prepare replay cursor used by debug backward checks."""
         if self._debug_replay_enabled:
             if self._replay_assignments is None:
                 raise RuntimeError("Reducer replay assignments are not available for backward replay.")
@@ -284,7 +261,6 @@ class BaseStreamingGlobalReducer(nn.Module, ABC):
             self._replay_cursor = None
 
     def validate_backward_replay_consumed(self, *, head_idx: int):
-        """Validate that backward replay consumed all recorded assignments."""
         if not self._debug_replay_enabled:
             return
         if self._replay_assignments is None or self._replay_cursor is None:
@@ -292,22 +268,9 @@ class BaseStreamingGlobalReducer(nn.Module, ABC):
         if self._replay_cursor != len(self._replay_assignments):
             raise RuntimeError(f"Reducer assignment replay incomplete for head {head_idx}: consumed={self._replay_cursor}, expected={len(self._replay_assignments)}")
 
-    def finalize_stream(self) -> torch.Tensor:
-        """Compute final output from reducer state."""
-        return self.finalize_from_state()
-
     def build_backward_pair(self, trimmed_output: torch.Tensor | Sequence[torch.Tensor], gradient: torch.Tensor, *, input_y: int, input_x: int, sides, valid_mask: torch.Tensor | None = None) -> tuple[torch.Tensor, torch.Tensor]:
-        """Build reducer output / upstream gradient pair for backward orchestration.
-
-        Parameters
-        ----------
-        trimmed_output : torch.Tensor | Sequence[torch.Tensor]
-            Tile payload for backward replay. Accepts legacy single-input tensor
-            or structured tuple/list for multi-input reducers.
-        """
-        tile_payload = self._parse_single_input_payload(trimmed_output)
-        expected_h = int(tile_payload.shape[-2])
-        expected_w = int(tile_payload.shape[-1])
+        tensors = self._parse_multi_input_payload(trimmed_output)
+        ref = tensors[0]
         if self._debug_replay_enabled:
             if self._replay_assignments is None or self._replay_cursor is None:
                 raise RuntimeError("Reducer replay state is not initialized. Call start_backward_replay() first.")
@@ -317,114 +280,67 @@ class BaseStreamingGlobalReducer(nn.Module, ABC):
                 input_y=input_y,
                 input_x=input_x,
                 sides=sides,
-                expected_h=expected_h,
-                expected_w=expected_w,
-                expected_arity=1,
+                expected_h=int(ref.shape[-2]),
+                expected_w=int(ref.shape[-1]),
+                expected_arity=len(tensors),
             )
-        global_context = self.extra_state_for_backward()
-        reduced_output = self.reduce_tile_for_backward(tile_payload, valid_mask=valid_mask, global_context=global_context)
+        box = Box(int(input_y), -1, int(input_x), -1, sides)
+        tile = ReducerTile(tensors=tensors, mask=valid_mask, box=box, is_new=valid_mask)
+        reduced_output = self.reduce_tile_for_backward(tile, global_context=self.extra_state_for_backward())
         return reduced_output, gradient
 
     @abstractmethod
-    def init_reduction_state(self, *, batch_size: int, channels: int, device: torch.device, dtype: torch.dtype, accumulator_dtype: torch.dtype) -> None:
-        """Initialize subclass-owned state for a stream."""
+    def init_state(self, meta: ReducerMeta) -> Any:
+        """Initialize and return reducer state for a stream."""
 
     @abstractmethod
-    def accumulate_valid_tile(self, tile: torch.Tensor | Sequence[torch.Tensor], valid_mask: torch.Tensor) -> None:
-        """Accumulate one valid tile contribution into subclass state.
+    def update(self, state: Any, tile: ReducerTile) -> Any:
+        """Fold one engine-normalized tile into reducer state."""
 
-        ``tile`` may be a single tensor or structured tuple/list payload.
+    @abstractmethod
+    def finalize(self, state: Any) -> torch.Tensor:
+        """Return the finalized reducer output."""
+
+    def reduce_tile_for_backward(self, tile: ReducerTile, global_context: dict[str, torch.Tensor | int | float | None]) -> torch.Tensor:
+        """Advanced escape hatch for custom reducer backward replay.
+
+        Reducers with non-trivial VJPs can override this method. The default is
+        correct for sum-style single-input reducers.
         """
-
-    @abstractmethod
-    def finalize_from_state(self) -> torch.Tensor:
-        """Finalize and return stream output from subclass state."""
-
-    @abstractmethod
-    def reduce_tile_for_backward(self, trimmed_output: torch.Tensor | Sequence[torch.Tensor], valid_mask: torch.Tensor | None, global_context: dict[str, torch.Tensor | int | float | None]) -> torch.Tensor:
-        """Build a tile-local replay expression for reducer backward.
-
-        ``trimmed_output`` may be a single tensor or structured tuple/list payload.
-
-        The returned tensor is consumed only by backward replay and is allowed to be
-        a derivative surrogate. It does not need to numerically equal the tile's
-        final forward contribution, and for nonlinear global reducers such as GeM
-        it generally should not finalize each tile independently. Instead, the
-        implementation contract is gradient equivalence: when the same upstream
-        reducer gradient is applied to every replay tile and those per-tile input
-        gradients are summed over all tiles, the result must match the gradient of
-        the finalized global reducer output with respect to the original full
-        input(s).
-
-        Avoid applying nonlinear finalization (for example, ``pow(1.0 / r)``) to
-        each tile contribution unless the math has been derived to be equivalent
-        under this gradient-summing contract. Use ``global_context`` for finalized
-        global state needed to build an equivalent replay expression.
-        """
+        normalization = global_context.get("normalization") if global_context else None
+        return streaming_reduce_tile(tile.tensors[0], tile.mask, normalization)
 
     def extra_state_for_backward(self) -> dict[str, torch.Tensor | int | float | None]:
-        """Optional global state to feed `reduce_tile_for_backward`."""
         return {}
 
-    def _validate_replay_assignment(
-        self,
-        *,
-        assignments: list[tuple],
-        cursor: int,
-        input_y: int,
-        input_x: int,
-        sides,
-        expected_h: int,
-        expected_w: int,
-        expected_arity: int,
-    ) -> int:
-        """Check backward tile metadata against recorded forward metadata."""
+    def _validate_replay_assignment(self, *, assignments: list[ReducerReplayRecord], cursor: int, input_y: int, input_x: int, sides, expected_h: int, expected_w: int, expected_arity: int) -> int:
         if cursor >= len(assignments):
             raise RuntimeError("Reducer assignment cursor out of range.")
-        (f_tile_y, f_tile_x, f_top, f_left, f_right, f_bottom, f_h, f_w, dst_y0, dst_y1, dst_x0, dst_x1, f_arity) = assignments[cursor]
-        if (int(input_y) != int(f_tile_y) or int(input_x) != int(f_tile_x) or bool(sides.top) != bool(f_top) or bool(sides.left) != bool(f_left) or bool(sides.right) != bool(f_right) or bool(sides.bottom) != bool(f_bottom)):
-            raise RuntimeError("Reducer tile replay mismatch: " f"forward tile=({f_tile_y},{f_tile_x},{f_top},{f_left},{f_right},{f_bottom}) " f"backward tile=({int(input_y)},{int(input_x)},{bool(sides.top)},{bool(sides.left)},{bool(sides.right)},{bool(sides.bottom)})")
-        if expected_h != int(f_h) or expected_w != int(f_w):
-            raise RuntimeError("Reducer trimmed shape mismatch: " f"forward=({f_h},{f_w}) backward=({expected_h},{expected_w})")
-        if (dst_y1 - dst_y0) != expected_h or (dst_x1 - dst_x0) != expected_w:
-            raise RuntimeError("Reducer assignment mismatch: " f"stored=({dst_y0}:{dst_y1},{dst_x0}:{dst_x1}) current=({expected_h},{expected_w})")
-        if int(f_arity) != int(expected_arity):
-            raise RuntimeError(f"Reducer input arity mismatch: forward={int(f_arity)} backward={int(expected_arity)}")
+        record = assignments[cursor]
+        if (
+            int(input_y) != record.tile_y
+            or int(input_x) != record.tile_x
+            or bool(sides.top) != record.top
+            or bool(sides.left) != record.left
+            or bool(sides.right) != record.right
+            or bool(sides.bottom) != record.bottom
+        ):
+            raise RuntimeError(
+                "Reducer tile replay mismatch: "
+                f"forward tile=({record.tile_y},{record.tile_x},{record.top},{record.left},{record.right},{record.bottom}) "
+                f"backward tile=({int(input_y)},{int(input_x)},{bool(sides.top)},{bool(sides.left)},{bool(sides.right)},{bool(sides.bottom)})"
+            )
+        if expected_h != record.height or expected_w != record.width:
+            raise RuntimeError(f"Reducer trimmed shape mismatch: forward=({record.height},{record.width}) backward=({expected_h},{expected_w})")
+        if (record.dst_y1 - record.dst_y0) != expected_h or (record.dst_x1 - record.dst_x0) != expected_w:
+            raise RuntimeError(
+                "Reducer assignment mismatch: "
+                f"stored=({record.dst_y0}:{record.dst_y1},{record.dst_x0}:{record.dst_x1}) current=({expected_h},{expected_w})"
+            )
+        if record.arity != int(expected_arity):
+            raise RuntimeError(f"Reducer input arity mismatch: forward={record.arity} backward={int(expected_arity)}")
         return cursor + 1
 
-    def forward(self, *inputs: torch.Tensor, mask: torch.Tensor | None = None) -> torch.Tensor:
-        """Streaming forward passthrough for reducer tile payloads.
-
-        Parameters
-        ----------
-        *inputs : torch.Tensor
-            Positional tile payload.
-            Legacy reducers pass exactly one tile tensor. Multi-input reducers
-            may pass multiple tensors, and should document expected arity and
-            per-input shapes. This base implementation preserves only the legacy
-            one-input passthrough behavior.
-        mask : torch.Tensor | None, default=None
-            Unused placeholder for API parity with non-streaming reducers.
-            Behaves as keyword-only metadata and is not part of ``*inputs``.
-
-        Returns
-        -------
-        torch.Tensor
-            Input tensor unchanged for one-input legacy reducers.
-        """
-        if len(inputs) != 1:
-            raise ValueError(
-                "BaseStreamingGlobalReducer legacy passthrough expects exactly one tensor input; "
-                f"got {len(inputs)}."
-            )
-        x = inputs[0]
-        self._last_output = x
-        return x
 
 class StreamingReducer(BaseStreamingGlobalReducer, ABC):
-    """Backward-compatible abstract alias for custom streaming reducers.
-
-    This class intentionally does not implement a concrete reduction strategy.
-    Subclassers should implement the abstract methods from
-    :class:`BaseStreamingGlobalReducer` directly.
-    """
+    """Backward-compatible abstract alias for custom streaming reducers."""

--- a/lightstream/core/reducer/gem.py
+++ b/lightstream/core/reducer/gem.py
@@ -1,8 +1,10 @@
 """GeM reducer implementations for offline and streaming execution."""
 
+from dataclasses import dataclass
+
 import torch
 
-from .base import BaseStreamingGlobalReducer, streaming_reduce_tile
+from .base import BaseStreamingGlobalReducer, ReducerMeta, ReducerTile, streaming_reduce_tile
 from .reducer_base import ManualVJPReducer, SpatialReducer
 from .utils import normalize_spatial_mask, resolve_accumulator_dtype
 
@@ -63,6 +65,13 @@ class GeMReducer(SpatialReducer):
         return reducer
 
 
+@dataclass
+class GeMState:
+    running_sum: torch.Tensor
+    running_count: torch.Tensor
+    running_q: torch.Tensor
+
+
 class StreamingGeMReducer(ManualVJPReducer):
     """Streaming global GeM reducer."""
 
@@ -83,40 +92,46 @@ class StreamingGeMReducer(ManualVJPReducer):
     def current_r(self) -> torch.Tensor:
         return self.r
 
-    def init_reduction_state(self, *, batch_size: int, channels: int, device: torch.device, dtype: torch.dtype, accumulator_dtype: torch.dtype) -> None:
-        self.running_q = torch.zeros((batch_size, channels, 1, 1), device=device, dtype=accumulator_dtype)
+    def init_state(self, meta: ReducerMeta) -> "GeMState":
+        running_sum = torch.zeros((meta.batch_size, meta.channels, 1, 1), device=meta.device, dtype=meta.dtype)
+        running_count = torch.zeros((meta.batch_size, 1, 1, 1), device=meta.device, dtype=meta.accumulator_dtype)
+        running_q = torch.zeros((meta.batch_size, meta.channels, 1, 1), device=meta.device, dtype=meta.dtype)
+        self.running_sum = running_sum
+        self.running_count = running_count
+        self.running_q = running_q
+        return GeMState(running_sum=running_sum, running_count=running_count, running_q=running_q)
 
-    def accumulate_valid_tile(self, tile: torch.Tensor, valid_mask: torch.Tensor) -> None:
-        if self.running_sum.numel() == 0:
-            self.reset_stream_state(batch_size=tile.shape[0], channels=tile.shape[1], device=tile.device, dtype=tile.dtype)
-
-        acc_dtype = resolve_accumulator_dtype(self.accumulator_dtype, tile.dtype)
-        x = tile.to(dtype=acc_dtype)
+    def update(self, state: "GeMState", tile: ReducerTile) -> "GeMState":
+        (x_tile,) = tile.tensors
+        acc_dtype = resolve_accumulator_dtype(self.accumulator_dtype, x_tile.dtype)
+        x = x_tile.to(dtype=acc_dtype)
         x_clamped = x.clamp_min(self.eps)
-        r = self.current_r.to(device=tile.device, dtype=acc_dtype)
+        r = self.current_r.to(device=x_tile.device, dtype=acc_dtype)
 
         x_pow = x_clamped.pow(r)
-        s_tile = streaming_reduce_tile(x_pow, valid_mask, None).to(dtype=self.running_sum.dtype)
-        q_tile = streaming_reduce_tile(x_pow * x_clamped.log(), valid_mask, None).to(dtype=self.running_q.dtype)
+        s_tile = streaming_reduce_tile(x_pow, tile.mask, None).to(dtype=state.running_sum.dtype)
+        q_tile = streaming_reduce_tile(x_pow * x_clamped.log(), tile.mask, None).to(dtype=state.running_q.dtype)
 
-        self.running_sum = self.running_sum + s_tile
-        self.running_q = self.running_q + q_tile
+        state.running_sum = state.running_sum + s_tile
+        state.running_q = state.running_q + q_tile
+        n_pixels = int(tile.mask.sum().item()) if tile.mask is not None else int(x_tile.shape[-2] * x_tile.shape[-1])
+        state.running_count = state.running_count + torch.tensor(n_pixels, device=state.running_count.device, dtype=state.running_count.dtype)
+        self.running_sum = state.running_sum
+        self.running_count = state.running_count
+        self.running_q = state.running_q
+        return state
 
-        n_pixels = int(valid_mask.sum().item())
-        pixel_increment = torch.tensor(n_pixels, device=self.running_count.device, dtype=self.running_count.dtype)
-        self.running_count = self.running_count + pixel_increment
+    def finalize(self, state: "GeMState") -> torch.Tensor:
+        if state.running_sum.numel() == 0:
+            raise RuntimeError("StreamingGeMReducer state is empty.")
 
-    def finalize_from_state(self) -> torch.Tensor:
-        if self.running_sum.numel() == 0:
-            raise RuntimeError("StreamingGeMReducer state is empty, accumulate_stream_tile() was not called.")
-
-        acc_dtype = resolve_accumulator_dtype(self.accumulator_dtype, self.running_sum.dtype)
-        r = self.current_r.to(device=self.running_sum.device, dtype=acc_dtype)
-        s = self.running_sum.to(dtype=acc_dtype)
-        n = self.running_count.to(dtype=acc_dtype).clamp_min(1)
+        acc_dtype = resolve_accumulator_dtype(self.accumulator_dtype, state.running_sum.dtype)
+        r = self.current_r.to(device=state.running_sum.device, dtype=acc_dtype)
+        s = state.running_sum.to(dtype=acc_dtype)
+        n = state.running_count.to(dtype=acc_dtype).clamp_min(1)
         m = (s / n).clamp_min(self.eps)
         y = m.pow(1.0 / r)
-        return y.to(dtype=self.running_sum.dtype)
+        return y.to(dtype=state.running_sum.dtype)
 
     def extra_state_for_backward(self) -> dict[str, torch.Tensor | int | float | None]:
         acc_dtype = resolve_accumulator_dtype(self.accumulator_dtype, self.running_sum.dtype)
@@ -131,9 +146,10 @@ class StreamingGeMReducer(ManualVJPReducer):
             "q": self.running_q.to(dtype=acc_dtype),
         }
 
-    def reduce_tile_for_backward(self, trimmed_output: torch.Tensor, valid_mask: torch.Tensor | None, global_context: dict[str, torch.Tensor | int | float | None]) -> torch.Tensor:
-        if valid_mask is None:
-            raise ValueError("StreamingGeMReducer backward replay requires a valid_mask.")
+    def reduce_tile_for_backward(self, tile: ReducerTile, global_context: dict[str, torch.Tensor | int | float | None]) -> torch.Tensor:
+        if tile.mask is None:
+            raise ValueError("StreamingGeMReducer backward replay requires a tile mask.")
+        trimmed_output = tile.tensors[0]
 
         acc_dtype = resolve_accumulator_dtype(self.accumulator_dtype, trimmed_output.dtype)
         x = trimmed_output.to(dtype=acc_dtype)
@@ -142,7 +158,7 @@ class StreamingGeMReducer(ManualVJPReducer):
         n = global_context["normalization"].to(device=trimmed_output.device, dtype=acc_dtype).clamp_min(1)
 
         x_pow = x_clamped.pow(r)
-        local_m = streaming_reduce_tile(x_pow, valid_mask, n)
+        local_m = streaming_reduce_tile(x_pow, tile.mask, n)
 
         global_m = global_context["m"].to(device=trimmed_output.device, dtype=acc_dtype)
         scale = (1.0 / r) * global_m.clamp_min(self.eps).pow(1.0 / r - 1.0)

--- a/lightstream/core/reducer/mean.py
+++ b/lightstream/core/reducer/mean.py
@@ -1,10 +1,13 @@
 """Mean reducer implementations for offline and streaming execution."""
 
+from __future__ import annotations
+
+from dataclasses import dataclass
+
 import torch
 
-from .base import BaseStreamingGlobalReducer, streaming_reduce_tile
+from .base import BaseStreamingGlobalReducer, ReducerMeta, ReducerTile, streaming_reduce_tile
 from .reducer_base import SpatialReducer
-from .sum import StreamingSumReducer
 from .utils import normalize_spatial_mask, resolve_accumulator_dtype
 
 
@@ -36,33 +39,46 @@ class MeanReducer(SpatialReducer):
         return StreamingMeanReducer(accumulator_dtype=self.accumulator_dtype)
 
 
-class StreamingMeanReducer(StreamingSumReducer):
-    """Streaming reducer configured for mean semantics."""
+@dataclass
+class MeanState:
+    running_sum: torch.Tensor
+    running_count: torch.Tensor
+
+
+class StreamingMeanReducer(BaseStreamingGlobalReducer):
+    """Streaming reducer configured for mean semantics using the ReducerTile API."""
 
     def __init__(self, accumulator_dtype: torch.dtype | None = None):
-        super().__init__(accumulator_dtype=accumulator_dtype)
-        self.mode = "mean"
+        super().__init__(mode="mean", accumulator_dtype=accumulator_dtype)
 
-    def accumulate_valid_tile(self, tile: torch.Tensor, valid_mask: torch.Tensor) -> None:
-        super().accumulate_valid_tile(tile, valid_mask)
-        n_pixels = int(valid_mask.sum().item())
-        pixel_increment = torch.tensor(n_pixels, device=self.running_count.device, dtype=self.running_count.dtype)
-        self.running_count = self.running_count + pixel_increment
+    def init_state(self, meta: ReducerMeta) -> MeanState:
+        running_sum = torch.zeros((meta.batch_size, meta.channels, 1, 1), device=meta.device, dtype=meta.dtype)
+        running_count = torch.zeros((meta.batch_size, 1, 1, 1), device=meta.device, dtype=meta.dtype)
+        self.running_sum = running_sum
+        self.running_count = running_count
+        return MeanState(running_sum=running_sum, running_count=running_count)
 
-    def finalize_from_state(self) -> torch.Tensor:
-        if self.running_sum.numel() == 0:
-            raise RuntimeError("StreamingReducer state is empty, accumulate_stream_tile() was not called.")
-        acc_dtype = resolve_accumulator_dtype(self.accumulator_dtype, self.running_sum.dtype)
-        denom = self.running_count.to(dtype=acc_dtype).clamp_min(1)
-        if denom.dtype != self.running_sum.dtype:
-            denom = denom.to(dtype=self.running_sum.dtype)
-        return self.running_sum / denom
+    def update(self, state: MeanState, tile: ReducerTile) -> MeanState:
+        (x,) = tile.tensors
+        tile_contribution = streaming_reduce_tile(x, tile.mask, None).to(dtype=state.running_sum.dtype)
+        state.running_sum = state.running_sum + tile_contribution
+        n_pixels = int(tile.mask.sum().item()) if tile.mask is not None else int(x.shape[-2] * x.shape[-1])
+        state.running_count = state.running_count + torch.tensor(n_pixels, device=state.running_count.device, dtype=state.running_count.dtype)
+        self.running_sum = state.running_sum
+        self.running_count = state.running_count
+        return state
+
+    def finalize(self, state: MeanState) -> torch.Tensor:
+        if state.running_sum.numel() == 0:
+            raise RuntimeError("StreamingMeanReducer state is empty.")
+        denom = state.running_count.to(dtype=state.running_sum.dtype).clamp_min(1)
+        return state.running_sum / denom
 
     def extra_state_for_backward(self) -> dict[str, torch.Tensor | int | float | None]:
         return {"normalization": self.running_count}
 
-    def reduce_tile_for_backward(self, trimmed_output: torch.Tensor, valid_mask: torch.Tensor | None, global_context: dict[str, torch.Tensor | int | float | None]) -> torch.Tensor:
-        return streaming_reduce_tile(trimmed_output, valid_mask, global_context.get("normalization"))
+    def reduce_tile_for_backward(self, tile: ReducerTile, global_context: dict[str, torch.Tensor | int | float | None]) -> torch.Tensor:
+        return streaming_reduce_tile(tile.tensors[0], tile.mask, global_context.get("normalization"))
 
     def to_reducer(self) -> MeanReducer:
         return MeanReducer(accumulator_dtype=self.accumulator_dtype)

--- a/lightstream/core/reducer/sum.py
+++ b/lightstream/core/reducer/sum.py
@@ -1,8 +1,12 @@
 """Sum reducer implementations for offline and streaming execution."""
 
+from __future__ import annotations
+
+from dataclasses import dataclass
+
 import torch
 
-from .base import BaseStreamingGlobalReducer, streaming_reduce_tile
+from .base import BaseStreamingGlobalReducer, ReducerMeta, ReducerTile, streaming_reduce_tile
 from .reducer_base import ManualVJPReducer, SpatialReducer
 from .utils import normalize_spatial_mask, resolve_accumulator_dtype
 
@@ -33,31 +37,39 @@ class SumReducer(SpatialReducer):
         return StreamingSumReducer(accumulator_dtype=self.accumulator_dtype)
 
 
+@dataclass
+class SumState:
+    running_sum: torch.Tensor
+
+
 class StreamingSumReducer(ManualVJPReducer):
-    """Streaming reducer configured for sum semantics."""
+    """Streaming reducer configured for sum semantics using the ReducerTile API."""
 
     def __init__(self, accumulator_dtype: torch.dtype | None = None):
         super().__init__(mode="sum", accumulator_dtype=accumulator_dtype)
 
-    def init_reduction_state(self, *, batch_size: int, channels: int, device: torch.device, dtype: torch.dtype, accumulator_dtype: torch.dtype) -> None:
-        _ = (batch_size, channels, device, dtype, accumulator_dtype)
+    def init_state(self, meta: ReducerMeta) -> SumState:
+        running_sum = torch.zeros((meta.batch_size, meta.channels, 1, 1), device=meta.device, dtype=meta.dtype)
+        self.running_sum = running_sum
+        return SumState(running_sum=running_sum)
 
-    def accumulate_valid_tile(self, tile: torch.Tensor, valid_mask: torch.Tensor) -> None:
-        if self.running_sum.numel() == 0:
-            self.reset_stream_state(batch_size=tile.shape[0], channels=tile.shape[1], device=tile.device, dtype=tile.dtype)
-        tile_contribution = streaming_reduce_tile(tile, valid_mask, None)
-        self.running_sum = self.running_sum + tile_contribution
+    def update(self, state: SumState, tile: ReducerTile) -> SumState:
+        (x,) = tile.tensors
+        tile_contribution = streaming_reduce_tile(x, tile.mask, None).to(dtype=state.running_sum.dtype)
+        state.running_sum = state.running_sum + tile_contribution
+        self.running_sum = state.running_sum
+        return state
 
-    def finalize_from_state(self) -> torch.Tensor:
-        if self.running_sum.numel() == 0:
-            raise RuntimeError("StreamingReducer state is empty, accumulate_stream_tile() was not called.")
-        return self.running_sum
+    def finalize(self, state: SumState) -> torch.Tensor:
+        if state.running_sum.numel() == 0:
+            raise RuntimeError("StreamingSumReducer state is empty.")
+        return state.running_sum
 
     def extra_state_for_backward(self) -> dict[str, torch.Tensor | int | float | None]:
         return {"normalization": None}
 
-    def reduce_tile_for_backward(self, trimmed_output: torch.Tensor, valid_mask: torch.Tensor | None, global_context: dict[str, torch.Tensor | int | float | None]) -> torch.Tensor:
-        return streaming_reduce_tile(trimmed_output, valid_mask, global_context.get("normalization"))
+    def reduce_tile_for_backward(self, tile: ReducerTile, global_context: dict[str, torch.Tensor | int | float | None]) -> torch.Tensor:
+        return streaming_reduce_tile(tile.tensors[0], tile.mask, global_context.get("normalization"))
 
     def to_reducer(self) -> SumReducer:
         return SumReducer(accumulator_dtype=self.accumulator_dtype)

--- a/lightstream/core/reducers/__init__.py
+++ b/lightstream/core/reducers/__init__.py
@@ -1,0 +1,50 @@
+"""Public reducer API.
+
+This plural package is the preferred import location for reducer extension
+points. The legacy :mod:`lightstream.core.reducer` package re-exports the same
+symbols for compatibility.
+"""
+
+from lightstream.core.reducer import (
+    AttentionGeMReducer,
+    BaseReducer,
+    BaseStreamingGlobalReducer,
+    GeMReducer,
+    ManualBackwardReducer,
+    ManualVJPReducer,
+    MeanReducer,
+    MultiInputSpatialReducer,
+    ReducerMeta,
+    ReducerReplayRecord,
+    ReducerTile,
+    SpatialReducer as OfflineSpatialReducer,
+    StreamingAttentionGeMReducer,
+    StreamingGeMReducer,
+    StreamingMeanReducer,
+    StreamingReducer,
+    StreamingSumReducer,
+    SumReducer,
+)
+from .base import SpatialReducer
+
+__all__ = [
+    "MeanReducer",
+    "SumReducer",
+    "GeMReducer",
+    "AttentionGeMReducer",
+    "BaseReducer",
+    "SpatialReducer",
+    "OfflineSpatialReducer",
+    "MultiInputSpatialReducer",
+    "ManualVJPReducer",
+    "ManualBackwardReducer",
+    "BaseStreamingGlobalReducer",
+    "StreamingReducer",
+    "ReducerMeta",
+    "ReducerTile",
+    "ReducerReplayRecord",
+    "StreamingMeanReducer",
+    "StreamingSumReducer",
+    "StreamingGeMReducer",
+    "StreamingAttentionGeMReducer",
+]

--- a/lightstream/core/reducers/base.py
+++ b/lightstream/core/reducers/base.py
@@ -1,0 +1,24 @@
+"""Preferred reducer extension API."""
+
+from lightstream.core.reducer.base import (
+    BaseStreamingGlobalReducer,
+    ReducerMeta,
+    ReducerReplayRecord,
+    ReducerTile,
+    StreamingReducer,
+    streaming_reduce_tile,
+)
+
+# ``SpatialReducer`` is the preferred name for authors implementing the new
+# streaming contract: init_state(meta), update(state, tile), finalize(state).
+SpatialReducer = BaseStreamingGlobalReducer
+
+__all__ = [
+    "SpatialReducer",
+    "BaseStreamingGlobalReducer",
+    "StreamingReducer",
+    "ReducerMeta",
+    "ReducerTile",
+    "ReducerReplayRecord",
+    "streaming_reduce_tile",
+]


### PR DESCRIPTION
### Motivation
- Move reducer author surface to a small, clear contract: `init_state(meta)`, `update(state, tile)`, `finalize(state)` so authors only implement reduction math. 
- Let the engine own overlap-safe tile accounting, mask slicing/normalization, multi-input alignment, replay metadata, and output placement to simplify reducers and avoid duplicated logic. 
- Provide a preferred public API surface under `lightstream/core/reducers/` while keeping backward-compatible re-exports in the legacy `lightstream.core.reducer` package.

### Description
- Introduce engine-normalized runtime types `ReducerMeta`, `ReducerTile`, and `ReducerReplayRecord` and adapt the streaming primitive `streaming_reduce_tile` in `lightstream/core/reducer/base.py`, and centralize lifecycle handling in `BaseStreamingGlobalReducer` which now drives `init_state`, `update`, and `finalize` calls. 
- Port the streaming implementations of `SumReducer`, `MeanReducer`, `GeMReducer`, and `AttentionGeMReducer` to the new contract by introducing small state dataclasses (`SumState`, `MeanState`, `GeMState`, `AttentionGeMState`) and implementing `init_state`, `update`, and `finalize` (files: `lightstream/core/reducer/{sum,mean,gem,attention_gem}.py`). 
- Add a new preferred public package `lightstream/core/reducers/` that re-exports the canonical types and provides `SpatialReducer` alias for the new contract (new files `lightstream/core/reducers/__init__.py` and `lightstream/core/reducers/base.py`). 
- Update engine integration to use engine-owned passthrough metadata (renamed internal fields to `_passthrough_inputs`/`_passthrough_output`) and to construct `ReducerTile` payloads before calling reducer `update`/`reduce_tile_for_backward`, keeping mask slicing, common-crop alignment, and replay validation centralized (changes in `lightstream/core/engine/reducers.py`, `forward.py`, `backward.py`). 
- Preserve an advanced escape hatch: streaming reducers may still override `reduce_tile_for_backward` to provide custom backward-replay behavior. 

### Testing
- Compiled relevant modules with `python -m compileall lightstream/core/reducer lightstream/core/reducers lightstream/core/engine` and confirmed there are no syntax/compile errors. 
- Ran manual smoke tests that instantiate `StreamingSumReducer`, `StreamingMeanReducer`, `StreamingGeMReducer`, and `StreamingAttentionGeMReducer`, exercised `start_stream`, `accumulate_stream_tile`, `finish_stream`, `start_backward_replay`, `build_backward_pair`, and `validate_backward_replay_consumed`, and verified tensor shapes and dtype outputs; tests used a stubbed `lightning` import because the optional package is not present in the environment. 
- Ran `git diff --check` to ensure no whitespace/merge issues; results were clean.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1f050b20a083308d5718c111a11a59)