### PR TITLE
Add reducer authoring base classes and validation helpers

### DIFF
--- a/lightstream/core/reducer/__init__.py
+++ b/lightstream/core/reducer/__init__.py
@@ -2,7 +2,18 @@ from .base import BaseStreamingGlobalReducer, ReducerMeta, ReducerReplayRecord, 
 from .attention_gem import AttentionGeMReducer, StreamingAttentionGeMReducer
 from .gem import GeMReducer, StreamingGeMReducer
 from .mean import MeanReducer, StreamingMeanReducer
-from .reducer_base import BaseReducer, ManualBackwardReducer, ManualVJPReducer, MultiInputSpatialReducer, SpatialReducer
+from .reducer_base import (
+    BaseReducer,
+    ManualBackwardReducer,
+    ManualVJPReducer,
+    MultiInputSpatialReducer,
+    SpatialReducer,
+    validate_aligned_nchw_inputs,
+    validate_arity,
+    validate_channel_compatibility,
+    validate_mask_shape,
+    validate_nchw_shape,
+)
 from .sum import StreamingSumReducer, SumReducer
 
 __all__ = [
@@ -24,4 +35,9 @@ __all__ = [
     "StreamingGeMReducer",
     "AttentionGeMReducer",
     "StreamingAttentionGeMReducer",
+    "validate_arity",
+    "validate_nchw_shape",
+    "validate_channel_compatibility",
+    "validate_aligned_nchw_inputs",
+    "validate_mask_shape",
 ]

--- a/lightstream/core/reducer/attention_gem.py
+++ b/lightstream/core/reducer/attention_gem.py
@@ -7,8 +7,8 @@ from dataclasses import dataclass
 import torch
 
 from .base import BaseStreamingGlobalReducer, ReducerMeta, ReducerTile, streaming_reduce_tile
-from .reducer_base import ManualVJPReducer, MultiInputSpatialReducer
-from .utils import normalize_spatial_mask, resolve_accumulator_dtype
+from .reducer_base import ManualVJPReducer, MultiInputSpatialReducer, validate_mask_shape, validate_nchw_shape
+from .utils import resolve_accumulator_dtype
 
 
 def _normalize_logits(logits: torch.Tensor, x: torch.Tensor) -> torch.Tensor:
@@ -37,6 +37,8 @@ def _normalize_logits(logits: torch.Tensor, x: torch.Tensor) -> torch.Tensor:
 class AttentionGeMReducer(MultiInputSpatialReducer):
     """Apply attention-weighted global GeM reduction on NCHW tensors."""
 
+    expected_inputs = 2
+
     def __init__(self, r_init: float = 4.0, eps: float = 1e-6, accumulator_dtype: torch.dtype | None = None):
         super().__init__()
         self.eps = float(eps)
@@ -48,11 +50,10 @@ class AttentionGeMReducer(MultiInputSpatialReducer):
         return self.r
 
     def forward(self, *inputs: torch.Tensor, mask: torch.Tensor | None = None) -> torch.Tensor | tuple[torch.Tensor, torch.Tensor]:
-        if len(inputs) != 2:
+        if len(inputs) != self.expected_inputs:
             raise ValueError(f"AttentionGeMReducer expects exactly two inputs (x, attn_logits), got {len(inputs)}.")
         x, attn_logits = inputs
-        if x.ndim != 4:
-            raise ValueError(f"Reducer expects NCHW x tensor, got shape={tuple(x.shape)}")
+        x = validate_nchw_shape(x, name="x", reducer_name=type(self).__name__)
         logits = _normalize_logits(attn_logits, x)
         if self._streaming_passthrough:
             logits_term = logits.to(dtype=x.dtype).sum(dim=(-2, -1), keepdim=True)
@@ -60,13 +61,25 @@ class AttentionGeMReducer(MultiInputSpatialReducer):
             x_passthrough = x + graph_passthrough
             return x_passthrough, logits
 
+        mask_nchw = validate_mask_shape(mask, x, reducer_name=type(self).__name__)
+        return self._reduce_attention_gem(x, logits, mask=mask_nchw)
+
+    def reduce_spatial_inputs(self, *inputs: torch.Tensor, mask: torch.Tensor | None = None) -> torch.Tensor:
+        if len(inputs) != self.expected_inputs:
+            raise ValueError(f"AttentionGeMReducer expects exactly two inputs (x, attn_logits), got {len(inputs)}.")
+        x, attn_logits = inputs
+        x = validate_nchw_shape(x, name="x", reducer_name=type(self).__name__)
+        logits = _normalize_logits(attn_logits, x)
+        return self._reduce_attention_gem(x, logits, mask=mask)
+
+    def _reduce_attention_gem(self, x: torch.Tensor, logits: torch.Tensor, *, mask: torch.Tensor | None = None) -> torch.Tensor:
         acc_dtype = resolve_accumulator_dtype(self.accumulator_dtype, x.dtype)
         x_acc = x.to(dtype=acc_dtype)
         x_pow = x_acc.clamp_min(self.eps).pow(self.current_r.to(device=x.device, dtype=acc_dtype))
         logits_acc = logits.to(dtype=acc_dtype)
 
         if mask is not None:
-            mask_nchw = normalize_spatial_mask(mask, x).to(device=x.device)
+            mask_nchw = mask.to(device=x.device, dtype=torch.bool)
             neg_inf = torch.finfo(acc_dtype).min
             logits_acc = torch.where(mask_nchw, logits_acc, torch.full_like(logits_acc, neg_inf))
             any_valid = mask_nchw.flatten(2).any(dim=-1, keepdim=True).unsqueeze(-1)

--- a/lightstream/core/reducer/gem.py
+++ b/lightstream/core/reducer/gem.py
@@ -6,7 +6,7 @@ import torch
 
 from .base import BaseStreamingGlobalReducer, ReducerMeta, ReducerTile, streaming_reduce_tile
 from .reducer_base import ManualVJPReducer, SpatialReducer
-from .utils import normalize_spatial_mask, resolve_accumulator_dtype
+from .utils import resolve_accumulator_dtype
 
 
 class GeMReducer(SpatialReducer):
@@ -29,15 +29,7 @@ class GeMReducer(SpatialReducer):
     def current_r(self) -> torch.Tensor:
         return self.r
 
-    def forward(self, *inputs: torch.Tensor, mask: torch.Tensor | None = None) -> torch.Tensor:
-        if len(inputs) != 1:
-            raise ValueError(f"GeMReducer expects exactly one tensor input, got {len(inputs)}.")
-        x = inputs[0]
-        if x.ndim != 4:
-            raise ValueError(f"Reducer expects NCHW tensor, got shape={tuple(x.shape)}")
-        if self._streaming_passthrough:
-            return x
-
+    def reduce_spatial(self, x: torch.Tensor, *, mask: torch.Tensor | None = None) -> torch.Tensor:
         acc_dtype = resolve_accumulator_dtype(self.accumulator_dtype, x.dtype)
         x_acc = x.to(dtype=acc_dtype)
         x_clamped = x_acc.clamp_min(self.eps)
@@ -45,8 +37,7 @@ class GeMReducer(SpatialReducer):
         x_pow = x_clamped.pow(r)
 
         if mask is not None:
-            mask_nchw = normalize_spatial_mask(mask, x)
-            mask_acc = mask_nchw.to(dtype=acc_dtype)
+            mask_acc = mask.to(dtype=acc_dtype)
             denom = mask_acc.sum(dim=(-2, -1), keepdim=True, dtype=acc_dtype).clamp_min(1)
             mean_pow = (x_pow * mask_acc).sum(dim=(-2, -1), keepdim=True, dtype=acc_dtype) / denom
         else:

--- a/lightstream/core/reducer/mean.py
+++ b/lightstream/core/reducer/mean.py
@@ -8,7 +8,7 @@ import torch
 
 from .base import BaseStreamingGlobalReducer, ReducerMeta, ReducerTile, streaming_reduce_tile
 from .reducer_base import SpatialReducer
-from .utils import normalize_spatial_mask, resolve_accumulator_dtype
+from .utils import resolve_accumulator_dtype
 
 
 class MeanReducer(SpatialReducer):
@@ -18,19 +18,11 @@ class MeanReducer(SpatialReducer):
         super().__init__()
         self.accumulator_dtype = accumulator_dtype
 
-    def forward(self, *inputs: torch.Tensor, mask: torch.Tensor | None = None) -> torch.Tensor:
-        if len(inputs) != 1:
-            raise ValueError(f"MeanReducer expects exactly one tensor input, got {len(inputs)}.")
-        x = inputs[0]
-        if x.ndim != 4:
-            raise ValueError(f"Reducer expects NCHW tensor, got shape={tuple(x.shape)}")
-        if self._streaming_passthrough:
-            return x
+    def reduce_spatial(self, x: torch.Tensor, *, mask: torch.Tensor | None = None) -> torch.Tensor:
         acc_dtype = resolve_accumulator_dtype(self.accumulator_dtype, x.dtype)
         if mask is not None:
-            mask_nchw = normalize_spatial_mask(mask, x)
-            masked = x * mask_nchw.to(dtype=x.dtype)
-            denom = mask_nchw.sum(dim=(-2, -1), keepdim=True, dtype=acc_dtype).clamp_min(1)
+            masked = x * mask.to(dtype=x.dtype)
+            denom = mask.sum(dim=(-2, -1), keepdim=True, dtype=acc_dtype).clamp_min(1)
             mean = masked.sum(dim=(-2, -1), keepdim=True, dtype=acc_dtype) / denom
             return mean.to(dtype=x.dtype)
         return x.mean(dim=(-2, -1), keepdim=True, dtype=acc_dtype).to(dtype=x.dtype)

--- a/lightstream/core/reducer/reducer_base.py
+++ b/lightstream/core/reducer/reducer_base.py
@@ -1,136 +1,27 @@
-"""Abstract base types for reducer extension points."""
+"""Compatibility re-exports for reducer extension base classes."""
 
-from __future__ import annotations
+from lightstream.core.reducers.api import (
+    BaseReducer,
+    ManualBackwardReducer,
+    ManualVJPReducer,
+    MultiInputSpatialReducer,
+    SpatialReducer,
+    validate_aligned_nchw_inputs,
+    validate_arity,
+    validate_channel_compatibility,
+    validate_mask_shape,
+    validate_nchw_shape,
+)
 
-from abc import ABC, abstractmethod
-from collections.abc import Sequence
-
-import torch
-import torch.nn as nn
-
-from .base import BaseStreamingGlobalReducer
-
-
-class BaseReducer(nn.Module, ABC):
-    """Base class for non-streaming reducers.
-
-    Non-streaming reducers implement offline/global reduction in :meth:`forward`
-    and must provide deterministic conversion to a streaming reducer via
-    :meth:`to_streaming` with equivalent reduction semantics.
-
-    Parameters
-    ----------
-    streaming_passthrough : bool, default=False
-        When ``True``, :meth:`forward` must return the input unchanged. This is
-        used for reducer-head tagging in SCNN where execution is deferred to
-        streaming orchestration.
-    """
-
-    def __init__(self, *, streaming_passthrough: bool = False):
-        super().__init__()
-        self._streaming_passthrough = bool(streaming_passthrough)
-
-    @abstractmethod
-    def forward(self, *inputs: torch.Tensor, mask: torch.Tensor | None = None) -> torch.Tensor:
-        """Run non-streaming reduction over positional ``inputs``.
-
-        Conventions
-        -----------
-        - Legacy reducers consume exactly one tensor input (``inputs[0]``).
-        - Multi-input reducers must define and validate expected arity and
-          per-input shape contracts.
-        - ``mask`` is always a keyword-only auxiliary argument and is not part
-          of ``*inputs``.
-        """
-
-    @abstractmethod
-    def to_streaming(self) -> BaseStreamingGlobalReducer:
-        """Create the equivalent streaming reducer implementation."""
-
-
-class SpatialReducer(BaseReducer, ABC):
-    """Base class for single-input spatial reducers.
-
-    Subclasses implement :meth:`reduce_spatial` for the math/operator behavior.
-    The engine can continue to treat reducers uniformly through ``BaseReducer``
-    while users get a focused inheritance point for custom NCHW spatial
-    reductions.
-    """
-
-    input_arity = 1
-
-    def forward(self, *inputs: torch.Tensor, mask: torch.Tensor | None = None) -> torch.Tensor:
-        x = self.require_single_nchw(inputs)
-        if self._streaming_passthrough:
-            return x
-        return self.reduce_spatial(x, mask=mask)
-
-    @staticmethod
-    def require_single_nchw(inputs: Sequence[torch.Tensor]) -> torch.Tensor:
-        """Validate and return the sole NCHW tensor input."""
-        if len(inputs) != 1:
-            raise ValueError(f"SpatialReducer expects exactly one tensor input, got {len(inputs)}.")
-        x = inputs[0]
-        if x.ndim != 4:
-            raise ValueError(f"SpatialReducer expects an NCHW tensor, got shape={tuple(x.shape)}")
-        return x
-
-    def reduce_spatial(self, x: torch.Tensor, *, mask: torch.Tensor | None = None) -> torch.Tensor:
-        """Reduce one NCHW tensor over its spatial dimensions."""
-        raise NotImplementedError(f"{type(self).__name__}.reduce_spatial() must be implemented")
-
-
-class MultiInputSpatialReducer(BaseReducer, ABC):
-    """Base class for reducers that consume multiple aligned spatial tensors.
-
-    ``expected_inputs`` may be set by subclasses to enforce arity.  Inputs are
-    validated as NCHW tensors with matching batch and spatial dimensions before
-    :meth:`reduce_spatial_inputs` is called.
-    """
-
-    expected_inputs: int | None = None
-
-    def forward(self, *inputs: torch.Tensor, mask: torch.Tensor | None = None) -> torch.Tensor:
-        tensors = self.require_aligned_nchw(inputs)
-        if self._streaming_passthrough:
-            return tensors[0]
-        return self.reduce_spatial_inputs(*tensors, mask=mask)
-
-    @classmethod
-    def require_aligned_nchw(cls, inputs: Sequence[torch.Tensor]) -> tuple[torch.Tensor, ...]:
-        """Validate multi-input NCHW arity and spatial alignment."""
-        if cls.expected_inputs is not None and len(inputs) != cls.expected_inputs:
-            raise ValueError(f"{cls.__name__} expects exactly {cls.expected_inputs} tensor inputs, got {len(inputs)}.")
-        if len(inputs) == 0:
-            raise ValueError(f"{cls.__name__} expects at least one tensor input.")
-        tensors = tuple(inputs)
-        first = tensors[0]
-        if first.ndim != 4:
-            raise ValueError(f"{cls.__name__} expects NCHW tensors, got shape={tuple(first.shape)}")
-        batch = first.shape[0]
-        spatial = first.shape[-2:]
-        for idx, tensor in enumerate(tensors[1:], start=1):
-            if tensor.ndim != 4:
-                raise ValueError(f"{cls.__name__} input {idx} must be NCHW, got shape={tuple(tensor.shape)}")
-            if tensor.shape[0] != batch or tensor.shape[-2:] != spatial:
-                raise ValueError(
-                    f"{cls.__name__} input {idx} must match batch/spatial dimensions "
-                    f"N={batch}, H/W={tuple(spatial)}, got shape={tuple(tensor.shape)}"
-                )
-        return tensors
-
-    def reduce_spatial_inputs(self, *inputs: torch.Tensor, mask: torch.Tensor | None = None) -> torch.Tensor:
-        """Reduce aligned NCHW tensor inputs over their spatial dimensions."""
-        raise NotImplementedError(f"{type(self).__name__}.reduce_spatial_inputs() must be implemented")
-
-
-class ManualVJPReducer(BaseStreamingGlobalReducer, ABC):
-    """Streaming reducer base for implementations with manual VJP replay.
-
-    Custom streaming reducers can inherit from this class when they provide a
-    reducer-specific :meth:`reduce_tile_for_backward` expression instead of
-    relying on a generic autograd reduction formula.
-    """
-
-
-ManualBackwardReducer = ManualVJPReducer
+__all__ = [
+    "BaseReducer",
+    "SpatialReducer",
+    "MultiInputSpatialReducer",
+    "ManualVJPReducer",
+    "ManualBackwardReducer",
+    "validate_arity",
+    "validate_nchw_shape",
+    "validate_channel_compatibility",
+    "validate_aligned_nchw_inputs",
+    "validate_mask_shape",
+]

--- a/lightstream/core/reducer/sum.py
+++ b/lightstream/core/reducer/sum.py
@@ -8,7 +8,7 @@ import torch
 
 from .base import BaseStreamingGlobalReducer, ReducerMeta, ReducerTile, streaming_reduce_tile
 from .reducer_base import ManualVJPReducer, SpatialReducer
-from .utils import normalize_spatial_mask, resolve_accumulator_dtype
+from .utils import resolve_accumulator_dtype
 
 
 class SumReducer(SpatialReducer):
@@ -18,18 +18,10 @@ class SumReducer(SpatialReducer):
         super().__init__()
         self.accumulator_dtype = accumulator_dtype
 
-    def forward(self, *inputs: torch.Tensor, mask: torch.Tensor | None = None) -> torch.Tensor:
-        if len(inputs) != 1:
-            raise ValueError(f"SumReducer expects exactly one tensor input, got {len(inputs)}.")
-        x = inputs[0]
-        if x.ndim != 4:
-            raise ValueError(f"Reducer expects NCHW tensor, got shape={tuple(x.shape)}")
-        if self._streaming_passthrough:
-            return x
+    def reduce_spatial(self, x: torch.Tensor, *, mask: torch.Tensor | None = None) -> torch.Tensor:
         acc_dtype = resolve_accumulator_dtype(self.accumulator_dtype, x.dtype)
         if mask is not None:
-            mask_nchw = normalize_spatial_mask(mask, x)
-            masked = x * mask_nchw.to(dtype=x.dtype)
+            masked = x * mask.to(dtype=x.dtype)
             return masked.sum(dim=(-2, -1), keepdim=True, dtype=acc_dtype).to(dtype=x.dtype)
         return x.sum(dim=(-2, -1), keepdim=True, dtype=acc_dtype).to(dtype=x.dtype)
 

--- a/lightstream/core/reducers/__init__.py
+++ b/lightstream/core/reducers/__init__.py
@@ -1,31 +1,52 @@
 """Public reducer API.
 
 This plural package is the preferred import location for reducer extension
-points. The legacy :mod:`lightstream.core.reducer` package re-exports the same
-symbols for compatibility.
+points. Concrete reducer implementations are loaded lazily to keep compatibility
+with the legacy :mod:`lightstream.core.reducer` package during import.
 """
 
-from lightstream.core.reducer import (
-    AttentionGeMReducer,
+from .api import (
     BaseReducer,
-    BaseStreamingGlobalReducer,
-    GeMReducer,
     ManualBackwardReducer,
     ManualVJPReducer,
-    MeanReducer,
     MultiInputSpatialReducer,
+    SpatialReducer,
+    validate_aligned_nchw_inputs,
+    validate_arity,
+    validate_channel_compatibility,
+    validate_mask_shape,
+    validate_nchw_shape,
+)
+from .base import (
+    BaseStreamingGlobalReducer,
     ReducerMeta,
     ReducerReplayRecord,
     ReducerTile,
-    SpatialReducer as OfflineSpatialReducer,
-    StreamingAttentionGeMReducer,
-    StreamingGeMReducer,
-    StreamingMeanReducer,
     StreamingReducer,
-    StreamingSumReducer,
-    SumReducer,
+    streaming_reduce_tile,
 )
-from .base import SpatialReducer
+
+_LAZY_REDUCER_EXPORTS = {
+    "MeanReducer",
+    "SumReducer",
+    "GeMReducer",
+    "AttentionGeMReducer",
+    "StreamingMeanReducer",
+    "StreamingSumReducer",
+    "StreamingGeMReducer",
+    "StreamingAttentionGeMReducer",
+}
+
+
+def __getattr__(name: str):
+    if name in _LAZY_REDUCER_EXPORTS:
+        from lightstream.core import reducer as _legacy_reducer
+
+        value = getattr(_legacy_reducer, name)
+        globals()[name] = value
+        return value
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
 
 __all__ = [
     "MeanReducer",
@@ -34,7 +55,6 @@ __all__ = [
     "AttentionGeMReducer",
     "BaseReducer",
     "SpatialReducer",
-    "OfflineSpatialReducer",
     "MultiInputSpatialReducer",
     "ManualVJPReducer",
     "ManualBackwardReducer",
@@ -43,8 +63,14 @@ __all__ = [
     "ReducerMeta",
     "ReducerTile",
     "ReducerReplayRecord",
+    "streaming_reduce_tile",
     "StreamingMeanReducer",
     "StreamingSumReducer",
     "StreamingGeMReducer",
     "StreamingAttentionGeMReducer",
+    "validate_arity",
+    "validate_nchw_shape",
+    "validate_channel_compatibility",
+    "validate_aligned_nchw_inputs",
+    "validate_mask_shape",
 ]

--- a/lightstream/core/reducers/api.py
+++ b/lightstream/core/reducers/api.py
@@ -1,0 +1,221 @@
+"""Reducer authoring base classes and validation helpers."""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from collections.abc import Sequence
+import torch
+import torch.nn as nn
+
+from lightstream.core.reducer.base import BaseStreamingGlobalReducer, ReducerMeta, ReducerTile
+from lightstream.core.reducer.utils import normalize_spatial_mask, resolve_accumulator_dtype
+from lightstream.core.scnn.utils import Box
+
+
+def validate_arity(inputs: Sequence[torch.Tensor], expected: int | None, *, reducer_name: str) -> None:
+    """Validate the number of tensor inputs supplied to a reducer."""
+    if expected is None:
+        if len(inputs) == 0:
+            raise ValueError(f"{reducer_name} expects at least one tensor input.")
+        return
+    if len(inputs) != expected:
+        raise ValueError(f"{reducer_name} expects exactly {expected} tensor input(s), got {len(inputs)}.")
+
+
+def validate_nchw_shape(tensor: torch.Tensor, *, name: str = "input", reducer_name: str = "Reducer") -> torch.Tensor:
+    """Validate that ``tensor`` is an NCHW tensor and return it unchanged."""
+    if not isinstance(tensor, torch.Tensor):
+        raise TypeError(f"{reducer_name} {name} must be a torch.Tensor, got {type(tensor)!r}.")
+    if tensor.ndim != 4:
+        raise ValueError(f"{reducer_name} {name} must be NCHW, got shape={tuple(tensor.shape)}.")
+    return tensor
+
+
+def validate_channel_compatibility(
+    tensors: Sequence[torch.Tensor],
+    *,
+    reducer_name: str = "Reducer",
+    allow_single_channel: bool = True,
+) -> None:
+    """Validate that aligned inputs have compatible channel dimensions.
+
+    By default an input with channel count ``1`` is accepted as broadcastable
+    against the reference input's channel count, which matches common spatial
+    attention/logit reducers.
+    """
+    if len(tensors) <= 1:
+        return
+    reference_channels = int(tensors[0].shape[1])
+    allowed = {reference_channels}
+    if allow_single_channel:
+        allowed.add(1)
+    for idx, tensor in enumerate(tensors[1:], start=1):
+        channels = int(tensor.shape[1])
+        if channels not in allowed:
+            raise ValueError(
+                f"{reducer_name} input {idx} channel dim must be compatible with C={reference_channels}"
+                f"{' or 1' if allow_single_channel else ''}, got {channels}."
+            )
+
+
+def validate_aligned_nchw_inputs(
+    inputs: Sequence[torch.Tensor],
+    *,
+    expected: int | None = None,
+    reducer_name: str = "Reducer",
+    require_channel_compatibility: bool = True,
+    allow_single_channel: bool = True,
+) -> tuple[torch.Tensor, ...]:
+    """Validate arity plus NCHW batch/spatial alignment for reducer inputs."""
+    validate_arity(inputs, expected, reducer_name=reducer_name)
+    tensors = tuple(validate_nchw_shape(tensor, name=f"input {idx}", reducer_name=reducer_name) for idx, tensor in enumerate(inputs))
+    if not tensors:
+        raise ValueError(f"{reducer_name} expects at least one tensor input.")
+
+    batch = int(tensors[0].shape[0])
+    spatial = tuple(int(v) for v in tensors[0].shape[-2:])
+    for idx, tensor in enumerate(tensors[1:], start=1):
+        if int(tensor.shape[0]) != batch or tuple(int(v) for v in tensor.shape[-2:]) != spatial:
+            raise ValueError(
+                f"{reducer_name} input {idx} must match batch/spatial dimensions "
+                f"N={batch}, H/W={spatial}, got shape={tuple(tensor.shape)}."
+            )
+    if require_channel_compatibility:
+        validate_channel_compatibility(tensors, reducer_name=reducer_name, allow_single_channel=allow_single_channel)
+    return tensors
+
+
+def validate_mask_shape(mask: torch.Tensor | None, reference: torch.Tensor, *, reducer_name: str = "Reducer") -> torch.Tensor | None:
+    """Validate and normalize an optional spatial mask to ``[N, 1, H, W]``."""
+    if mask is None:
+        return None
+    if not isinstance(mask, torch.Tensor):
+        raise TypeError(f"{reducer_name} mask must be a torch.Tensor, got {type(mask)!r}.")
+    try:
+        return normalize_spatial_mask(mask, reference)
+    except ValueError as exc:
+        raise ValueError(f"{reducer_name} mask shape is incompatible with input shape {tuple(reference.shape)}: {exc}") from exc
+
+
+class BaseReducer(nn.Module, ABC):
+    """Base class for reducer modules with offline and streaming forms."""
+
+    def __init__(self, *, streaming_passthrough: bool = False, streaming_forward: bool = False):
+        super().__init__()
+        self._streaming_passthrough = bool(streaming_passthrough)
+        self._streaming_forward = bool(streaming_forward)
+
+    @abstractmethod
+    def forward(self, *inputs: torch.Tensor, mask: torch.Tensor | None = None) -> torch.Tensor | tuple[torch.Tensor, ...]:
+        """Run reducer logic over one or more NCHW tensors."""
+
+    @abstractmethod
+    def to_streaming(self) -> BaseStreamingGlobalReducer:
+        """Create the equivalent streaming reducer implementation."""
+
+
+class SpatialReducer(BaseReducer, ABC):
+    """Base class for reducers that consume one NCHW tensor."""
+
+    input_arity = 1
+
+    def forward(self, x: torch.Tensor, mask: torch.Tensor | None = None) -> torch.Tensor:
+        """Reduce ``x`` while preserving normal non-streaming behavior by default."""
+        x = validate_nchw_shape(x, reducer_name=type(self).__name__)
+        normalized_mask = validate_mask_shape(mask, x, reducer_name=type(self).__name__)
+        if self._streaming_passthrough:
+            return x
+        if self._streaming_forward:
+            return self._run_streaming_forward((x,), normalized_mask)
+        return self.reduce_spatial(x, mask=normalized_mask)
+
+    def _run_streaming_forward(self, inputs: tuple[torch.Tensor, ...], mask: torch.Tensor | None) -> torch.Tensor:
+        """Run init_state/update/finalize over a full tensor as one stream tile."""
+        x = inputs[0]
+        streaming = self.to_streaming()
+        acc_dtype = resolve_accumulator_dtype(getattr(streaming, "accumulator_dtype", None), x.dtype)
+        meta = ReducerMeta(
+            output_height=int(x.shape[-2]),
+            output_width=int(x.shape[-1]),
+            batch_size=int(x.shape[0]),
+            channels=int(x.shape[1]),
+            device=x.device,
+            dtype=x.dtype,
+            accumulator_dtype=acc_dtype,
+        )
+        state = streaming.init_state(meta)
+        tile_mask = None
+        if mask is not None:
+            # ReducerTile masks are 2D in engine-normalized coordinates. Full
+            # forward streaming only supports a shared spatial mask.
+            if mask.shape[0] != 1 and mask.shape[0] != x.shape[0]:
+                raise ValueError(f"{type(self).__name__} mask batch dim must be 1 or N={x.shape[0]}, got {mask.shape[0]}.")
+            if mask.shape[0] != 1 or not torch.all(mask == mask[:1]):
+                raise ValueError(f"{type(self).__name__} streaming forward requires a batch-shared spatial mask.")
+            tile_mask = mask[0, 0].to(device=x.device, dtype=torch.bool)
+        tile = ReducerTile(tensors=inputs, mask=tile_mask, box=Box(0, int(x.shape[-2]), 0, int(x.shape[-1]), None), is_new=tile_mask)
+        state = streaming.update(state, tile)
+        return streaming.finalize(state)
+
+    @abstractmethod
+    def reduce_spatial(self, x: torch.Tensor, *, mask: torch.Tensor | None = None) -> torch.Tensor:
+        """Reduce one validated NCHW tensor over its spatial dimensions."""
+
+
+class MultiInputSpatialReducer(BaseReducer, ABC):
+    """Base class for reducers consuming several aligned NCHW tensors."""
+
+    expected_inputs: int | None = None
+    require_channel_compatibility = True
+    allow_single_channel = True
+
+    def forward(self, *inputs: torch.Tensor, mask: torch.Tensor | None = None) -> torch.Tensor | tuple[torch.Tensor, ...]:
+        tensors = self.require_aligned_nchw(inputs)
+        normalized_mask = validate_mask_shape(mask, tensors[0], reducer_name=type(self).__name__)
+        if self._streaming_passthrough:
+            return tensors[0] if len(tensors) == 1 else tensors
+        if self._streaming_forward:
+            return self._run_streaming_forward(tensors, normalized_mask)
+        return self.reduce_spatial_inputs(*tensors, mask=normalized_mask)
+
+    @classmethod
+    def require_aligned_nchw(cls, inputs: Sequence[torch.Tensor]) -> tuple[torch.Tensor, ...]:
+        """Validate multi-input NCHW arity, channel compatibility, and alignment."""
+        return validate_aligned_nchw_inputs(
+            inputs,
+            expected=cls.expected_inputs,
+            reducer_name=cls.__name__,
+            require_channel_compatibility=cls.require_channel_compatibility,
+            allow_single_channel=cls.allow_single_channel,
+        )
+
+    def _run_streaming_forward(self, inputs: tuple[torch.Tensor, ...], mask: torch.Tensor | None) -> torch.Tensor:
+        return SpatialReducer._run_streaming_forward(self, inputs, mask)
+
+    @abstractmethod
+    def reduce_spatial_inputs(self, *inputs: torch.Tensor, mask: torch.Tensor | None = None) -> torch.Tensor:
+        """Reduce validated aligned NCHW tensor inputs."""
+
+
+class ManualVJPReducer(BaseStreamingGlobalReducer, ABC):
+    """Streaming reducer base for reducers with custom backward replay math."""
+
+    @abstractmethod
+    def reduce_tile_for_backward(self, tile: ReducerTile, global_context: dict[str, torch.Tensor | int | float | None]) -> torch.Tensor:
+        """Replay tile-local reduction used by manual VJP implementations."""
+
+
+ManualBackwardReducer = ManualVJPReducer
+
+__all__ = [
+    "BaseReducer",
+    "SpatialReducer",
+    "MultiInputSpatialReducer",
+    "ManualVJPReducer",
+    "ManualBackwardReducer",
+    "validate_arity",
+    "validate_nchw_shape",
+    "validate_channel_compatibility",
+    "validate_aligned_nchw_inputs",
+    "validate_mask_shape",
+]

--- a/lightstream/core/reducers/base.py
+++ b/lightstream/core/reducers/base.py
@@ -1,4 +1,4 @@
-"""Preferred reducer extension API."""
+"""Preferred reducer streaming primitives."""
 
 from lightstream.core.reducer.base import (
     BaseStreamingGlobalReducer,
@@ -9,12 +9,7 @@ from lightstream.core.reducer.base import (
     streaming_reduce_tile,
 )
 
-# ``SpatialReducer`` is the preferred name for authors implementing the new
-# streaming contract: init_state(meta), update(state, tile), finalize(state).
-SpatialReducer = BaseStreamingGlobalReducer
-
 __all__ = [
-    "SpatialReducer",
     "BaseStreamingGlobalReducer",
     "StreamingReducer",
     "ReducerMeta",


### PR DESCRIPTION
### Motivation
- Provide a small, focused authoring API for common reducer patterns (single-input spatial, multi-input spatial, manual VJP) so new reducers can share validation and streaming-forward semantics.
- Make it easy to preserve the existing non-streaming behavior while enabling tile-based streaming execution via `init_state`/`update`/`finalize` for full-tensor forwards.
- Consolidate common shape/arity/channel/mask validation logic to reduce duplication and hard-to-debug errors across reducer implementations.

### Description
- Added `lightstream/core/reducers/api.py` which defines `BaseReducer`, `SpatialReducer`, `MultiInputSpatialReducer`, `ManualVJPReducer` and validation helpers `validate_arity`, `validate_nchw_shape`, `validate_channel_compatibility`, `validate_aligned_nchw_inputs`, and `validate_mask_shape`.
- Implemented streaming-forward support in `SpatialReducer.forward()` so when `_streaming_forward` is enabled it constructs a `ReducerMeta`, calls `to_streaming().init_state(...)`, `update(...)`, and `finalize()` to reproduce streaming behavior for a full-tensor forward.
- Refactored built-in reducers (`SumReducer`, `MeanReducer`, `GeMReducer`, and `AttentionGeMReducer`) to use the new `reduce_spatial` / `reduce_spatial_inputs` hooks and the new validation helpers instead of ad-hoc checks and duplicated mask normalization.
- Updated module exports and compatibility layers: added `lightstream/core/reducers` public API with lazy loading for concrete reducers, and made `lightstream/core/reducer/reducer_base.py` a compatibility re-exporting shim to avoid breaking existing imports.

### Testing
- Compiled changed modules with `python -m py_compile` on the modified reducer files and `python -m compileall -q lightstream/core/reducer lightstream/core/reducers` (succeeded).
- Ran a smoke test script with a stubbed `lightning` module exercising imports, offline `SumReducer`/`MeanReducer` behavior, `AttentionGeMReducer` usage, and `_streaming_forward` lifecycle equivalence (succeeded).
- Ran `pytest` which collected zero tests in this repository (no tests were run).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1f0aa145208330b765cc124f944ddb)