### PR TITLE
Normalize SCNN tile-statistics gradients and harden border inference

### DIFF
--- a/lightstream/core/scnn/scnn.py
+++ b/lightstream/core/scnn/scnn.py
@@ -668,14 +668,87 @@ class StreamingCNN(torch.nn.Module):
     def _restore_parameters(self, state_dict):
         self.stream_module.load_state_dict(state_dict)
 
+    def _statistics_tensor_diagnostics(self, tensor, *, context: str = ""):
+        finite = torch.isfinite(tensor)
+        nan = torch.isnan(tensor) if torch.is_floating_point(tensor) else torch.zeros_like(tensor, dtype=torch.bool)
+        pos_inf = tensor == float("inf") if torch.is_floating_point(tensor) else torch.zeros_like(tensor, dtype=torch.bool)
+        neg_inf = tensor == float("-inf") if torch.is_floating_point(tensor) else torch.zeros_like(tensor, dtype=torch.bool)
+        prefix = f"{context}: " if context else ""
+        return (
+            f"{prefix}shape={tuple(tensor.shape)}, dtype={tensor.dtype}, "
+            f"finite_count={int(finite.sum().item())}, nan_count={int(nan.sum().item())}, "
+            f"positive_infinity_count={int(pos_inf.sum().item())}, "
+            f"negative_infinity_count={int(neg_inf.sum().item())}"
+        )
+
+    def _normalize_statistics_gradient(self, tensor, *, context: str = ""):
+        if tensor is None:
+            return None
+        if tensor.numel() == 0:
+            return tensor
+        if not torch.is_floating_point(tensor):
+            return tensor
+
+        detached = tensor.detach()
+        finite = torch.isfinite(detached)
+
+        finite_positive = finite & (detached > 0)
+        if torch.any(finite_positive):
+            positive_sentinel = detached[finite_positive].max()
+        else:
+            positive_sentinel = torch.ones((), dtype=detached.dtype, device=detached.device)
+
+        finite_negative = finite & (detached < 0)
+        if torch.any(finite_negative):
+            negative_sentinel = detached[finite_negative].min()
+        else:
+            negative_sentinel = -torch.ones((), dtype=detached.dtype, device=detached.device)
+
+        cleaned = torch.where(
+            torch.isnan(detached),
+            torch.zeros((), dtype=detached.dtype, device=detached.device),
+            detached,
+        )
+        cleaned = torch.where(detached == float("inf"), positive_sentinel, cleaned)
+        cleaned = torch.where(detached == float("-inf"), negative_sentinel, cleaned)
+
+        scale = cleaned.max()
+        if torch.isfinite(scale).item() and (scale > 0).item():
+            return cleaned / scale
+        return cleaned
+
     def _non_max_border_amount(self, tensor):
+        if tensor is None:
+            raise RuntimeError("Cannot infer non-max border amount from None tensor")
+        if tensor.numel() == 0:
+            raise RuntimeError(
+                "Cannot infer non-max border amount from empty tensor: "
+                + self._statistics_tensor_diagnostics(tensor, context="non_max_border_amount")
+            )
+
+        original = tensor
+        tensor = self._normalize_statistics_gradient(tensor, context="non_max_border_amount")
+
         # Sum over the channels, useful for networks that treat certain channels
         # different (e.g., DenseNet)
         if tensor.dim() > 3:
             tensor = torch.sum(tensor, dim=1)[0]
-        tensor = tensor / tensor.max()  # normalize
+
+        tensor_max = tensor.max()
+        if (not torch.isfinite(tensor_max).item()) or (tensor_max <= 0).item():
+            raise RuntimeError(
+                "Cannot infer non-max border amount without a finite positive maximum: "
+                + self._statistics_tensor_diagnostics(original, context="non_max_border_amount")
+            )
+
+        tensor = tensor / tensor_max  # normalize by a positive scalar to preserve max localization
         tensor = tensor > tensor.max() * (1 - self.eps)
         non_zero = tensor.nonzero(as_tuple=False)
+        if non_zero.numel() == 0:
+            raise RuntimeError(
+                "Cannot infer non-max border amount because thresholding produced no support: "
+                + self._statistics_tensor_diagnostics(original, context="non_max_border_amount")
+            )
         top, left = non_zero.min(dim=0)[0]
         # for bottom and right we need to substract -1: correct index 3 is actually the 4th pixel
         bottom, right = (
@@ -1690,16 +1763,21 @@ class StreamingCNN(torch.nn.Module):
                 f_grad = torch.from_numpy(grad)
                 f_grad = f_grad.to(self.device)
 
-            if grad_out[0].numel() == 0 or torch.count_nonzero(grad_out[0]) == 0:
+            normalized_grad_out = self._normalize_statistics_gradient(
+                grad_out[0], context=f"{type(module).__name__} grad_out statistics"
+            )
+            if normalized_grad_out.numel() == 0 or torch.count_nonzero(normalized_grad_out) == 0:
                 # Some connected branches (e.g. zero-scaled passthrough links for graph connectivity)
                 # produce valid but all-zero gradients during stats gathering; skip border inference.
                 return grad_in
-            print(grad_out[0])
-            grad_lost = self._non_max_border_amount(grad_out[0])
+            grad_lost = self._non_max_border_amount(normalized_grad_out)
 
             self._print_verbose(module, "\n", grad_lost)
             self._module_stats[module]["grad_lost"] = grad_lost
 
+            f_grad = self._normalize_statistics_gradient(
+                f_grad, context=f"{type(module).__name__} input-gradient statistics"
+            )
             valid_grad = f_grad > (1 - self.eps) * f_grad.max()
 
             # When kernel_size > stride we have some _overlap_ of gradients,

--- a/tests/test_scnn.py
+++ b/tests/test_scnn.py
@@ -3,6 +3,8 @@ import torch.nn as nn
 import pytest
 
 from lightstream.core.constructor import StreamingConstructor
+from lightstream.core.scnn.scnn import StreamingCNN
+from lightstream.core.scnn.utils import Lost
 from lightstream.core.reducer import (
     BaseReducer,
     BaseStreamingGlobalReducer,
@@ -135,6 +137,19 @@ class ValueLogitsHeadNet(nn.Module):
         logits = self.logit_head(feat)
         reduced = self.reducer(value, logits, mask=mask)
         return reduced, value, logits
+
+
+class MultiplicativeStatsNet(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.left = nn.Conv2d(3, 1, kernel_size=3, padding=1, bias=False)
+        self.right = nn.Conv2d(3, 1, kernel_size=3, padding=1, bias=False)
+        self.out = nn.Conv2d(1, 1, kernel_size=1, bias=False)
+
+    def forward(self, x):
+        left = self.left(x) * 1e20
+        right = self.right(x) * 1e20
+        return self.out(left * right)
 
 
 def _make_streaming(model: nn.Module, tile_size: int = 4):
@@ -472,3 +487,70 @@ def test_scnn_multi_input_reducer_failure_on_input_order_mismatch():
     scnn._reducer_input_indices = {0: (0, 2, 1)}
     with pytest.raises(RuntimeError, match="input index order mismatch"):
         scnn._stitch_forward_outputs([None, None, None], (torch.randn(1, 3, 3, 3),) * 3, 0, 0, type('S', (), dict(top=False,left=False,right=False,bottom=False))(), None)
+
+
+def _unconfigured_scnn_for_statistics():
+    scnn = StreamingCNN.__new__(StreamingCNN)
+    scnn.eps = 1e-5
+    scnn.device = torch.device("cpu")
+    scnn.dtype = torch.float32
+    return scnn
+
+
+def test_scnn_statistics_gradient_normalization_cleans_nonfinite_without_abs_support():
+    scnn = _unconfigured_scnn_for_statistics()
+    tensor = torch.tensor([[float("nan"), float("inf")], [float("-inf"), 2.0]])
+
+    normalized = scnn._normalize_statistics_gradient(tensor, context="unit test")
+
+    assert torch.isfinite(normalized).all()
+    assert normalized.max() == 1
+    assert normalized[0, 0] == 0
+    assert normalized[0, 1] == 1
+    assert normalized[1, 0] == -0.5
+    assert normalized[1, 1] == 1
+
+    negative_only = torch.tensor([[-4.0, -2.0]])
+    assert torch.equal(scnn._normalize_statistics_gradient(negative_only), negative_only)
+
+
+def test_scnn_non_max_border_amount_rejects_missing_positive_support_with_diagnostics():
+    scnn = _unconfigured_scnn_for_statistics()
+
+    with pytest.raises(RuntimeError, match="finite positive maximum") as exc_info:
+        scnn._non_max_border_amount(torch.tensor([[0.0, float("nan")], [float("-inf"), -2.0]]))
+
+    message = str(exc_info.value)
+    assert "shape=(2, 2)" in message
+    assert "dtype=torch.float32" in message
+    assert "finite_count=2" in message
+    assert "nan_count=1" in message
+    assert "negative_infinity_count=1" in message
+
+
+def test_scnn_multiplicative_statistics_normalization_keeps_lost_values_stable():
+    torch.manual_seed(131)
+    model = MultiplicativeStatsNet().eval()
+
+    first = StreamingCNN(
+        model,
+        tile_shape=(1, 3, 8, 8),
+        verbose=False,
+        deterministic=True,
+        copy_to_gpu=False,
+        statistics_on_cpu=False,
+        normalize_on_gpu=False,
+    )
+    second = StreamingCNN(
+        MultiplicativeStatsNet().eval(),
+        tile_shape=(1, 3, 8, 8),
+        verbose=False,
+        deterministic=True,
+        copy_to_gpu=False,
+        statistics_on_cpu=False,
+        normalize_on_gpu=False,
+    )
+
+    assert first.tile_output_lost == second.tile_output_lost == Lost(1, 1, 1, 1)
+    assert first.tile_gradient_lost == second.tile_gradient_lost
+    assert all(torch.isfinite(stat["output_stride"]).all() for stat in first._module_stats.values())


### PR DESCRIPTION
### Motivation
- Prevent statistics-generation gradients from overflowing (inf / nan) when pointwise multiplications or large amplifications occur while preserving positive-maximum support semantics used for lost-border inference.
- Ensure downstream border-localization logic receives finite, positive-rescaled tensors so argmax-like localization is unchanged but numerical stability is improved.

### Description
- Added `_normalize_statistics_gradient(tensor, *, context: str = "")` that finite-cleans `nan/+inf/-inf`, chooses finite sentinels when available (fallback +/-1), computes `scale = cleaned.max()` from a detached view, and divides by that positive scalar only when `scale > 0` to preserve positive-max localization.
- Added `_statistics_tensor_diagnostics(tensor, *, context: str = "")` to produce shape/dtype/finite/NaN/inf counts used in descriptive errors.
- Hardened `_non_max_border_amount` to call the normalizer first, ensure a finite positive maximum exists before dividing, and raise clear `RuntimeError` including diagnostics if positive support is missing or thresholding yields no support.
- Applied normalization in `_backward_gather_statistics_hook`: normalize `grad_out[0]` before calling `_non_max_border_amount(...)` and normalize the channel-summed `f_grad` before computing the near-max `valid_grad` mask, while preserving the existing synthetic `new_grad_in` generation behavior.
- Added focused unit tests to `tests/test_scnn.py` that validate non-finite cleaning semantics, diagnostics on missing positive support, and stability for a constructed multiplicative stats network that previously triggered exploding statistics gradients.

### Testing
- Compiled modified files with `python -m compileall lightstream/core/scnn/scnn.py tests/test_scnn.py` which succeeded.
- Ran focused unit validation (local runner with lightweight stubs for optional packages) covering `test_scnn_statistics_gradient_normalization_cleans_nonfinite_without_abs_support`, `test_scnn_non_max_border_amount_rejects_missing_positive_support_with_diagnostics`, and `test_scnn_multiplicative_statistics_normalization_keeps_lost_values_stable`, and these focused checks passed.
- Full `pytest tests/test_scnn.py` was attempted but collection failed in this environment due to missing optional runtime dependency `lightning` (environmental), so full test-suite run was blocked rather than indicating a regression.
- Example/script smoke runs (`examples/compare_grads_segment.py --help`) were attempted but also blocked by the same missing optional dependency in the current environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2049483b988330bc7102b0d5bac406)