### PR TITLE
Scale stats Conv2d initialization by grouped fan-in/out

### DIFF
--- a/lightstream/core/scnn/scnn.py
+++ b/lightstream/core/scnn/scnn.py
@@ -637,9 +637,13 @@ class StreamingCNN(torch.nn.Module):
     def _reset_parameters_to_constant(self):
         for mod in self.stream_module.modules():
             if isinstance(mod, (torch.nn.Conv2d)):
-                # to counter floating precision errors, we assign 1 to the weights and
-                # normalize the output after the conv.
-                torch.nn.init.constant_(mod.weight, 1)
+                kernel_h, kernel_w = mod.kernel_size
+                fan_in = (mod.in_channels / mod.groups) * kernel_h * kernel_w
+                fan_out = (mod.out_channels / mod.groups) * kernel_h * kernel_w
+                scale = 1.0 / max(fan_in, fan_out)
+                # Keep positive support geometry while preventing fan-in/fan-out
+                # amplification during tile-statistics generation.
+                torch.nn.init.constant_(mod.weight, scale)
                 if mod.bias is not None:
                     torch.nn.init.constant_(mod.bias, 0)
 


### PR DESCRIPTION
### Motivation

- Prevent tile-statistics generation from amplifying activations by replacing a fixed-`1` weight init with a compact positive value scaled by convolution fan geometry.
- Ensure the change works correctly for grouped and depthwise convolutions by accounting for `mod.groups` when computing fan-in/fan-out.

### Description

- For each `torch.nn.Conv2d` in `StreamingCNN._reset_parameters_to_constant`, compute `kernel_h, kernel_w = mod.kernel_size`, `fan_in = (mod.in_channels / mod.groups) * kernel_h * kernel_w`, `fan_out = (mod.out_channels / mod.groups) * kernel_h * kernel_w`, and `scale = 1.0 / max(fan_in, fan_out)`.
- Initialize convolution weights with `torch.nn.init.constant_(mod.weight, scale)` and preserve zeroing of `mod.bias` via `torch.nn.init.constant_(mod.bias, 0)` when present.
- Preserve the existing `BatchNorm2d` handling and add a comment that the scaled positive init preserves positive support geometry while preventing fan-in/fan-out amplification during tile-statistics generation.

### Testing

- `python -m py_compile lightstream/core/scnn/scnn.py` completed successfully.
- `python -m pytest tests/test_scnn.py -q` was run but collection failed due to a missing optional dependency (`lightning`), so tests could not be executed end-to-end.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a20b0d3d5788330895eedffacf1ecc3)