### PR TITLE
Fix AttentionGeM streaming passthrough

### DIFF
--- a/lightstream/core/reducer/attention_gem.py
+++ b/lightstream/core/reducer/attention_gem.py
@@ -53,10 +53,10 @@ class AttentionGeMReducer(BaseReducer):
             raise ValueError(f"Reducer expects NCHW x tensor, got shape={tuple(x.shape)}")
         logits = _normalize_logits(attn_logits, x)
         if self._streaming_passthrough:
-            logits_term = logits.to(dtype=x.dtype).sum(dim=(-2, -1), keepdim=True)
-            graph_passthrough = logits_term - logits_term.detach()
-            x_passthrough = x + graph_passthrough
-            return x_passthrough, logits
+            passthrough = (x.view_as(x), logits.view_as(logits))
+            self._last_inputs = passthrough
+            self._last_output = passthrough[0]
+            return passthrough
 
         acc_dtype = resolve_accumulator_dtype(self.accumulator_dtype, x.dtype)
         x_acc = x.to(dtype=acc_dtype)

--- a/tests/test_scnn.py
+++ b/tests/test_scnn.py
@@ -7,6 +7,7 @@ from lightstream.core.constructor import StreamingConstructor
 from lightstream.core.reducer import (
     BaseReducer,
     BaseStreamingGlobalReducer,
+    AttentionGeMReducer,
     GeMReducer,
     MeanReducer,
     StreamingGeMReducer,
@@ -72,6 +73,28 @@ class GeMHeadNet(nn.Module):
     def forward(self, x):
         feat = self.backbone(x)
         return self.gem_head(feat)
+
+
+class AttentionGeMHeadNet(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.backbone = nn.Sequential(
+            nn.Conv2d(3, 5, kernel_size=3, padding=1, bias=False),
+            nn.Softplus(),
+        )
+        self.value_head = nn.Sequential(
+            nn.Conv2d(5, 2, kernel_size=1, bias=True),
+            nn.Softplus(),
+        )
+        self.att_logits = nn.Conv2d(5, 1, kernel_size=1, bias=True)
+        self.reducer = AttentionGeMReducer(r_init=2.0, eps=1e-6)
+
+    def forward(self, x, mask: torch.Tensor | None = None):
+        feat = self.backbone(x)
+        value = self.value_head(feat)
+        logits = self.att_logits(feat)
+        reduced = self.reducer(value, logits, mask=mask)
+        return reduced, value, logits
 
 
 class ValueLogitsReducer(BaseReducer):
@@ -383,6 +406,42 @@ def test_scnn_multi_input_reducer_backward_positional_input_parity_streaming_vs_
     for name, ref_grad in ref_grads.items():
         assert name in stream_grads
         assert torch.allclose(stream_grads[name], ref_grad, atol=1e-5, rtol=1e-4), name
+
+
+def test_attention_gem_streaming_passthrough_logit_bias_gradient_uniform_shift_parity():
+    torch.manual_seed(123)
+    reference = AttentionGeMHeadNet().eval()
+    streaming_probe = AttentionGeMHeadNet().eval()
+    streaming_probe.load_state_dict(reference.state_dict())
+    image = torch.randn(1, 3, 11, 13)
+    mask = torch.rand(11, 13) > 0.2
+
+    ref_reduced, ref_value, ref_logits = reference(image.clone().requires_grad_(True), mask=mask)
+    torch.autograd.backward(
+        (ref_reduced, ref_value, ref_logits),
+        (torch.ones_like(ref_reduced), torch.zeros_like(ref_value), torch.zeros_like(ref_logits)),
+    )
+    ref_bias_grad = reference.att_logits.bias.grad.detach().clone()
+
+    streaming_probe.reducer._streaming_passthrough = True
+    (stream_value, stream_logits), public_value, public_logits = streaming_probe(image.clone().requires_grad_(True), mask=mask)
+    torch.autograd.backward(
+        (stream_value, stream_logits, public_value, public_logits),
+        (
+            torch.ones_like(stream_value),
+            torch.zeros_like(stream_logits),
+            torch.zeros_like(public_value),
+            torch.zeros_like(public_logits),
+        ),
+    )
+    stream_bias_grad = streaming_probe.att_logits.bias.grad.detach().clone()
+
+    assert streaming_probe.reducer._last_inputs[0] is stream_value
+    assert streaming_probe.reducer._last_inputs[1] is stream_logits
+    assert streaming_probe.reducer._last_output is stream_value
+    assert torch.allclose(stream_bias_grad, ref_bias_grad, atol=1e-5, rtol=1e-4)
+    assert torch.allclose(ref_bias_grad, torch.zeros_like(ref_bias_grad), atol=1e-6, rtol=0)
+    assert torch.allclose(stream_bias_grad, torch.zeros_like(stream_bias_grad), atol=1e-6, rtol=0)
 
 
 def test_scnn_single_input_reducers_compatibility_unchanged():


### PR DESCRIPTION
### Motivation
- Remove the additive, nonzero-gradient logits term that was injected into the value passthrough during streaming and caused mismatched gradient paths for attention logits bias.
- Ensure the streaming passthrough follows the same structural contract as other multi-input reducers so `StreamingCNN._resolve_reducer_head_map()` can identify reducer outputs and auxiliary logits inputs.

### Description
- Replaced the prior `logits_term - logits_term.detach()` additive passthrough in `AttentionGeMReducer.forward()` with a structural passthrough `passthrough = (x.view_as(x), logits.view_as(logits))` returned directly. (`lightstream/core/reducer/attention_gem.py`)
- Set `self._last_inputs = passthrough` and `self._last_output = passthrough[0]` in the passthrough branch so reducer head resolution remains possible (mirrors `FusedAttentionGeMReducer` behavior).
- Added `AttentionGeMHeadNet` test fixture and `test_attention_gem_streaming_passthrough_logit_bias_gradient_uniform_shift_parity` to `tests/test_scnn.py` to assert that `att_logits.bias` gradient is near-zero and matches between non-streaming and streaming-passthrough runs.

### Testing
- Ran Python syntax checks with `python -m py_compile lightstream/core/reducer/attention_gem.py tests/test_scnn.py`, which succeeded.
- Attempted targeted pytest for the new test; initial run in the base environment was blocked by missing optional dev deps (`lightning`, `numpy`), so a follow-up run using local stubs for those imports executed the single new test and it passed.
- Performed local sanity checks that confirmed `_last_inputs`/`_last_output` are set and that passthrough gradients for `att_logits.bias` are zero in the streaming passthrough path.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2172d4824483309a71721634230675)