### PR TITLE
Make reducer head mapping occurrence-aware and assert fused reducer payload order

### DIFF
--- a/lightstream/core/reducer/fused_attention_gem.py
+++ b/lightstream/core/reducer/fused_attention_gem.py
@@ -212,7 +212,15 @@ class StreamingFusedAttentionGeMReducer(BaseStreamingGlobalReducer):
         payload = self._parse_multi_input_payload(trimmed_output)
         if len(payload) != 6:
             raise ValueError(f"StreamingFusedAttentionGeMReducer expects payload arity=6, got {len(payload)}")
-        y1 = payload[0]
+        y1, y2, y3, logits1, logits2, logits3 = payload
+        try:
+            _validate_value_maps(y1, y2, y3)
+            _normalize_three_logits(logits1, logits2, logits3, y1)
+        except Exception as exc:
+            raise RuntimeError(
+                "StreamingFusedAttentionGeMReducer.build_backward_pair expected payload order "
+                "(y1, y2, y3, logits1, logits2, logits3)."
+            ) from exc
         expected_h, expected_w = int(y1.shape[-2]), int(y1.shape[-1])
         if self._debug_replay_enabled:
             if self._replay_assignments is None or self._replay_cursor is None:

--- a/lightstream/core/scnn/scnn.py
+++ b/lightstream/core/scnn/scnn.py
@@ -17,7 +17,12 @@ import torch.nn.functional
 from lightstream.core.scnn.utils import Sides, Box, Lost, _ntuple, _new_value_indices, B_DIM, C_DIM, H_DIM, W_DIM
 from lightstream.core.scnn.streamingconv import StreamingConv2d
 from lightstream.core.scnn.streamingupsample import StreamingUpsample2d
-from lightstream.core.reducer import BaseReducer, BaseStreamingGlobalReducer
+from lightstream.core.reducer import (
+    BaseReducer,
+    BaseStreamingGlobalReducer,
+    FusedAttentionGeMReducer,
+    StreamingFusedAttentionGeMReducer,
+)
 
 
 logger = logging.getLogger(__name__)
@@ -598,41 +603,85 @@ class StreamingCNN(torch.nn.Module):
                 "Reducer backward replay requires prior streaming forward pass to resolve reducer heads."
             )
 
+    def _is_fused_attention_gem_reducer(self, reducer) -> bool:
+        return isinstance(reducer, (FusedAttentionGeMReducer, StreamingFusedAttentionGeMReducer))
+
+    def _assert_fused_reducer_payload_order(self, *, reducer, head_idx, ordered_indices, location: str) -> None:
+        if not self._is_fused_attention_gem_reducer(reducer):
+            return
+        expected_indices = tuple(range(int(head_idx), int(head_idx) + 6))
+        if tuple(ordered_indices) != expected_indices:
+            raise RuntimeError(
+                f"{location}: fused reducer head {head_idx} must consume its own passthrough payload "
+                "in order (y1, y2, y3, logits1, logits2, logits3); "
+                f"expected indices={expected_indices}, got indices={tuple(ordered_indices)}"
+            )
+
+    def _find_reducer_payload_occurrence(self, *, reducer, reducer_inputs, flat_output_ids, claimed_output_indices):
+        target_ids = tuple(id(inp) for inp in reducer_inputs)
+        arity = len(target_ids)
+        matches = [
+            start
+            for start in range(0, len(flat_output_ids) - arity + 1)
+            if tuple(flat_output_ids[start : start + arity]) == target_ids
+        ]
+        for start in matches:
+            if all(idx not in claimed_output_indices for idx in range(start, start + arity)):
+                return start
+        if matches:
+            raise RuntimeError(
+                f"Reducer {type(reducer).__name__} passthrough occurrence is ambiguous; "
+                f"matched already-claimed output indices={matches}."
+            )
+        raise RuntimeError(
+            f"Reducer {type(reducer).__name__} passthrough payload is not present as a contiguous "
+            "occurrence in flattened outputs; cannot resolve reducer head inputs."
+        )
+
     def _resolve_reducer_head_map(self, flat_outputs):
         # Invariant: reducer-head resolution happens once per forward stream and remains stable
-        # for the paired backward replay traversal.
+        # for the paired backward replay traversal. Multi-input reducers must be resolved by
+        # their own flattened return occurrence, not by the first matching tensor identity:
+        # WSS-style models intentionally feed the same semantic tensors into red1/red2/red3
+        # and a later fused reducer passthrough.
         if self._reducer_head_map or not self._streaming_reducers:
             return
 
-        output_id_to_index = {}
-        for idx, tensor in enumerate(flat_outputs):
-            output_id_to_index.setdefault(id(tensor), idx)
+        flat_output_ids = [id(tensor) for tensor in flat_outputs]
+        claimed_output_indices = set()
         for reducer in self._streaming_reducers:
             reducer_inputs = getattr(reducer, "_last_inputs", None)
             if reducer_inputs is not None:
                 if not isinstance(reducer_inputs, (tuple, list)):
                     raise RuntimeError(f"Reducer {type(reducer).__name__} _last_inputs must be tuple/list, got {type(reducer_inputs)}")
-                input_indices = []
-                for input_pos, inp in enumerate(reducer_inputs):
-                    idx = output_id_to_index.get(id(inp))
-                    if idx is None:
-                        raise RuntimeError(
-                            f"Reducer {type(reducer).__name__} input {input_pos} is not present in flattened outputs; cannot resolve reducer head inputs."
-                        )
-                    input_indices.append(idx)
-                output_index = output_id_to_index.get(id(reducer._last_output))
-                if output_index is None:
-                    raise RuntimeError(f"Reducer {type(reducer).__name__} output is not present in flattened outputs.")
+                if len(reducer_inputs) == 0:
+                    raise RuntimeError(f"Reducer {type(reducer).__name__} _last_inputs must not be empty.")
+                output_index = self._find_reducer_payload_occurrence(
+                    reducer=reducer,
+                    reducer_inputs=reducer_inputs,
+                    flat_output_ids=flat_output_ids,
+                    claimed_output_indices=claimed_output_indices,
+                )
+                input_indices = tuple(range(output_index, output_index + len(reducer_inputs)))
+                self._assert_fused_reducer_payload_order(
+                    reducer=reducer,
+                    head_idx=output_index,
+                    ordered_indices=input_indices,
+                    location="StreamingCNN._resolve_reducer_head_map",
+                )
                 self._reducer_head_map[output_index] = reducer
-                self._reducer_input_indices[output_index] = tuple(input_indices)
+                self._reducer_input_indices[output_index] = input_indices
+                claimed_output_indices.update(input_indices)
                 continue
 
             if reducer._last_output is None:
                 continue
-            output_index = output_id_to_index.get(id(reducer._last_output))
+            matches = [idx for idx, tensor_id in enumerate(flat_output_ids) if tensor_id == id(reducer._last_output)]
+            output_index = next((idx for idx in matches if idx not in claimed_output_indices), None)
             if output_index is not None:
                 self._reducer_head_map[output_index] = reducer
                 self._reducer_input_indices[output_index] = (output_index,)
+                claimed_output_indices.add(output_index)
 
     def _reset_parameters_to_constant(self):
         for mod in self.stream_module.modules():
@@ -904,6 +953,13 @@ class StreamingCNN(torch.nn.Module):
     ):
         if not ordered_indices or ordered_indices[0] != head_idx:
             raise RuntimeError(f"Reducer head {head_idx} input index order mismatch: indices={ordered_indices}")
+        reducer = self._reducer_head_map.get(head_idx)
+        self._assert_fused_reducer_payload_order(
+            reducer=reducer,
+            head_idx=head_idx,
+            ordered_indices=ordered_indices,
+            location="StreamingCNN._build_common_aligned_reducer_payload",
+        )
 
         payload_entries = []
         previous_idx = -1
@@ -1457,6 +1513,12 @@ class StreamingCNN(torch.nn.Module):
     ):
         reducer = self._reducer_head_map[head_idx]
         ordered_indices = self._reducer_input_indices.get(head_idx, (head_idx,))
+        self._assert_fused_reducer_payload_order(
+            reducer=reducer,
+            head_idx=head_idx,
+            ordered_indices=ordered_indices,
+            location="StreamingCNN._build_reducer_backward_pair",
+        )
         if len(ordered_indices) == 1:
             payload = trimmed_output
             common_dst_box = (

--- a/tests/test_streaming_reducer.py
+++ b/tests/test_streaming_reducer.py
@@ -860,6 +860,30 @@ def _install_common_crop_recorder(scnn: StreamingCNN):
     return records
 
 
+
+def test_resolve_fused_reducer_uses_own_repeated_passthrough_occurrence():
+    reducer = StreamingFusedAttentionGeMReducer(r_init=2.0)
+    y1 = torch.randn(1, 1, 4, 4)
+    y2 = torch.randn(1, 1, 4, 4)
+    y3 = torch.randn(1, 1, 4, 4)
+    logits1 = torch.randn(1, 1, 4, 4)
+    logits2 = torch.randn(1, 1, 4, 4)
+    logits3 = torch.randn(1, 1, 4, 4)
+    reducer._last_inputs = (y1, y2, y3, logits1, logits2, logits3)
+    reducer._last_output = y1
+
+    scnn = StreamingCNN.__new__(StreamingCNN)
+    object.__setattr__(scnn, "_streaming_reducers", [reducer])
+    object.__setattr__(scnn, "_reducer_head_map", {})
+    object.__setattr__(scnn, "_reducer_input_indices", {})
+
+    flat_outputs = (y1, logits1, y2, logits2, y3, logits3, y1, y2, y3, logits1, logits2, logits3)
+    scnn._resolve_reducer_head_map(flat_outputs)
+
+    assert scnn._reducer_head_map == {6: reducer}
+    assert scnn._reducer_input_indices == {6: (6, 7, 8, 9, 10, 11)}
+
+
 def test_streaming_wss_like_branch_gradients_match_non_streaming_with_masked_lost_borders():
     torch.manual_seed(211)
     model = SmallWSSLikeReducerNet().eval()
@@ -893,6 +917,7 @@ def test_streaming_wss_like_branch_gradients_match_non_streaming_with_masked_los
     assert scnn.tile_gradient_lost.right > 0
 
     stream_outputs = scnn.forward(image.detach().clone(), mask=mask)
+    assert scnn._reducer_input_indices.get(6) == (6, 7, 8, 9, 10, 11)
     assert isinstance(stream_outputs, tuple)
     assert len(stream_outputs) == 4
     for stream_output, ref_output in zip(stream_outputs, ref_outputs):


### PR DESCRIPTION
### Motivation
- Prevent multi-input reducers (notably the fused WSS segment reducer) from resolving to earlier identical-tensor outputs by id alone, which caused reducers to consume passthrough tensors belonging to other reducer occurrences.
- Add defensive checks for the Fused/StreamingFusedAttentionGeMReducer to ensure its resolved indices match the expected six-tensor passthrough ordering `(y1, y2, y3, logits1, logits2, logits3)`.

### Description
- Replace first-match-by-`id` resolution with an occurrence-aware search that finds a reducer's contiguous flattened passthrough occurrence and claims those output indices to avoid aliasing other heads, and expose this via `_find_reducer_payload_occurrence` in `StreamingCNN._resolve_reducer_head_map`.
- Track claimed output indices to prevent overlapping claims and use occurrence start -> input index range to populate `_reducer_input_indices` for multi-input reducers in `StreamingCNN._resolve_reducer_head_map`.
- Add helper `_assert_fused_reducer_payload_order` and `_is_fused_attention_gem_reducer` and call the assertion at resolution time and when building aligned payloads in `StreamingCNN._build_common_aligned_reducer_payload` and when constructing reducer backward pairs in `StreamingCNN._build_reducer_backward_pair` to enforce the expected fused order.
- Add a runtime payload-order validation inside `StreamingFusedAttentionGeMReducer.build_backward_pair` that raises a clear `RuntimeError` if the six-tensor payload is not in the `(y1, y2, y3, logits1, logits2, logits3)` shape/order.
- Add a focused regression test `test_resolve_fused_reducer_uses_own_repeated_passthrough_occurrence` and a runtime assertion within the WSS-like streaming test to ensure the fused reducer maps to its own six indices (example `(6,7,8,9,10,11)`).

### Testing
- Ran `python -m py_compile lightstream/core/scnn/scnn.py lightstream/core/reducer/fused_attention_gem.py tests/test_streaming_reducer.py` which succeeded.
- Ran `git diff --check` and basic repository checks before committing the change (commit `2cbf556`).
- Attempted to execute the focused `pytest` selections for the new regression and related fused-reducer tests, but test collection was blocked by a missing external dependency (`lightning`/`lightning.pytorch`) in the execution environment so full pytest runs were not completed in CI here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a21a1d633f883309da25892a4232446)