### PR TITLE
Fix reducer backward overlap masks

### DIFF
--- a/lightstream/core/reducer/attention_gem.py
+++ b/lightstream/core/reducer/attention_gem.py
@@ -147,6 +147,7 @@ class StreamingAttentionGeMReducer(BaseStreamingGlobalReducer):
                     len(payload),
                 )
             )
+        self._record_effective_mask_for_backward(effective_mask)
         if torch.any(effective_mask):
             self.accumulate_valid_tile(payload, valid_mask=effective_mask)
         seen_slice |= new_mask
@@ -154,6 +155,7 @@ class StreamingAttentionGeMReducer(BaseStreamingGlobalReducer):
     def build_backward_pair(self, trimmed_output, gradient: torch.Tensor, *, input_y: int, input_x: int, sides, valid_mask: torch.Tensor | None = None):
         payload = self._parse_multi_input_payload(trimmed_output)
         x_tile = payload[0]
+        valid_mask = self._consume_effective_mask_for_backward(valid_mask, x_tile)
         expected_h, expected_w = int(x_tile.shape[-2]), int(x_tile.shape[-1])
         if self._debug_replay_enabled:
             if self._replay_assignments is None or self._replay_cursor is None:

--- a/lightstream/core/reducer/base.py
+++ b/lightstream/core/reducer/base.py
@@ -186,6 +186,8 @@ class BaseStreamingGlobalReducer(nn.Module, ABC):
         self._debug_replay_enabled = False
         self._replay_assignments: list[tuple] | None = None
         self._replay_cursor: int | None = None
+        self._replay_effective_masks: list[torch.Tensor] | None = None
+        self._replay_effective_mask_cursor: int | None = None
 
     def reset_stream_state(
         self,
@@ -231,6 +233,8 @@ class BaseStreamingGlobalReducer(nn.Module, ABC):
         self._debug_replay_enabled = debug_replay
         self._replay_assignments = [] if debug_replay else None
         self._replay_cursor = None
+        self._replay_effective_masks = []
+        self._replay_effective_mask_cursor = None
 
     def accumulate_stream_tile(self, trimmed_output: torch.Tensor | Sequence[torch.Tensor], tile_y: int, tile_x: int, sides, dst_box, user_mask: torch.Tensor | None = None):
         """Accumulate one tile while enforcing non-overlapping pixel counting.
@@ -266,6 +270,7 @@ class BaseStreamingGlobalReducer(nn.Module, ABC):
                     1,
                 )
             )
+        self._record_effective_mask_for_backward(effective_mask)
         if torch.any(effective_mask):
             self.accumulate_valid_tile(tile_payload, valid_mask=effective_mask)
         seen_slice |= new_mask
@@ -275,7 +280,10 @@ class BaseStreamingGlobalReducer(nn.Module, ABC):
         return self.finalize_stream()
 
     def start_backward_replay(self):
-        """Prepare replay cursor used by debug backward checks."""
+        """Prepare replay cursors used by backward tile checks and masks."""
+        if self._replay_effective_masks is None:
+            raise RuntimeError("Reducer effective-mask replay state is not available. Run forward before backward.")
+        self._replay_effective_mask_cursor = 0
         if self._debug_replay_enabled:
             if self._replay_assignments is None:
                 raise RuntimeError("Reducer replay assignments are not available for backward replay.")
@@ -284,13 +292,62 @@ class BaseStreamingGlobalReducer(nn.Module, ABC):
             self._replay_cursor = None
 
     def validate_backward_replay_consumed(self, *, head_idx: int):
-        """Validate that backward replay consumed all recorded assignments."""
+        """Validate that backward replay consumed all recorded assignments and masks."""
+        if self._replay_effective_masks is None or self._replay_effective_mask_cursor is None:
+            raise RuntimeError("Reducer effective-mask replay state is not initialized.")
+        if self._replay_effective_mask_cursor != len(self._replay_effective_masks):
+            raise RuntimeError(
+                f"Reducer effective-mask replay incomplete for head {head_idx}: "
+                f"consumed={self._replay_effective_mask_cursor}, expected={len(self._replay_effective_masks)}"
+            )
         if not self._debug_replay_enabled:
             return
         if self._replay_assignments is None or self._replay_cursor is None:
             raise RuntimeError("Reducer replay state is not initialized.")
         if self._replay_cursor != len(self._replay_assignments):
             raise RuntimeError(f"Reducer assignment replay incomplete for head {head_idx}: consumed={self._replay_cursor}, expected={len(self._replay_assignments)}")
+
+    def _record_effective_mask_for_backward(self, effective_mask: torch.Tensor) -> None:
+        """Store the exact forward contribution mask for backward replay."""
+        if self._replay_effective_masks is None:
+            raise RuntimeError("Reducer effective-mask replay storage is not initialized.")
+        self._replay_effective_masks.append(effective_mask.detach().clone())
+
+    def _consume_effective_mask_for_backward(
+        self,
+        valid_mask: torch.Tensor | None,
+        reference: torch.Tensor,
+    ) -> torch.Tensor | None:
+        """Return the forward effective mask for this backward replay tile.
+
+        Reducer forward accumulation counts each reducer-domain pixel once by
+        combining the user mask with the not-yet-seen overlap mask.  Backward
+        replay must use that same effective mask; using only the user mask
+        double-counts overlapping regions when multiple tiles cover a pixel.
+        """
+        if self._replay_effective_masks is None or self._replay_effective_mask_cursor is None:
+            raise RuntimeError("Reducer effective-mask replay state is not initialized. Call start_backward_replay() first.")
+        if self._replay_effective_mask_cursor >= len(self._replay_effective_masks):
+            raise RuntimeError("Reducer effective-mask replay consumed more tiles than were recorded during forward.")
+
+        effective_mask = self._replay_effective_masks[self._replay_effective_mask_cursor]
+        self._replay_effective_mask_cursor += 1
+        effective_mask = effective_mask.to(device=reference.device, dtype=torch.bool)
+        expected_shape = tuple(reference.shape[-2:])
+        if tuple(effective_mask.shape) != expected_shape:
+            raise RuntimeError(
+                f"Reducer effective-mask replay shape mismatch: got {tuple(effective_mask.shape)}, "
+                f"expected {expected_shape}."
+            )
+        if valid_mask is None:
+            return effective_mask
+        user_mask = valid_mask.to(device=reference.device, dtype=torch.bool)
+        if tuple(user_mask.shape) != expected_shape:
+            raise RuntimeError(
+                f"Reducer backward valid-mask shape mismatch: got {tuple(user_mask.shape)}, "
+                f"expected {expected_shape}."
+            )
+        return effective_mask & user_mask
 
     def finalize_stream(self) -> torch.Tensor:
         """Compute final output from reducer state."""
@@ -306,6 +363,7 @@ class BaseStreamingGlobalReducer(nn.Module, ABC):
             or structured tuple/list for multi-input reducers.
         """
         tile_payload = self._parse_single_input_payload(trimmed_output)
+        valid_mask = self._consume_effective_mask_for_backward(valid_mask, tile_payload)
         expected_h = int(tile_payload.shape[-2])
         expected_w = int(tile_payload.shape[-1])
         if self._debug_replay_enabled:

--- a/lightstream/core/reducer/fused_attention_gem.py
+++ b/lightstream/core/reducer/fused_attention_gem.py
@@ -204,6 +204,7 @@ class StreamingFusedAttentionGeMReducer(BaseStreamingGlobalReducer):
                     len(payload),
                 )
             )
+        self._record_effective_mask_for_backward(effective_mask)
         if torch.any(effective_mask):
             self.accumulate_valid_tile(payload, valid_mask=effective_mask)
         seen_slice |= new_mask
@@ -213,6 +214,7 @@ class StreamingFusedAttentionGeMReducer(BaseStreamingGlobalReducer):
         if len(payload) != 6:
             raise ValueError(f"StreamingFusedAttentionGeMReducer expects payload arity=6, got {len(payload)}")
         y1 = payload[0]
+        valid_mask = self._consume_effective_mask_for_backward(valid_mask, y1)
         expected_h, expected_w = int(y1.shape[-2]), int(y1.shape[-1])
         if self._debug_replay_enabled:
             if self._replay_assignments is None or self._replay_cursor is None:

--- a/lightstream/core/scnn/scnn.py
+++ b/lightstream/core/scnn/scnn.py
@@ -1341,10 +1341,8 @@ class StreamingCNN(torch.nn.Module):
             output_widths=output_widths,
         )
 
-        if self.debug_reducer_replay:
-            for reducer in self._reducer_head_map.values():
-                reducer.start_backward_replay()
-
+        for reducer in self._reducer_head_map.values():
+            reducer.start_backward_replay()
 
         last_sides = None
         for input_y, input_x, sides in tile_iter:
@@ -1356,9 +1354,8 @@ class StreamingCNN(torch.nn.Module):
                 sides=sides,
             )
 
-        if self.debug_reducer_replay:
-            for idx, reducer in self._reducer_head_map.items():
-                reducer.validate_backward_replay_consumed(head_idx=idx)
+        for idx, reducer in self._reducer_head_map.items():
+            reducer.validate_backward_replay_consumed(head_idx=idx)
 
         self._saved_tensors = {}
 


### PR DESCRIPTION
### Motivation
- Backward replay used the user-provided mask instead of the forward "effective" mask (user mask ∧ first-seen pixels), causing overlapping tile pixels to be double-counted and producing large streaming vs non‑streaming gradient mismatches for certain tile/image size ratios.

### Description
- Record the forward effective reducer mask (user mask ∧ first-seen pixels) per tile during `BaseStreamingGlobalReducer.accumulate_stream_tile` and persist it for replay.
- Add replay storage and cursor fields (`_replay_effective_masks`, `_replay_effective_mask_cursor`) and helpers `_record_effective_mask_for_backward` and `_consume_effective_mask_for_backward` to produce the exact effective mask during backward replay.
- Consume the recorded effective mask in `BaseStreamingGlobalReducer.build_backward_pair` and in multi-input reducers `StreamingAttentionGeMReducer` and `StreamingFusedAttentionGeMReducer` so backward replay uses the identical pixel set as forward.
- Always start and validate reducer backward replay for all reducers in `StreamingCNN` (not only when debug replay is enabled) because effective-mask replay is required for correctness.

### Testing
- Compiled the modified modules with `python -m compileall lightstream/core/reducer lightstream/core/scnn/scnn.py` which succeeded.
- Attempted to run targeted tests `tests/test_streaming_reducer.py::test_streaming_wss_like_branch_gradients_match_non_streaming_with_masked_lost_borders` and `tests/test_streaming_reducer.py::test_streaming_fused_attention_gem_backward_parity_all_inputs` but full pytest runs were blocked by missing optional dependencies (`numpy`, `lightning`, `torchvision`, `torchinfo`) and environment constraints (no NVIDIA driver), and `pip install` was not permitted in this environment; therefore full automated parity tests could not be completed here.
- Performed local/emulated runs with dependency stubs to exercise the new replay logic, which exercised the new code paths; remaining small gradient mismatch observed in one ad-hoc run (max_abs≈4.7e-4) indicating the fix reduces the large overlap double-counting but further numeric tuning/tests may be needed in CI with full deps.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a21abb11250833083762a62abb86924)