### PR TITLE
Revert reducer backward overlap masks (remove effective-mask replay)

### DIFF
--- a/lightstream/core/reducer/attention_gem.py
+++ b/lightstream/core/reducer/attention_gem.py
@@ -147,7 +147,6 @@ class StreamingAttentionGeMReducer(BaseStreamingGlobalReducer):
                     len(payload),
                 )
             )
-        self._record_effective_mask_for_backward(effective_mask)
         if torch.any(effective_mask):
             self.accumulate_valid_tile(payload, valid_mask=effective_mask)
         seen_slice |= new_mask
@@ -155,7 +154,6 @@ class StreamingAttentionGeMReducer(BaseStreamingGlobalReducer):
     def build_backward_pair(self, trimmed_output, gradient: torch.Tensor, *, input_y: int, input_x: int, sides, valid_mask: torch.Tensor | None = None):
         payload = self._parse_multi_input_payload(trimmed_output)
         x_tile = payload[0]
-        valid_mask = self._consume_effective_mask_for_backward(valid_mask, x_tile)
         expected_h, expected_w = int(x_tile.shape[-2]), int(x_tile.shape[-1])
         if self._debug_replay_enabled:
             if self._replay_assignments is None or self._replay_cursor is None:

--- a/lightstream/core/reducer/base.py
+++ b/lightstream/core/reducer/base.py
@@ -186,8 +186,6 @@ class BaseStreamingGlobalReducer(nn.Module, ABC):
         self._debug_replay_enabled = False
         self._replay_assignments: list[tuple] | None = None
         self._replay_cursor: int | None = None
-        self._replay_effective_masks: list[torch.Tensor] | None = None
-        self._replay_effective_mask_cursor: int | None = None
 
     def reset_stream_state(
         self,
@@ -233,8 +231,6 @@ class BaseStreamingGlobalReducer(nn.Module, ABC):
         self._debug_replay_enabled = debug_replay
         self._replay_assignments = [] if debug_replay else None
         self._replay_cursor = None
-        self._replay_effective_masks = []
-        self._replay_effective_mask_cursor = None
 
     def accumulate_stream_tile(self, trimmed_output: torch.Tensor | Sequence[torch.Tensor], tile_y: int, tile_x: int, sides, dst_box, user_mask: torch.Tensor | None = None):
         """Accumulate one tile while enforcing non-overlapping pixel counting.
@@ -270,7 +266,6 @@ class BaseStreamingGlobalReducer(nn.Module, ABC):
                     1,
                 )
             )
-        self._record_effective_mask_for_backward(effective_mask)
         if torch.any(effective_mask):
             self.accumulate_valid_tile(tile_payload, valid_mask=effective_mask)
         seen_slice |= new_mask
@@ -280,10 +275,7 @@ class BaseStreamingGlobalReducer(nn.Module, ABC):
         return self.finalize_stream()
 
     def start_backward_replay(self):
-        """Prepare replay cursors used by backward tile checks and masks."""
-        if self._replay_effective_masks is None:
-            raise RuntimeError("Reducer effective-mask replay state is not available. Run forward before backward.")
-        self._replay_effective_mask_cursor = 0
+        """Prepare replay cursor used by debug backward checks."""
         if self._debug_replay_enabled:
             if self._replay_assignments is None:
                 raise RuntimeError("Reducer replay assignments are not available for backward replay.")
@@ -292,62 +284,13 @@ class BaseStreamingGlobalReducer(nn.Module, ABC):
             self._replay_cursor = None
 
     def validate_backward_replay_consumed(self, *, head_idx: int):
-        """Validate that backward replay consumed all recorded assignments and masks."""
-        if self._replay_effective_masks is None or self._replay_effective_mask_cursor is None:
-            raise RuntimeError("Reducer effective-mask replay state is not initialized.")
-        if self._replay_effective_mask_cursor != len(self._replay_effective_masks):
-            raise RuntimeError(
-                f"Reducer effective-mask replay incomplete for head {head_idx}: "
-                f"consumed={self._replay_effective_mask_cursor}, expected={len(self._replay_effective_masks)}"
-            )
+        """Validate that backward replay consumed all recorded assignments."""
         if not self._debug_replay_enabled:
             return
         if self._replay_assignments is None or self._replay_cursor is None:
             raise RuntimeError("Reducer replay state is not initialized.")
         if self._replay_cursor != len(self._replay_assignments):
             raise RuntimeError(f"Reducer assignment replay incomplete for head {head_idx}: consumed={self._replay_cursor}, expected={len(self._replay_assignments)}")
-
-    def _record_effective_mask_for_backward(self, effective_mask: torch.Tensor) -> None:
-        """Store the exact forward contribution mask for backward replay."""
-        if self._replay_effective_masks is None:
-            raise RuntimeError("Reducer effective-mask replay storage is not initialized.")
-        self._replay_effective_masks.append(effective_mask.detach().clone())
-
-    def _consume_effective_mask_for_backward(
-        self,
-        valid_mask: torch.Tensor | None,
-        reference: torch.Tensor,
-    ) -> torch.Tensor | None:
-        """Return the forward effective mask for this backward replay tile.
-
-        Reducer forward accumulation counts each reducer-domain pixel once by
-        combining the user mask with the not-yet-seen overlap mask.  Backward
-        replay must use that same effective mask; using only the user mask
-        double-counts overlapping regions when multiple tiles cover a pixel.
-        """
-        if self._replay_effective_masks is None or self._replay_effective_mask_cursor is None:
-            raise RuntimeError("Reducer effective-mask replay state is not initialized. Call start_backward_replay() first.")
-        if self._replay_effective_mask_cursor >= len(self._replay_effective_masks):
-            raise RuntimeError("Reducer effective-mask replay consumed more tiles than were recorded during forward.")
-
-        effective_mask = self._replay_effective_masks[self._replay_effective_mask_cursor]
-        self._replay_effective_mask_cursor += 1
-        effective_mask = effective_mask.to(device=reference.device, dtype=torch.bool)
-        expected_shape = tuple(reference.shape[-2:])
-        if tuple(effective_mask.shape) != expected_shape:
-            raise RuntimeError(
-                f"Reducer effective-mask replay shape mismatch: got {tuple(effective_mask.shape)}, "
-                f"expected {expected_shape}."
-            )
-        if valid_mask is None:
-            return effective_mask
-        user_mask = valid_mask.to(device=reference.device, dtype=torch.bool)
-        if tuple(user_mask.shape) != expected_shape:
-            raise RuntimeError(
-                f"Reducer backward valid-mask shape mismatch: got {tuple(user_mask.shape)}, "
-                f"expected {expected_shape}."
-            )
-        return effective_mask & user_mask
 
     def finalize_stream(self) -> torch.Tensor:
         """Compute final output from reducer state."""
@@ -363,7 +306,6 @@ class BaseStreamingGlobalReducer(nn.Module, ABC):
             or structured tuple/list for multi-input reducers.
         """
         tile_payload = self._parse_single_input_payload(trimmed_output)
-        valid_mask = self._consume_effective_mask_for_backward(valid_mask, tile_payload)
         expected_h = int(tile_payload.shape[-2])
         expected_w = int(tile_payload.shape[-1])
         if self._debug_replay_enabled:

--- a/lightstream/core/reducer/fused_attention_gem.py
+++ b/lightstream/core/reducer/fused_attention_gem.py
@@ -204,7 +204,6 @@ class StreamingFusedAttentionGeMReducer(BaseStreamingGlobalReducer):
                     len(payload),
                 )
             )
-        self._record_effective_mask_for_backward(effective_mask)
         if torch.any(effective_mask):
             self.accumulate_valid_tile(payload, valid_mask=effective_mask)
         seen_slice |= new_mask
@@ -214,7 +213,6 @@ class StreamingFusedAttentionGeMReducer(BaseStreamingGlobalReducer):
         if len(payload) != 6:
             raise ValueError(f"StreamingFusedAttentionGeMReducer expects payload arity=6, got {len(payload)}")
         y1 = payload[0]
-        valid_mask = self._consume_effective_mask_for_backward(valid_mask, y1)
         expected_h, expected_w = int(y1.shape[-2]), int(y1.shape[-1])
         if self._debug_replay_enabled:
             if self._replay_assignments is None or self._replay_cursor is None:

--- a/lightstream/core/scnn/scnn.py
+++ b/lightstream/core/scnn/scnn.py
@@ -1341,8 +1341,10 @@ class StreamingCNN(torch.nn.Module):
             output_widths=output_widths,
         )
 
-        for reducer in self._reducer_head_map.values():
-            reducer.start_backward_replay()
+        if self.debug_reducer_replay:
+            for reducer in self._reducer_head_map.values():
+                reducer.start_backward_replay()
+
 
         last_sides = None
         for input_y, input_x, sides in tile_iter:
@@ -1354,8 +1356,9 @@ class StreamingCNN(torch.nn.Module):
                 sides=sides,
             )
 
-        for idx, reducer in self._reducer_head_map.items():
-            reducer.validate_backward_replay_consumed(head_idx=idx)
+        if self.debug_reducer_replay:
+            for idx, reducer in self._reducer_head_map.items():
+                reducer.validate_backward_replay_consumed(head_idx=idx)
 
         self._saved_tensors = {}
 


### PR DESCRIPTION
### Motivation
- The recent change introduced per-tile effective-mask replay bookkeeping to enforce non-overlapping backward replay and caused large decoder / fused-attention parameter diffs in the failing comparison; this PR returns the code to the previous behavior where backward replay uses the provided `valid_mask` and replay bookkeeping is debug-only.

### Description
- Removed effective-mask replay storage/cursors and the helpers ` _record_effective_mask_for_backward` and `_consume_effective_mask_for_backward` from `lightstream/core/reducer/base.py` and removed their uses in the reducer code paths.
- Removed calls to effective-mask recording/consumption from `StreamingAttentionGeMReducer` and `StreamingFusedAttentionGeMReducer` in `lightstream/core/reducer/attention_gem.py` and `lightstream/core/reducer/fused_attention_gem.py` so accumulation/backward pair construction again uses the supplied `valid_mask` directly.
- Restored `StreamingCNN.backward` behavior in `lightstream/core/scnn/scnn.py` to call `start_backward_replay()` and `validate_backward_replay_consumed(...)` only when `self.debug_reducer_replay` is enabled (debug-only replay setup/validation).
- Changes are localized to `lightstream/core/reducer/base.py`, `lightstream/core/reducer/attention_gem.py`, `lightstream/core/reducer/fused_attention_gem.py`, and `lightstream/core/scnn/scnn.py` and revert the previous effective-mask replay additions.

### Testing
- Attempted to run the targeted pytest `tests/test_streaming_reducer.py::test_streaming_wss_like_branch_gradients_match_non_streaming_with_masked_lost_borders`, but test collection failed due to missing optional runtime dependencies (`ModuleNotFoundError: No module named 'lightning'`) in this environment, so the full pytest could not be executed.
- Attempted to install missing packages (`numpy`, `lightning`) via `pip`, but network access to PyPI was blocked so installation failed and automated test run could not be completed.
- Performed a CPU-only, shimmed local reproduction of the original WSS-like masked-lost-border gradient comparison (shimmed out optional deps and GPU paths); the shim confirmed the prior behavior after this revert: forward outputs show tiny diffs and parameter gradient differences concentrated in decoder / fused-attention-related branches (small stem/backbone diffs ~1e-6, larger decoder/attention diffs up to ~2e-3), matching the expected pre-change behavior.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a21de6dde408330984ad8b1b0542807)