### PR TITLE
Implement per-reducer backward effective masks

### DIFF
--- a/lightstream/core/scnn/scnn.py
+++ b/lightstream/core/scnn/scnn.py
@@ -148,6 +148,7 @@ class StreamingCNN(torch.nn.Module):
         self._reducer_head_map = {}
         self._reducer_input_indices = {}
         self._active_reducer_mask = None
+        self._backward_reducer_seen_masks = {}
 
         if state_dict is None:
             self._configure()
@@ -1341,24 +1342,35 @@ class StreamingCNN(torch.nn.Module):
             output_widths=output_widths,
         )
 
-        if self.debug_reducer_replay:
-            for reducer in self._reducer_head_map.values():
-                reducer.start_backward_replay()
-
-
-        last_sides = None
-        for input_y, input_x, sides in tile_iter:
-            last_sides = sides
-            self._run_backward_tile(
-                backward_ctx=backward_ctx,
-                input_y=input_y,
-                input_x=input_x,
-                sides=sides,
+        self._backward_reducer_seen_masks = {
+            head_idx: torch.zeros(
+                (output_heights[head_idx], output_widths[head_idx]),
+                dtype=torch.bool,
+                device=self.device,
             )
+            for head_idx in self._reducer_head_map
+        }
 
-        if self.debug_reducer_replay:
-            for idx, reducer in self._reducer_head_map.items():
-                reducer.validate_backward_replay_consumed(head_idx=idx)
+        try:
+            if self.debug_reducer_replay:
+                for reducer in self._reducer_head_map.values():
+                    reducer.start_backward_replay()
+
+            last_sides = None
+            for input_y, input_x, sides in tile_iter:
+                last_sides = sides
+                self._run_backward_tile(
+                    backward_ctx=backward_ctx,
+                    input_y=input_y,
+                    input_x=input_x,
+                    sides=sides,
+                )
+
+            if self.debug_reducer_replay:
+                for idx, reducer in self._reducer_head_map.items():
+                    reducer.validate_backward_replay_consumed(head_idx=idx)
+        finally:
+            self._backward_reducer_seen_masks = {}
 
         self._saved_tensors = {}
 
@@ -1478,7 +1490,7 @@ class StreamingCNN(torch.nn.Module):
 
         dst_y0, dst_y1, dst_x0, dst_x1 = common_dst_box
         ref = payload[0] if isinstance(payload, (tuple, list)) else payload
-        valid_mask = self._slice_reducer_mask(
+        user_valid_mask = self._slice_reducer_mask(
             self._active_reducer_mask,
             dst_y0,
             dst_y1,
@@ -1487,6 +1499,20 @@ class StreamingCNN(torch.nn.Module):
             context=f"backward reducer head {head_idx}",
             expected_shape=(ref.shape[H_DIM], ref.shape[W_DIM]),
         )
+        try:
+            seen = self._backward_reducer_seen_masks[head_idx]
+        except KeyError as exc:
+            raise RuntimeError(
+                f"Backward reducer seen mask for head {head_idx} was not initialized"
+            ) from exc
+        seen_slice = seen[dst_y0:dst_y1, dst_x0:dst_x1]
+        new_mask = ~seen_slice
+        effective_valid_mask = new_mask
+        if user_valid_mask is not None:
+            effective_valid_mask = new_mask & user_valid_mask.to(
+                device=new_mask.device,
+                dtype=torch.bool,
+            )
 
         reduced_output, reduced_grad = reducer.build_backward_pair(
             payload,
@@ -1494,8 +1520,9 @@ class StreamingCNN(torch.nn.Module):
             input_y=int(tile_input_y),
             input_x=int(tile_input_x),
             sides=sides,
-            valid_mask=valid_mask,
+            valid_mask=effective_valid_mask,
         )
+        seen_slice |= new_mask
 
         return reduced_output, reduced_grad
 

--- a/tests/test_streaming_reducer.py
+++ b/tests/test_streaming_reducer.py
@@ -1364,3 +1364,72 @@ def test_streaming_fused_attention_gem_backward_parity_all_inputs():
     for name, ref_grad in ref_grads.items():
         assert name in stream_grads
         assert torch.allclose(stream_grads[name], ref_grad, atol=4e-5, rtol=4e-4), name
+
+
+class RecordingBackwardReducer:
+    def __init__(self):
+        self.valid_masks = []
+
+    def build_backward_pair(
+        self,
+        payload,
+        gradient,
+        *,
+        input_y,
+        input_x,
+        sides,
+        valid_mask,
+    ):
+        self.valid_masks.append(valid_mask.detach().clone())
+        return payload, gradient
+
+
+def test_scnn_backward_reducer_effective_masks_are_per_head_and_common_dst_box():
+    scnn = StreamingCNN.__new__(StreamingCNN)
+    reducer0 = RecordingBackwardReducer()
+    reducer1 = RecordingBackwardReducer()
+    scnn._reducer_head_map = {0: reducer0, 1: reducer1}
+    scnn._reducer_input_indices = {}
+    scnn._active_reducer_mask = torch.tensor(
+        [
+            [1, 1, 1, 1],
+            [1, 0, 1, 1],
+            [1, 1, 1, 1],
+            [1, 1, 1, 1],
+        ],
+        dtype=torch.bool,
+    )
+    scnn._backward_reducer_seen_masks = {
+        0: torch.zeros((4, 4), dtype=torch.bool),
+        1: torch.zeros((4, 4), dtype=torch.bool),
+    }
+    scnn.device = torch.device("cpu")
+    sides = type("S", (), dict(top=False, left=False, right=False, bottom=False))()
+    gradient = torch.ones((1, 1, 1, 1))
+
+    first_tile = torch.ones((1, 1, 2, 2))
+    second_tile = torch.ones((1, 1, 2, 2))
+    scnn._build_reducer_backward_pair(
+        0, first_tile, [first_tile], gradient, 0, 0, sides, 0, 0
+    )
+    scnn._build_reducer_backward_pair(
+        0, second_tile, [second_tile], gradient, 0, 0, sides, 1, 1
+    )
+    scnn._build_reducer_backward_pair(
+        1, second_tile, [second_tile], gradient, 0, 0, sides, 1, 1
+    )
+
+    assert torch.equal(
+        reducer0.valid_masks[0],
+        torch.tensor([[1, 1], [1, 0]], dtype=torch.bool),
+    )
+    assert torch.equal(
+        reducer0.valid_masks[1],
+        torch.tensor([[0, 1], [1, 1]], dtype=torch.bool),
+    )
+    assert torch.equal(
+        reducer1.valid_masks[0],
+        torch.tensor([[0, 1], [1, 1]], dtype=torch.bool),
+    )
+    assert scnn._backward_reducer_seen_masks[0].sum().item() == 7
+    assert scnn._backward_reducer_seen_masks[1].sum().item() == 4


### PR DESCRIPTION
### Motivation
- Backward replay for global reducers previously used only the user-provided mask slice and reducer-local state, causing incorrect overlapping replay when multiple reducer heads share output regions; the effective backward mask must be tied to each reducer head and the concrete `common_dst_box` being replayed.

### Description
- Add a per-head seen-mask map `self._backward_reducer_seen_masks` on `StreamingCNN` and initialize one boolean mask per reducer head sized `(output_heights[head_idx], output_widths[head_idx])` on `backward` entry. (`lightstream/core/scnn/scnn.py`)
- In `_build_reducer_backward_pair`, replace the direct use of the user mask with `user_valid_mask = self._slice_reducer_mask(...)`, compute a head-local `seen_slice` and `new_mask = ~seen_slice`, combine them to form `effective_valid_mask = new_mask` or `new_mask & user_valid_mask`, pass `effective_valid_mask` into `reducer.build_backward_pair(...)`, and then update `seen_slice |= new_mask`. (`lightstream/core/scnn/scnn.py`)
- Clear `self._backward_reducer_seen_masks` in a `finally` block after backward tile replay finishes to ensure no leakage across backward calls. (`lightstream/core/scnn/scnn.py`)
- Add a unit test `test_scnn_backward_reducer_effective_masks_are_per_head_and_common_dst_box` that uses a `RecordingBackwardReducer` to assert the per-head effective masks and the seen-mask updates. (`tests/test_streaming_reducer.py`)

### Testing
- Ran `python -m py_compile lightstream/core/scnn/scnn.py tests/test_streaming_reducer.py` which succeeded. 
- Ran `git diff --check` (code/style sanity) which reported no issues. 
- Attempted to run the targeted unit test `pytest -q tests/test_streaming_reducer.py::test_scnn_backward_reducer_effective_masks_are_per_head_and_common_dst_box`, however test collection failed due to an environment ImportError (`ModuleNotFoundError: No module named 'lightning'`), so pytest could not execute the test in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a21f06a64b483309657fa1b27afef70)