### PR TITLE
Add red4-only boundary gradient diagnostic

### DIFF
--- a/lightstream/models/segment/model.py
+++ b/lightstream/models/segment/model.py
@@ -74,6 +74,26 @@ class WSS(nn.Module):
 
         self.w = [0.3, 0.4, 0.3]
 
+        # Test/diagnostic-only switch used to inspect the exact autograd
+        # boundary feeding ``red4``.  It is intentionally opt-in so normal
+        # training/inference does not retain intermediate gradients.
+        self.capture_red4_boundary_grads = False
+        self.red4_boundary_tensors: list[dict[str, Tensor]] = []
+
+    def reset_red4_boundary_grad_capture(self) -> None:
+        """Clear retained ``red4`` input tensors captured for diagnostics."""
+        self.red4_boundary_tensors.clear()
+
+    def _capture_red4_boundary_tensors(self, **tensors: Tensor) -> None:
+        if not self.capture_red4_boundary_grads:
+            return
+
+        captured = {}
+        for name, tensor in tensors.items():
+            if tensor.requires_grad:
+                tensor.retain_grad()
+            captured[name] = tensor
+        self.red4_boundary_tensors.append(captured)
 
     def forward(self, x, mask: torch.Tensor | None = None):
         x1, x2, x3 = self.backbone(x)
@@ -86,6 +106,15 @@ class WSS(nn.Module):
         att1 = self.att_1(x1)
         att2 = self.att_2(x2)
         att3 = self.att_3(x3)
+
+        self._capture_red4_boundary_tensors(
+            y1=y1,
+            y2=y2,
+            y3=y3,
+            att1=att1,
+            att2=att2,
+            att3=att3,
+        )
 
         return self.red1(y1, att1, mask=mask), self.red2(y2, att2, mask=mask), self.red3(y3, att3, mask=mask), self.red4(y1,y2,y3,att1,att2,att3,mask=mask)
 

--- a/tests/test_streaming_reducer.py
+++ b/tests/test_streaming_reducer.py
@@ -6,6 +6,7 @@ import pytest
 
 from lightstream.core.constructor import StreamingConstructor
 from lightstream.core.scnn.scnn import StreamingCNN
+from lightstream.models.segment.model import WSS
 from lightstream.models.segment.streamingwss import StreamingWSS
 
 from lightstream.core.reducer import (
@@ -115,6 +116,84 @@ class SmallWSSLikeReducerNet(nn.Module):
             self.red4(y1, y2, y3, att1, att2, att3, mask=mask),
         )
 
+
+def _red4_boundary_grad_records(model: WSS) -> dict[str, torch.Tensor]:
+    assert model.red4_boundary_tensors
+    record = model.red4_boundary_tensors[-1]
+    result = {}
+    for name, tensor in record.items():
+        assert tensor.grad is not None, name
+        result[name] = tensor.grad.detach().clone()
+    return result
+
+
+def _red4_boundary_stream_grad_records(
+    model: WSS, image_shape: torch.Size, tile_records: list[tuple[int, int]]
+) -> dict[str, torch.Tensor]:
+    assert model.red4_boundary_tensors
+    assert len(model.red4_boundary_tensors) == len(tile_records)
+    result = {}
+    for name in ("y1", "y2", "y3", "att1", "att2", "att3"):
+        first_grad = model.red4_boundary_tensors[0][name].grad
+        assert first_grad is not None, name
+        canvas = torch.zeros(
+            first_grad.shape[0],
+            first_grad.shape[1],
+            image_shape[-2],
+            image_shape[-1],
+            dtype=first_grad.dtype,
+            device=first_grad.device,
+        )
+        for record, (input_y, input_x) in zip(model.red4_boundary_tensors, tile_records):
+            grad = record[name].grad
+            assert grad is not None, name
+            h = min(grad.shape[-2], canvas.shape[-2] - input_y)
+            w = min(grad.shape[-1], canvas.shape[-1] - input_x)
+            if h > 0 and w > 0:
+                canvas[:, :, input_y : input_y + h, input_x : input_x + w] += grad[
+                    :, :, :h, :w
+                ].detach()
+        result[name] = canvas
+    return result
+
+
+def _red4_boundary_gradient_diagnostics(
+    stream_grads: dict[str, torch.Tensor], ref_grads: dict[str, torch.Tensor]
+) -> dict[str, dict[str, object]]:
+    diagnostics = {}
+    for name in ("y1", "y2", "y3", "att1", "att2", "att3"):
+        stream = stream_grads[name]
+        ref = ref_grads[name].to(stream.device)
+        diff = (stream - ref).abs()
+        flat_idx = int(diff.reshape(-1).argmax().item())
+        diagnostics[name] = {
+            "mean_abs_diff": float(diff.mean().item()),
+            "max_abs_diff": float(diff.reshape(-1)[flat_idx].item()),
+            "stream_mean_abs": float(stream.abs().mean().item()),
+            "normal_mean_abs": float(ref.abs().mean().item()),
+            "max_diff_index": tuple(
+                int(i) for i in torch.unravel_index(torch.tensor(flat_idx), diff.shape)
+            ),
+        }
+    return diagnostics
+
+
+def _format_red4_boundary_diagnostics(diagnostics: dict[str, dict[str, object]]) -> str:
+    lines = ["red4_only boundary gradient diagnostics:"]
+    for name, values in diagnostics.items():
+        lines.append(
+            f"  {name}: mean_abs_diff={values['mean_abs_diff']:.6g}, "
+            f"max_abs_diff={values['max_abs_diff']:.6g}, "
+            f"stream_mean_abs={values['stream_mean_abs']:.6g}, "
+            f"normal_mean_abs={values['normal_mean_abs']:.6g}, "
+            f"max_diff_index={values['max_diff_index']}"
+        )
+    lines.append(
+        "Interpretation: if y1/y2/att1/att2 already differ while y3/att3 match, "
+        "inspect red4 payload alignment/cropping; if all six boundary gradients match, "
+        "inspect decoder upsample backward/cropping for decoder1 and decoder2."
+    )
+    return "\n".join(lines)
 
 def _require_and_retain_output_grads(outputs: tuple[torch.Tensor, ...]) -> tuple[torch.Tensor, ...]:
     for output in outputs:
@@ -828,6 +907,88 @@ def test_streaming_wss_attention_gem_backward_public_outputs_drive_aux_attention
 
     for name in ("att1.0.weight", "att2.0.weight", "att3.0.weight"):
         assert stream_grads[name].abs().sum() > 0, name
+
+
+def test_streaming_wss_red4_only_boundary_gradient_diagnostics(tmp_path):
+    torch.manual_seed(23)
+    image = torch.rand(1, 3, 80, 80)
+    network = StreamingWSS(
+        "resnet18",
+        tile_size=64,
+        weights=None,
+        verbose=False,
+        deterministic=True,
+        copy_to_gpu=False,
+        statistics_on_cpu=True,
+        normalize_on_gpu=False,
+        mean=[0, 0, 0],
+        std=[1, 1, 1],
+        tile_cache_path=tmp_path / "resnet18_wss_red4_only_boundary_grad_cache",
+    ).eval()
+    scnn = network.stream_network
+    reference = copy.deepcopy(scnn.stream_module).eval()
+
+    assert isinstance(reference, WSS)
+    assert isinstance(scnn.stream_module, WSS)
+    reference.capture_red4_boundary_grads = True
+    scnn.stream_module.capture_red4_boundary_grads = True
+
+    ref_image = image.detach().clone().requires_grad_(True)
+    reference.reset_red4_boundary_grad_capture()
+    ref_outputs = reference(ref_image)
+    ref_grads_out = (
+        torch.zeros_like(ref_outputs[0]),
+        torch.zeros_like(ref_outputs[1]),
+        torch.zeros_like(ref_outputs[2]),
+        torch.full_like(ref_outputs[3], 0.07),
+    )
+    torch.autograd.backward(ref_outputs, ref_grads_out)
+    ref_boundary_grads = _red4_boundary_grad_records(reference)
+
+    scnn.stream_module.reset_red4_boundary_grad_capture()
+    stream_outputs = scnn.forward(image.detach().clone())
+    assert isinstance(stream_outputs, tuple)
+    assert len(stream_outputs) == 4
+    for stream_output, ref_output in zip(stream_outputs, ref_outputs):
+        assert torch.allclose(stream_output, ref_output.detach(), atol=2e-4, rtol=2e-3)
+
+    stream_grads_out = (
+        torch.zeros_like(stream_outputs[0]),
+        torch.zeros_like(stream_outputs[1]),
+        torch.zeros_like(stream_outputs[2]),
+        torch.full_like(stream_outputs[3], 0.07),
+    )
+
+    scnn.stream_module.reset_red4_boundary_grad_capture()
+    tile_records = []
+    original_run_backward_tile = scnn._run_backward_tile
+
+    def recording_run_backward_tile(**kwargs):
+        tile_records.append((int(kwargs["input_y"]), int(kwargs["input_x"])))
+        return original_run_backward_tile(**kwargs)
+
+    scnn._run_backward_tile = recording_run_backward_tile
+    try:
+        scnn.backward(image.detach().clone(), stream_grads_out)
+    finally:
+        scnn._run_backward_tile = original_run_backward_tile
+
+    stream_boundary_grads = _red4_boundary_stream_grad_records(
+        scnn.stream_module, image.shape, tile_records
+    )
+    diagnostics = _red4_boundary_gradient_diagnostics(stream_boundary_grads, ref_boundary_grads)
+    diagnostic_message = _format_red4_boundary_diagnostics(diagnostics)
+
+    for name, values in diagnostics.items():
+        assert values["stream_mean_abs"] > 0, (
+            f"{name} has zero streaming red4_only gradient; {diagnostic_message}"
+        )
+        assert values["normal_mean_abs"] > 0, (
+            f"{name} has zero normal red4_only gradient; {diagnostic_message}"
+        )
+        assert torch.allclose(
+            stream_boundary_grads[name], ref_boundary_grads[name], atol=3e-4, rtol=3e-3
+        ), diagnostic_message
 
 
 def _install_common_crop_recorder(scnn: StreamingCNN):


### PR DESCRIPTION
### Motivation
- Provide an opt-in diagnostic to retain and compare upstream gradients at the six tensors fed into `red4` so streaming vs non-streaming boundary/backward mismatches can be inspected precisely.

### Description
- Add an opt-in capture to `WSS` (`capture_red4_boundary_grads`, `red4_boundary_tensors`) and helper methods `reset_red4_boundary_grad_capture()` and `_capture_red4_boundary_tensors()` to retain gradients for `y1`, `y2`, `y3`, `att1`, `att2`, and `att3` when enabled, and call this capture from `WSS.forward` before invoking `red4`.
- Add test helpers in `tests/test_streaming_reducer.py` that extract retained non-streaming gradient records (`_red4_boundary_grad_records`), stitch per-tile retained streaming gradients into full-image canvases (`_red4_boundary_stream_grad_records`), compute per-tensor diagnostics (`_red4_boundary_gradient_diagnostics`) and format messages (`_format_red4_boundary_diagnostics`).
- Add a focused test `test_streaming_wss_red4_only_boundary_gradient_diagnostics` that runs a non-streaming and a streaming pass in the red4-only configuration (upstream grads: `red1=0`, `red2=0`, `red3=0`, `red4=nonzero`), collects the six retained gradients, and compares them using the requested metrics: mean abs diff, max abs diff, stream mean abs, normal mean abs, and max-diff index; the test includes interpretation text to help triage mismatch patterns.
- The capture is opt-in and defaults to `False` so normal training/inference is unaffected.

### Testing
- `python -m py_compile lightstream/models/segment/model.py tests/test_streaming_reducer.py` succeeded (syntax check passed).
- Attempted to run the focused pytest `tests/test_streaming_reducer.py::test_streaming_wss_red4_only_boundary_gradient_diagnostics`, but it failed to import test dependencies in the current environment (missing packages such as `lightning`, `torchvision`, `torchinfo`, and `numpy`), so the runtime test is blocked by missing CI/dev dependencies.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a21ffa04d5c833095cae0c6246bedf2)