### PR TITLE
Add opt-in diagnostic capture for WSS decoder branches and diagnostics in compare_grads_segment

### DIFF
--- a/examples/compare_grads_segment.py
+++ b/examples/compare_grads_segment.py
@@ -18,6 +18,122 @@ MODE_ACTIVE_OUTPUTS: dict[str, tuple[int, ...]] = {
 }
 
 
+DECODER_DIAGNOSTIC_STRIDES: dict[str, int] = {
+    "decoder1.x": 4,
+    "decoder1.conv_out": 4,
+    "decoder1.upsample_out": 1,
+    "decoder1.y": 1,
+    "decoder2.x": 8,
+    "decoder2.conv_out": 8,
+    "decoder2.upsample_out": 1,
+    "decoder2.y": 1,
+    "decoder3.x": 16,
+    "decoder3.conv_out": 16,
+    "decoder3.upsample_out": 1,
+    "decoder3.y": 1,
+}
+
+
+def _decoder_branch_grad_records(model: nn.Module) -> dict[str, torch.Tensor]:
+    records = getattr(model, "decoder_branch_tensors", None)
+    if not records:
+        raise RuntimeError("No decoder branch diagnostic tensors were captured.")
+    record = records[-1]
+    result = {}
+    for name in DECODER_DIAGNOSTIC_STRIDES:
+        tensor = record[name]
+        if tensor.grad is None:
+            raise RuntimeError(f"Missing retained gradient for {name}.")
+        result[name] = tensor.grad.detach().clone()
+    return result
+
+
+def _decoder_branch_stream_grad_records(
+    records: list[dict[str, torch.Tensor]], ref_grads: dict[str, torch.Tensor], tile_records: list[tuple[int, int]]
+) -> dict[str, torch.Tensor]:
+    if not records:
+        raise RuntimeError("No streaming decoder branch diagnostic tensors were captured.")
+    if len(records) != len(tile_records):
+        raise RuntimeError(
+            f"Expected one decoder diagnostic record per backward tile; got {len(records)} records "
+            f"for {len(tile_records)} tiles."
+        )
+
+    result = {}
+    for name, stride in DECODER_DIAGNOSTIC_STRIDES.items():
+        canvas = torch.zeros_like(ref_grads[name])
+        for record, (input_y, input_x) in zip(records, tile_records):
+            grad = record[name].grad
+            if grad is None:
+                raise RuntimeError(f"Missing retained streaming gradient for {name}.")
+            dst_y = int(input_y) // stride
+            dst_x = int(input_x) // stride
+            h = min(grad.shape[-2], canvas.shape[-2] - dst_y)
+            w = min(grad.shape[-1], canvas.shape[-1] - dst_x)
+            if h > 0 and w > 0:
+                canvas[:, :, dst_y : dst_y + h, dst_x : dst_x + w] += (
+                    grad[:, :, :h, :w].detach().to(canvas.device)
+                )
+        result[name] = canvas
+    return result
+
+
+def _decoder_branch_gradient_diagnostics(
+    stream_grads: dict[str, torch.Tensor], normal_grads: dict[str, torch.Tensor]
+) -> dict[str, dict[str, object]]:
+    diagnostics = {}
+    for name in DECODER_DIAGNOSTIC_STRIDES:
+        stream = stream_grads[name]
+        normal = normal_grads[name].to(stream.device)
+        diff = (stream - normal).abs()
+        flat_idx = int(diff.reshape(-1).argmax().item())
+        diagnostics[name] = {
+            "mean_abs_diff": float(diff.mean().item()),
+            "max_abs_diff": float(diff.reshape(-1)[flat_idx].item()),
+            "stream_mean_abs": float(stream.abs().mean().item()),
+            "normal_mean_abs": float(normal.abs().mean().item()),
+            "max_diff_index": tuple(int(i) for i in torch.unravel_index(torch.tensor(flat_idx), diff.shape)),
+        }
+    return diagnostics
+
+
+def _first_decoder_divergence(
+    diagnostics: dict[str, dict[str, object]], *, atol: float = 3e-4, rtol: float = 3e-3
+) -> str:
+    for branch in (1, 2, 3):
+        for suffix in ("y", "upsample_out", "conv_out", "x"):
+            name = f"decoder{branch}.{suffix}"
+            values = diagnostics[name]
+            limit = atol + rtol * float(values["normal_mean_abs"])
+            if float(values["max_abs_diff"]) > limit:
+                if suffix == "y" and branch in (1, 2):
+                    return "divergence at y1/y2: red4 payload/crop/reducer replay problem"
+                if suffix == "conv_out":
+                    x_name = f"decoder{branch}.x"
+                    x_values = diagnostics[x_name]
+                    x_limit = atol + rtol * float(x_values["normal_mean_abs"])
+                    if float(x_values["max_abs_diff"]) <= x_limit:
+                        return "conv_out gradient differs but x gradient matches: conv weight-gradient crop/aggregation issue"
+                    return "divergence appears after upsample backward: StreamingUpsample2d / tile-lost crop problem"
+                return f"first retained decoder divergence: {name}"
+    return "no retained decoder branch gradient divergence found within tolerance"
+
+
+def _print_decoder_branch_gradient_diagnostics(
+    stream_grads: dict[str, torch.Tensor], normal_grads: dict[str, torch.Tensor]
+) -> None:
+    diagnostics = _decoder_branch_gradient_diagnostics(stream_grads, normal_grads)
+    print("\nDecoder branch retained-gradient diagnostics:")
+    for name, values in diagnostics.items():
+        print(
+            f"  {name}: mean_abs_diff={values['mean_abs_diff']:.6e}, "
+            f"max_abs_diff={values['max_abs_diff']:.6e}, "
+            f"stream_mean_abs={values['stream_mean_abs']:.6e}, "
+            f"normal_mean_abs={values['normal_mean_abs']:.6e}, "
+            f"max_diff_index={values['max_diff_index']}"
+        )
+    print("First-divergence interpretation:", _first_decoder_divergence(diagnostics))
+
 def _gather_param_grads(model: nn.Module) -> dict[str, torch.Tensor]:
     grads: dict[str, torch.Tensor] = {}
     for name, param in model.named_parameters():
@@ -169,6 +285,7 @@ def _run_mode(args: argparse.Namespace, mode: str, img: torch.Tensor, mask: torc
     )
 
     _freeze_batchnorm(network.stream_network.stream_module)
+    network.stream_network.stream_module.capture_decoder_branch_grads = args.decoder_diagnostics
 
     _zero_grads(network.stream_network.stream_module.parameters())
     start_streaming_forward = time()
@@ -188,18 +305,37 @@ def _run_mode(args: argparse.Namespace, mode: str, img: torch.Tensor, mask: torc
         [f"red{idx + 1}={grad.abs().mean().item():.6e}" for idx, grad in enumerate(output_grads)],
     )
 
+    network.stream_network.stream_module.reset_decoder_branch_grad_capture()
+    tile_records: list[tuple[int, int]] = []
+    original_run_backward_tile = network.stream_network._run_backward_tile
+
+    def recording_run_backward_tile(**kwargs):
+        tile_records.append((int(kwargs["input_y"]), int(kwargs["input_x"])))
+        return original_run_backward_tile(**kwargs)
+
+    if args.decoder_diagnostics:
+        network.stream_network._run_backward_tile = recording_run_backward_tile
     start_streaming_backward = time()
-    network.stream_network.backward(img, output_grads, mask=mask)
+    try:
+        network.stream_network.backward(img, output_grads, mask=mask)
+    finally:
+        if args.decoder_diagnostics:
+            network.stream_network._run_backward_tile = original_run_backward_tile
     end_streaming_backward = time() - start_streaming_backward
 
     streaming_param_grads = _gather_param_grads(network.stream_network.stream_module)
+    streaming_decoder_records = list(
+        getattr(network.stream_network.stream_module, "decoder_branch_tensors", [])
+    )
 
     network.stream_network.disable()
     normal_net = network.stream_network.stream_module
+    normal_net.capture_decoder_branch_grads = args.decoder_diagnostics
     _freeze_batchnorm(normal_net)
     _zero_grads(normal_net.parameters())
     img_normal = img.detach().clone().requires_grad_(args.input_grad)
 
+    normal_net.reset_decoder_branch_grad_capture()
     start_normal_forward = time()
     normal_outputs = normal_net(img_normal, mask=mask)
     end_normal_forward = time() - start_normal_forward
@@ -212,6 +348,13 @@ def _run_mode(args: argparse.Namespace, mode: str, img: torch.Tensor, mask: torc
     torch.autograd.backward(normal_outputs, tuple(grad.detach().clone() for grad in output_grads))
     end_normal_backward = time() - start_normal_backward
     normal_param_grads = _gather_param_grads(normal_net)
+
+    if args.decoder_diagnostics:
+        normal_decoder_grads = _decoder_branch_grad_records(normal_net)
+        streaming_decoder_grads = _decoder_branch_stream_grad_records(
+            streaming_decoder_records, normal_decoder_grads, tile_records
+        )
+        _print_decoder_branch_gradient_diagnostics(streaming_decoder_grads, normal_decoder_grads)
 
     if args.input_grad:
         if img_normal.grad is None:
@@ -264,7 +407,13 @@ def main() -> None:
         action="store_false",
         help="Disable streaming saliency/input-gradient gathering and skip input-gradient comparison.",
     )
-    parser.set_defaults(input_grad=True)
+    parser.add_argument(
+        "--no-decoder-diagnostics",
+        dest="decoder_diagnostics",
+        action="store_false",
+        help="Disable retained-gradient diagnostics for WSS decoder branch internals.",
+    )
+    parser.set_defaults(input_grad=True, decoder_diagnostics=True)
 
     args = parser.parse_args()
 

--- a/lightstream/models/segment/model.py
+++ b/lightstream/models/segment/model.py
@@ -2,6 +2,8 @@
 https://github.com/Nexuslkl/Swin_MIL/blob/main/models/swin_mil.py
 
 """
+from collections.abc import Mapping
+
 import torch
 from torch import Tensor
 import torch.nn as nn
@@ -36,6 +38,24 @@ class GatedAttention(nn.Module):
         return self.upsample(att_logits)
 
 
+class DiagnosticDecoderBranch(nn.Sequential):
+    """WSS decoder branch with stable child names for streaming diagnostics.
+
+    The module intentionally keeps the ``0``/``1``/``2`` child names used by the
+    previous ``nn.Sequential`` decoders, preserving parameter names such as
+    ``decoder1.0.weight`` while allowing :class:`WSS` to run the branch step by
+    step and retain gradients for ``x``, the convolution output, the upsample
+    output, and the final sigmoid output.
+    """
+
+    def __init__(self, in_channels: int, scale_factor: int):
+        super().__init__(
+            nn.Conv2d(in_channels, 1, 1),
+            nn.Upsample(scale_factor=scale_factor, mode="bilinear", align_corners=False),
+            nn.Sigmoid(),
+        )
+
+
 class WSS(nn.Module):
     "Streaming application of SWIN MIL: https://github.com/Nexuslkl/Swin_MIL"
     def __init__(
@@ -52,21 +72,9 @@ class WSS(nn.Module):
         self.red3 = AttentionGeMReducer(accumulator_dtype=reducer_accumulator_dtype)
         self.red4 = FusedAttentionGeMReducer(r_init=4.0, accumulator_dtype=reducer_accumulator_dtype)
 
-        self.decoder1 = nn.Sequential(
-            nn.Conv2d(64, 1, 1),
-            nn.Upsample(scale_factor=4, mode="bilinear", align_corners=False),
-            nn.Sigmoid(),
-        )
-        self.decoder2 = nn.Sequential(
-            nn.Conv2d(128, 1, 1),
-            nn.Upsample(scale_factor=8, mode="bilinear", align_corners=False),
-            nn.Sigmoid(),
-        )
-        self.decoder3 = nn.Sequential(
-            nn.Conv2d(256, 1, 1),
-            nn.Upsample(scale_factor=16, mode="bilinear", align_corners=False),
-            nn.Sigmoid(),
-        )
+        self.decoder1 = DiagnosticDecoderBranch(64, scale_factor=4)
+        self.decoder2 = DiagnosticDecoderBranch(128, scale_factor=8)
+        self.decoder3 = DiagnosticDecoderBranch(256, scale_factor=16)
 
         self.att_1 = GatedAttention(in_channels=64, hidden_channels=32, n_classes=1, scale_factor=4)
         self.att_2 = GatedAttention(in_channels=128, hidden_channels=64, n_classes=1, scale_factor=8)
@@ -74,18 +82,26 @@ class WSS(nn.Module):
 
         self.w = [0.3, 0.4, 0.3]
 
-        # Test/diagnostic-only switch used to inspect the exact autograd
-        # boundary feeding ``red4``.  It is intentionally opt-in so normal
-        # training/inference does not retain intermediate gradients.
+        # Test/diagnostic-only switches used to inspect exact autograd
+        # boundaries. They are intentionally opt-in so normal training/inference
+        # does not retain intermediate gradients.
         self.capture_red4_boundary_grads = False
         self.red4_boundary_tensors: list[dict[str, Tensor]] = []
+        self.capture_decoder_branch_grads = False
+        self.decoder_branch_tensors: list[dict[str, Tensor]] = []
 
     def reset_red4_boundary_grad_capture(self) -> None:
         """Clear retained ``red4`` input tensors captured for diagnostics."""
         self.red4_boundary_tensors.clear()
 
-    def _capture_red4_boundary_tensors(self, **tensors: Tensor) -> None:
-        if not self.capture_red4_boundary_grads:
+    def reset_decoder_branch_grad_capture(self) -> None:
+        """Clear retained decoder branch tensors captured for diagnostics."""
+        self.decoder_branch_tensors.clear()
+
+    def _capture_tensors(
+        self, enabled: bool, records: list[dict[str, Tensor]], tensors: Mapping[str, Tensor]
+    ) -> None:
+        if not enabled:
             return
 
         captured = {}
@@ -93,14 +109,45 @@ class WSS(nn.Module):
             if tensor.requires_grad:
                 tensor.retain_grad()
             captured[name] = tensor
-        self.red4_boundary_tensors.append(captured)
+        records.append(captured)
+
+    def _capture_red4_boundary_tensors(self, **tensors: Tensor) -> None:
+        self._capture_tensors(self.capture_red4_boundary_grads, self.red4_boundary_tensors, tensors)
+
+    def _capture_decoder_branch_tensors(self, **tensors: Tensor) -> None:
+        self._capture_tensors(self.capture_decoder_branch_grads, self.decoder_branch_tensors, tensors)
 
     def forward(self, x, mask: torch.Tensor | None = None):
         x1, x2, x3 = self.backbone(x)
 
-        y1 = self.decoder1(x1)
-        y2 = self.decoder2(x2)
-        y3 = self.decoder3(x3)
+        decoder1_conv_out = self.decoder1[0](x1)
+        decoder1_upsample_out = self.decoder1[1](decoder1_conv_out)
+        y1 = self.decoder1[2](decoder1_upsample_out)
+
+        decoder2_conv_out = self.decoder2[0](x2)
+        decoder2_upsample_out = self.decoder2[1](decoder2_conv_out)
+        y2 = self.decoder2[2](decoder2_upsample_out)
+
+        decoder3_conv_out = self.decoder3[0](x3)
+        decoder3_upsample_out = self.decoder3[1](decoder3_conv_out)
+        y3 = self.decoder3[2](decoder3_upsample_out)
+
+        self._capture_decoder_branch_tensors(
+            **{
+                "decoder1.x": x1,
+                "decoder1.conv_out": decoder1_conv_out,
+                "decoder1.upsample_out": decoder1_upsample_out,
+                "decoder1.y": y1,
+                "decoder2.x": x2,
+                "decoder2.conv_out": decoder2_conv_out,
+                "decoder2.upsample_out": decoder2_upsample_out,
+                "decoder2.y": y2,
+                "decoder3.x": x3,
+                "decoder3.conv_out": decoder3_conv_out,
+                "decoder3.upsample_out": decoder3_upsample_out,
+                "decoder3.y": y3,
+            }
+        )
         #y = 0.3 * y1 + 0.4*y2 + 0.3*y3
 
         att1 = self.att_1(x1)


### PR DESCRIPTION
### Motivation
- Provide an opt-in diagnostic wrapper that retains internal decoder branch tensors/gradients so discrepancies between streaming and non-streaming backward passes can be localized to decoder conv/upsample/aggregation stages.\
- Enable automated aggregation of per-tile streaming backward contributions for the decoder internals and a small decision heuristic to interpret the first retained-tensor divergence.\

### Description
- Add `DiagnosticDecoderBranch` (keeps child names `0/1/2`) and wire WSS to run decoder branches stepwise so the module can retain `x`, `conv_out` (conv output before upsample), `upsample_out` (after upsample), and `y` (final sigmoid) per branch.\
- Add opt-in capture flags and helpers on `WSS`: `capture_decoder_branch_grads`, `decoder_branch_tensors`, `reset_decoder_branch_grad_capture()`, and a generic `_capture_tensors` used for both red4 boundary and decoder captures.\
- Extend `examples/compare_grads_segment.py` to: record backward tile coordinates, collect retained per-tile decoder records, stitch/aggregate streaming per-tile grads into full-sized canvases respecting branch strides, compute per-tensor mean/max absolute diffs vs non-streaming grads, and print a `first-divergence` interpretation mapping (y1/y2 -> red4 payload/cropping, upsample_out -> `StreamingUpsample2d` tile-crop, conv_out/x -> conv-weight aggregation hints).\
- Add CLI wiring (`--no-decoder-diagnostics` opt-out, default on) and integrate recording of `network.stream_network._run_backward_tile` to capture tile positions during streaming backward for correct aggregation.\

### Testing
- Syntax/type-check: `python -m py_compile lightstream/models/segment/model.py examples/compare_grads_segment.py` completed successfully.\
- Unit test attempt: `pytest tests/test_streaming_reducer.py::test_streaming_wss_red4_only_boundary_gradient_diagnostics -q` failed to run due to missing environment dependency (`ModuleNotFoundError: No module named 'lightning'`).\
- End-to-end example attempt: `PYTHONPATH=. python examples/compare_grads_segment.py --modes red4_only --tile-size 2560 --input-size 4800 --dtype float64` could not run in CI environment because importing the package triggers a missing `lightning` dependency; diagnostic code exercised in local environment under proper deps should produce per-branch retained-gradient reports and the first-divergence interpretation.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2201739b6c83308bf9ed6d2db1d29d)