### PR TITLE
Compact fused attention streaming payload

### DIFF
--- a/lightstream/core/reducer/README.md
+++ b/lightstream/core/reducer/README.md
@@ -188,7 +188,7 @@ The reducer first fuses the three value maps with the constant `value_weights` b
 
 Both `value_weights` and `attention_weights` are registered as non-trainable buffers, alongside the non-trainable GeM exponent `r`. They are included in module state and copied by `to_streaming()`, but they are not optimized during training.
 
-SCNN conversion uses `StreamingFusedAttentionGeMReducer`, which preserves the same ordered six-tensor payload for tiled accumulation and backward replay.
+SCNN conversion uses `StreamingFusedAttentionGeMReducer`, which keeps the public six-input reducer API but exposes a compact four-tensor internal payload `(fused_y, att_logits1, att_logits2, att_logits3)` for tiled accumulation and backward replay.
 
 ## Extension guide: custom reducers
 

--- a/lightstream/core/reducer/fused_attention_gem.py
+++ b/lightstream/core/reducer/fused_attention_gem.py
@@ -81,7 +81,9 @@ class FusedAttentionGeMReducer(BaseReducer):
         logits = _normalize_three_logits(logits1, logits2, logits3, y1)
 
         if self._streaming_passthrough:
-            passthrough = tuple(t.view_as(t) for t in (y1, y2, y3, *logits))
+            vw = self.value_weights.to(device=y1.device, dtype=y1.dtype)
+            fused_y = vw[0] * y1 + vw[1] * y2 + vw[2] * y3
+            passthrough = (fused_y.view_as(fused_y), *logits)
             self._last_inputs = passthrough
             self._last_output = passthrough[0]
             return passthrough
@@ -170,16 +172,20 @@ class StreamingFusedAttentionGeMReducer(BaseStreamingGlobalReducer):
     ) -> tuple[torch.Tensor, ...]:
         _validate_value_maps(y1, y2, y3)
         logits = _normalize_three_logits(logits1, logits2, logits3, y1)
-        passthrough = tuple(t.view_as(t) for t in (y1, y2, y3, *logits))
+        vw = self.value_weights.to(device=y1.device, dtype=y1.dtype)
+        fused_y = vw[0] * y1 + vw[1] * y2 + vw[2] * y3
+        passthrough = (fused_y.view_as(fused_y), *logits)
         self._last_inputs = passthrough
         self._last_output = passthrough[0]
         return passthrough
 
     def accumulate_stream_tile(self, trimmed_output, tile_y: int, tile_x: int, sides, dst_box, user_mask: torch.Tensor | None = None):
         payload = self._parse_multi_input_payload(trimmed_output)
-        if len(payload) != 6:
-            raise ValueError(f"StreamingFusedAttentionGeMReducer expects payload arity=6, got {len(payload)}")
-        y1 = payload[0]
+        if len(payload) != 4:
+            raise ValueError(f"StreamingFusedAttentionGeMReducer expects payload arity=4, got {len(payload)}")
+        fused_y = payload[0]
+        if fused_y.ndim != 4:
+            raise ValueError(f"fused_y must be an NCHW tensor, got shape={tuple(fused_y.shape)}")
         dst_y0, dst_y1, dst_x0, dst_x1 = dst_box
         seen_slice = self._stream_seen_mask[dst_y0:dst_y1, dst_x0:dst_x1]
         new_mask = ~seen_slice
@@ -195,8 +201,8 @@ class StreamingFusedAttentionGeMReducer(BaseStreamingGlobalReducer):
                     bool(sides.left),
                     bool(sides.right),
                     bool(sides.bottom),
-                    int(y1.shape[-2]),
-                    int(y1.shape[-1]),
+                    int(fused_y.shape[-2]),
+                    int(fused_y.shape[-1]),
                     int(dst_y0),
                     int(dst_y1),
                     int(dst_x0),
@@ -215,10 +221,12 @@ class StreamingFusedAttentionGeMReducer(BaseStreamingGlobalReducer):
         reducer applies it locally without retaining separate mask replay state.
         """
         payload = self._parse_multi_input_payload(trimmed_output)
-        if len(payload) != 6:
-            raise ValueError(f"StreamingFusedAttentionGeMReducer expects payload arity=6, got {len(payload)}")
-        y1 = payload[0]
-        expected_h, expected_w = int(y1.shape[-2]), int(y1.shape[-1])
+        if len(payload) != 4:
+            raise ValueError(f"StreamingFusedAttentionGeMReducer expects payload arity=4, got {len(payload)}")
+        fused_y = payload[0]
+        if fused_y.ndim != 4:
+            raise ValueError(f"fused_y must be an NCHW tensor, got shape={tuple(fused_y.shape)}")
+        expected_h, expected_w = int(fused_y.shape[-2]), int(fused_y.shape[-1])
         if self._debug_replay_enabled:
             if self._replay_assignments is None or self._replay_cursor is None:
                 raise RuntimeError("Reducer replay state is not initialized. Call start_backward_replay() first.")
@@ -243,25 +251,24 @@ class StreamingFusedAttentionGeMReducer(BaseStreamingGlobalReducer):
 
     def accumulate_valid_tile(self, tile, valid_mask: torch.Tensor) -> None:
         payload = self._parse_multi_input_payload(tile)
-        if len(payload) != 6:
-            raise ValueError(f"StreamingFusedAttentionGeMReducer expects payload arity=6, got {len(payload)}")
-        y1, y2, y3, logits1, logits2, logits3 = payload
-        _validate_value_maps(y1, y2, y3)
+        if len(payload) != 4:
+            raise ValueError(f"StreamingFusedAttentionGeMReducer expects payload arity=4, got {len(payload)}")
+        fused_y, logits1, logits2, logits3 = payload
+        if fused_y.ndim != 4:
+            raise ValueError(f"fused_y must be an NCHW tensor, got shape={tuple(fused_y.shape)}")
         if self.running_shat.numel() == 0:
-            self.reset_stream_state(batch_size=y1.shape[0], channels=y1.shape[1], device=y1.device, dtype=y1.dtype)
+            self.reset_stream_state(batch_size=fused_y.shape[0], channels=fused_y.shape[1], device=fused_y.device, dtype=fused_y.dtype)
 
-        acc_dtype = resolve_accumulator_dtype(self.accumulator_dtype, y1.dtype)
-        vw = self.value_weights.to(device=y1.device, dtype=acc_dtype)
-        r = self.current_r.to(device=y1.device, dtype=acc_dtype)
-        fused_y = vw[0] * y1.to(dtype=acc_dtype) + vw[1] * y2.to(device=y1.device, dtype=acc_dtype) + vw[2] * y3.to(device=y1.device, dtype=acc_dtype)
-        x_pow = fused_y.clamp_min(self.eps).pow(r)
+        acc_dtype = resolve_accumulator_dtype(self.accumulator_dtype, fused_y.dtype)
+        r = self.current_r.to(device=fused_y.device, dtype=acc_dtype)
+        x_pow = fused_y.to(acc_dtype).clamp_min(self.eps).pow(r)
         logits = torch.stack(
-            [logit.to(device=y1.device, dtype=acc_dtype) for logit in _normalize_three_logits(logits1, logits2, logits3, y1)],
+            [logit.to(device=fused_y.device, dtype=acc_dtype) for logit in _normalize_three_logits(logits1, logits2, logits3, fused_y)],
             dim=1,
         )
 
         neg_inf = torch.finfo(acc_dtype).min
-        valid5d = valid_mask[None, None, None].to(device=y1.device, dtype=torch.bool)
+        valid5d = valid_mask[None, None, None].to(device=fused_y.device, dtype=torch.bool)
         logits = torch.where(valid5d, logits, torch.full_like(logits, neg_inf))
 
         m_tile = logits.amax(dim=(-2, -1), keepdim=True)
@@ -305,7 +312,6 @@ class StreamingFusedAttentionGeMReducer(BaseStreamingGlobalReducer):
             "branch_means": branch_means,
             "weighted_mean": weighted_mean,
             "r": r,
-            "value_weights": self.value_weights.to(device=self.running_shat.device, dtype=acc_dtype),
             "attention_weights": aw,
         }
 
@@ -313,27 +319,26 @@ class StreamingFusedAttentionGeMReducer(BaseStreamingGlobalReducer):
         if valid_mask is None:
             raise ValueError("StreamingFusedAttentionGeMReducer backward replay requires a valid_mask.")
         payload = self._parse_multi_input_payload(trimmed_output)
-        if len(payload) != 6:
-            raise ValueError(f"StreamingFusedAttentionGeMReducer expects payload arity=6, got {len(payload)}")
-        y1, y2, y3, logits1, logits2, logits3 = payload
-        _validate_value_maps(y1, y2, y3)
-        acc_dtype = resolve_accumulator_dtype(self.accumulator_dtype, y1.dtype)
-        vw = global_context["value_weights"].to(device=y1.device, dtype=acc_dtype)
-        aw = global_context["attention_weights"].to(device=y1.device, dtype=acc_dtype)
-        r = global_context["r"].to(device=y1.device, dtype=acc_dtype)
-        m = global_context["m"].to(device=y1.device, dtype=acc_dtype)
-        zhat = global_context["zhat"].to(device=y1.device, dtype=acc_dtype).clamp_min(self.eps)
-        branch_means = global_context["branch_means"].to(device=y1.device, dtype=acc_dtype)
-        weighted_mean = global_context["weighted_mean"].to(device=y1.device, dtype=acc_dtype)
+        if len(payload) != 4:
+            raise ValueError(f"StreamingFusedAttentionGeMReducer expects payload arity=4, got {len(payload)}")
+        fused_y, logits1, logits2, logits3 = payload
+        if fused_y.ndim != 4:
+            raise ValueError(f"fused_y must be an NCHW tensor, got shape={tuple(fused_y.shape)}")
+        acc_dtype = resolve_accumulator_dtype(self.accumulator_dtype, fused_y.dtype)
+        aw = global_context["attention_weights"].to(device=fused_y.device, dtype=acc_dtype)
+        r = global_context["r"].to(device=fused_y.device, dtype=acc_dtype)
+        m = global_context["m"].to(device=fused_y.device, dtype=acc_dtype)
+        zhat = global_context["zhat"].to(device=fused_y.device, dtype=acc_dtype).clamp_min(self.eps)
+        branch_means = global_context["branch_means"].to(device=fused_y.device, dtype=acc_dtype)
+        weighted_mean = global_context["weighted_mean"].to(device=fused_y.device, dtype=acc_dtype)
 
-        fused_y = vw[0] * y1.to(dtype=acc_dtype) + vw[1] * y2.to(device=y1.device, dtype=acc_dtype) + vw[2] * y3.to(device=y1.device, dtype=acc_dtype)
-        x_pow = fused_y.clamp_min(self.eps).pow(r)
+        x_pow = fused_y.to(acc_dtype).clamp_min(self.eps).pow(r)
         logits = torch.stack(
-            [logit.to(device=y1.device, dtype=acc_dtype) for logit in _normalize_three_logits(logits1, logits2, logits3, y1)],
+            [logit.to(device=fused_y.device, dtype=acc_dtype) for logit in _normalize_three_logits(logits1, logits2, logits3, fused_y)],
             dim=1,
         )
 
-        valid5d = valid_mask[None, None, None].to(device=y1.device, dtype=torch.bool)
+        valid5d = valid_mask[None, None, None].to(device=fused_y.device, dtype=torch.bool)
         neg_inf = torch.finfo(acc_dtype).min
         logits = torch.where(valid5d, logits, torch.full_like(logits, neg_inf))
         weights_unnorm = torch.exp(logits - m)
@@ -354,7 +359,7 @@ class StreamingFusedAttentionGeMReducer(BaseStreamingGlobalReducer):
         branch_terms = local_s_over_z - branch_means.detach() * local_z_over_z
         scale = (1.0 / r) * weighted_mean.clamp_min(self.eps).pow(1.0 / r - 1.0)
         surrogate = scale.detach() * (branch_terms * aw.view(1, 3, 1, 1, 1)).sum(dim=1)
-        return surrogate.to(dtype=y1.dtype)
+        return surrogate.to(dtype=fused_y.dtype)
 
     def to_reducer(self) -> FusedAttentionGeMReducer:
         reducer = FusedAttentionGeMReducer(

--- a/tests/test_scnn.py
+++ b/tests/test_scnn.py
@@ -8,8 +8,10 @@ from lightstream.core.reducer import (
     BaseReducer,
     BaseStreamingGlobalReducer,
     AttentionGeMReducer,
+    FusedAttentionGeMReducer,
     GeMReducer,
     MeanReducer,
+    StreamingFusedAttentionGeMReducer,
     StreamingGeMReducer,
     StreamingMeanReducer,
     StreamingSumReducer,
@@ -95,6 +97,31 @@ class AttentionGeMHeadNet(nn.Module):
         logits = self.att_logits(feat)
         reduced = self.reducer(value, logits, mask=mask)
         return reduced, value, logits
+
+
+
+class FusedAttentionGeMHeadNet(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.backbone = nn.Sequential(
+            nn.Conv2d(3, 5, kernel_size=3, padding=1, bias=False),
+            nn.Softplus(),
+        )
+        self.value_heads = nn.ModuleList(
+            [
+                nn.Sequential(nn.Conv2d(5, 2, kernel_size=1, bias=True), nn.Softplus()),
+                nn.Sequential(nn.Conv2d(5, 2, kernel_size=1, bias=True), nn.Softplus()),
+                nn.Sequential(nn.Conv2d(5, 2, kernel_size=1, bias=True), nn.Softplus()),
+            ]
+        )
+        self.logit_heads = nn.ModuleList([nn.Conv2d(5, 1, kernel_size=1, bias=True) for _ in range(3)])
+        self.reducer = FusedAttentionGeMReducer(r_init=2.5, eps=1e-6)
+
+    def forward(self, x, mask: torch.Tensor | None = None):
+        feat = self.backbone(x)
+        values = [head(feat) for head in self.value_heads]
+        logits = [head(feat) for head in self.logit_heads]
+        return self.reducer(*values, *logits, mask=mask)
 
 
 class ValueLogitsReducer(BaseReducer):
@@ -532,3 +559,40 @@ def test_scnn_multi_input_reducer_failure_on_input_order_mismatch():
     scnn._reducer_input_indices = {0: (0, 2, 1)}
     with pytest.raises(RuntimeError, match="input index order mismatch"):
         scnn._stitch_forward_outputs([None, None, None], (torch.randn(1, 3, 3, 3),) * 3, 0, 0, type('S', (), dict(top=False,left=False,right=False,bottom=False))(), None)
+
+
+def test_streaming_fused_attention_gem_reducer_exposes_four_tensor_payload():
+    torch.manual_seed(127)
+    reducer = FusedAttentionGeMReducer(value_weights=(0.2, 0.5, 0.3)).to_streaming()
+    y1 = torch.rand(1, 2, 4, 5) + 0.1
+    y2 = torch.rand(1, 2, 4, 5) + 0.1
+    y3 = torch.rand(1, 2, 4, 5) + 0.1
+    logits = [torch.randn(1, 1, 4, 5) for _ in range(3)]
+
+    payload = reducer(y1, y2, y3, *logits)
+
+    assert isinstance(reducer, StreamingFusedAttentionGeMReducer)
+    assert len(payload) == 4
+    expected_fused = 0.2 * y1 + 0.5 * y2 + 0.3 * y3
+    assert torch.allclose(payload[0], expected_fused)
+    assert reducer._last_inputs is payload
+    assert reducer._last_output is payload[0]
+
+
+def test_scnn_fused_attention_gem_internal_payload_count_shrinks_to_four():
+    torch.manual_seed(131)
+    model = FusedAttentionGeMHeadNet().eval()
+    image = torch.rand(1, 3, 9, 11) + 0.05
+    mask = torch.rand(9, 11) > 0.2
+
+    with torch.no_grad():
+        expected = model(image, mask=mask)
+
+    scnn = _make_streaming(model, tile_size=4)
+    assert isinstance(scnn.stream_module.reducer, StreamingFusedAttentionGeMReducer)
+    assert len(scnn._tile_output_shapes) == 4
+
+    with torch.no_grad():
+        streamed = scnn.forward(image, mask=mask)
+
+    assert torch.allclose(streamed, expected, atol=1e-5, rtol=1e-4)


### PR DESCRIPTION
### Motivation
- Reduce the internal streaming payload size and avoid replaying value-map fusion by precomputing a fused value tensor for the fused three-value + three-attention reducer.
- Preserve the public non-streaming `FusedAttentionGeMReducer` API while simplifying streaming accumulation and backward replay logic.

### Description
- `FusedAttentionGeMReducer.forward(...)` now pre-fuses the three value maps and, when in passthrough mode, returns `(fused_y, logits1, logits2, logits3)` instead of `(y1, y2, y3, logits1, logits2, logits3)` and records `self._last_inputs`/`self._last_output` accordingly.
- `StreamingFusedAttentionGeMReducer.forward(...)` mirrors the same four-tensor passthrough payload `(fused_y, logits1, logits2, logits3)` and sets the replay bookkeeping to reference the fused tensor.
- `accumulate_stream_tile(...)` and `accumulate_valid_tile(...)` now expect payload arity `4`, validate `fused_y` is an NCHW tensor, remove runtime value-map fusion, and compute `x_pow` from `fused_y` via `x_pow = fused_y.to(acc_dtype).clamp_min(self.eps).pow(r)`.
- `build_backward_pair(...)` and `reduce_tile_for_backward(...)` now expect arity `4` and use `fused_y = payload[0]` as the reference tensor; replay no longer uses `value_weights` from global context and computes `x_pow` directly from `fused_y` while keeping the existing attention-branch math.
- `extra_state_for_backward()` no longer exposes `value_weights` for replay; non-streaming `FusedAttentionGeMReducer` public API and full-frame behavior are unchanged.
- Updated reducer documentation to mention the internal four-tensor streaming payload and added unit tests in `tests/test_scnn.py` to assert the streaming reducer emits a four-tensor payload and that SCNN internal output count for the fused head shrinks accordingly.

### Testing
- Performed static checks with `python -m py_compile lightstream/core/reducer/fused_attention_gem.py tests/test_scnn.py`, which succeeded.
- Attempted to run the streaming unit tests with `python -m pytest tests/test_scnn.py -q`, but collection failed in this environment due to a missing external dependency (`ModuleNotFoundError: No module named 'lightning'`).
- Added tests asserting the four-tensor passthrough payload and the SCNN internal output count reduction; these tests are included in `tests/test_scnn.py` and will run in CI where dependencies are available.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a220767187c833094fe7440cf14a21e)