### PR TITLE
Compact stacked logits payload for StreamingFusedAttentionGeMReducer

### DIFF
--- a/lightstream/core/reducer/README.md
+++ b/lightstream/core/reducer/README.md
@@ -188,7 +188,7 @@ The reducer first fuses the three value maps with the constant `value_weights` b
 
 Both `value_weights` and `attention_weights` are registered as non-trainable buffers, alongside the non-trainable GeM exponent `r`. They are included in module state and copied by `to_streaming()`, but they are not optimized during training.
 
-SCNN conversion uses `StreamingFusedAttentionGeMReducer`, which keeps the public six-input reducer API but exposes a compact four-tensor internal payload `(fused_y, att_logits1, att_logits2, att_logits3)` for tiled accumulation and backward replay.
+SCNN conversion uses `StreamingFusedAttentionGeMReducer`, which keeps the public six-input reducer API but exposes a compact two-tensor internal payload `(fused_y, att_logits_stacked)`, where the stacked logits use shape `[N, 3, H, W]` for tiled accumulation and backward replay.
 
 ## Extension guide: custom reducers
 

--- a/lightstream/core/reducer/fused_attention_gem.py
+++ b/lightstream/core/reducer/fused_attention_gem.py
@@ -46,6 +46,22 @@ def _normalize_three_logits(
     )
 
 
+def _validate_stacked_logits(logits_stacked: torch.Tensor, reference: torch.Tensor) -> None:
+    if logits_stacked.ndim != 4:
+        raise ValueError(
+            f"logits_stacked must be an NCHW tensor, got shape={tuple(logits_stacked.shape)}"
+        )
+    if (
+        logits_stacked.shape[0] != reference.shape[0]
+        or logits_stacked.shape[1] != 3
+        or logits_stacked.shape[-2:] != reference.shape[-2:]
+    ):
+        raise ValueError(
+            "logits_stacked must have shape [N,3,H,W] matching fused_y; "
+            f"got logits_stacked={tuple(logits_stacked.shape)}, fused_y={tuple(reference.shape)}"
+        )
+
+
 class FusedAttentionGeMReducer(BaseReducer):
     """Fuse three value maps, then apply three globally normalized attention-GeM branches."""
 
@@ -83,7 +99,8 @@ class FusedAttentionGeMReducer(BaseReducer):
         if self._streaming_passthrough:
             vw = self.value_weights.to(device=y1.device, dtype=y1.dtype)
             fused_y = vw[0] * y1 + vw[1] * y2 + vw[2] * y3
-            passthrough = (fused_y.view_as(fused_y), *logits)
+            logits_stacked = torch.cat(logits, dim=1)
+            passthrough = (fused_y.view_as(fused_y), logits_stacked.view_as(logits_stacked))
             self._last_inputs = passthrough
             self._last_output = passthrough[0]
             return passthrough
@@ -171,21 +188,23 @@ class StreamingFusedAttentionGeMReducer(BaseStreamingGlobalReducer):
         mask: torch.Tensor | None = None,
     ) -> tuple[torch.Tensor, ...]:
         _validate_value_maps(y1, y2, y3)
-        logits = _normalize_three_logits(logits1, logits2, logits3, y1)
         vw = self.value_weights.to(device=y1.device, dtype=y1.dtype)
         fused_y = vw[0] * y1 + vw[1] * y2 + vw[2] * y3
-        passthrough = (fused_y.view_as(fused_y), *logits)
+        logits = _normalize_three_logits(logits1, logits2, logits3, y1)
+        logits_stacked = torch.cat(logits, dim=1)
+        passthrough = (fused_y.view_as(fused_y), logits_stacked.view_as(logits_stacked))
         self._last_inputs = passthrough
         self._last_output = passthrough[0]
         return passthrough
 
     def accumulate_stream_tile(self, trimmed_output, tile_y: int, tile_x: int, sides, dst_box, user_mask: torch.Tensor | None = None):
         payload = self._parse_multi_input_payload(trimmed_output)
-        if len(payload) != 4:
-            raise ValueError(f"StreamingFusedAttentionGeMReducer expects payload arity=4, got {len(payload)}")
-        fused_y = payload[0]
+        if len(payload) != 2:
+            raise ValueError(f"StreamingFusedAttentionGeMReducer expects payload arity=2, got {len(payload)}")
+        fused_y, logits_stacked = payload
         if fused_y.ndim != 4:
             raise ValueError(f"fused_y must be an NCHW tensor, got shape={tuple(fused_y.shape)}")
+        _validate_stacked_logits(logits_stacked, fused_y)
         dst_y0, dst_y1, dst_x0, dst_x1 = dst_box
         seen_slice = self._stream_seen_mask[dst_y0:dst_y1, dst_x0:dst_x1]
         new_mask = ~seen_slice
@@ -221,11 +240,12 @@ class StreamingFusedAttentionGeMReducer(BaseStreamingGlobalReducer):
         reducer applies it locally without retaining separate mask replay state.
         """
         payload = self._parse_multi_input_payload(trimmed_output)
-        if len(payload) != 4:
-            raise ValueError(f"StreamingFusedAttentionGeMReducer expects payload arity=4, got {len(payload)}")
-        fused_y = payload[0]
+        if len(payload) != 2:
+            raise ValueError(f"StreamingFusedAttentionGeMReducer expects payload arity=2, got {len(payload)}")
+        fused_y, logits_stacked = payload
         if fused_y.ndim != 4:
             raise ValueError(f"fused_y must be an NCHW tensor, got shape={tuple(fused_y.shape)}")
+        _validate_stacked_logits(logits_stacked, fused_y)
         expected_h, expected_w = int(fused_y.shape[-2]), int(fused_y.shape[-1])
         if self._debug_replay_enabled:
             if self._replay_assignments is None or self._replay_cursor is None:
@@ -251,21 +271,19 @@ class StreamingFusedAttentionGeMReducer(BaseStreamingGlobalReducer):
 
     def accumulate_valid_tile(self, tile, valid_mask: torch.Tensor) -> None:
         payload = self._parse_multi_input_payload(tile)
-        if len(payload) != 4:
-            raise ValueError(f"StreamingFusedAttentionGeMReducer expects payload arity=4, got {len(payload)}")
-        fused_y, logits1, logits2, logits3 = payload
+        if len(payload) != 2:
+            raise ValueError(f"StreamingFusedAttentionGeMReducer expects payload arity=2, got {len(payload)}")
+        fused_y, logits_stacked = payload
         if fused_y.ndim != 4:
             raise ValueError(f"fused_y must be an NCHW tensor, got shape={tuple(fused_y.shape)}")
+        _validate_stacked_logits(logits_stacked, fused_y)
         if self.running_shat.numel() == 0:
             self.reset_stream_state(batch_size=fused_y.shape[0], channels=fused_y.shape[1], device=fused_y.device, dtype=fused_y.dtype)
 
         acc_dtype = resolve_accumulator_dtype(self.accumulator_dtype, fused_y.dtype)
         r = self.current_r.to(device=fused_y.device, dtype=acc_dtype)
         x_pow = fused_y.to(acc_dtype).clamp_min(self.eps).pow(r)
-        logits = torch.stack(
-            [logit.to(device=fused_y.device, dtype=acc_dtype) for logit in _normalize_three_logits(logits1, logits2, logits3, fused_y)],
-            dim=1,
-        )
+        logits = logits_stacked.to(device=fused_y.device, dtype=acc_dtype)[:, :, None]
 
         neg_inf = torch.finfo(acc_dtype).min
         valid5d = valid_mask[None, None, None].to(device=fused_y.device, dtype=torch.bool)
@@ -319,11 +337,12 @@ class StreamingFusedAttentionGeMReducer(BaseStreamingGlobalReducer):
         if valid_mask is None:
             raise ValueError("StreamingFusedAttentionGeMReducer backward replay requires a valid_mask.")
         payload = self._parse_multi_input_payload(trimmed_output)
-        if len(payload) != 4:
-            raise ValueError(f"StreamingFusedAttentionGeMReducer expects payload arity=4, got {len(payload)}")
-        fused_y, logits1, logits2, logits3 = payload
+        if len(payload) != 2:
+            raise ValueError(f"StreamingFusedAttentionGeMReducer expects payload arity=2, got {len(payload)}")
+        fused_y, logits_stacked = payload
         if fused_y.ndim != 4:
             raise ValueError(f"fused_y must be an NCHW tensor, got shape={tuple(fused_y.shape)}")
+        _validate_stacked_logits(logits_stacked, fused_y)
         acc_dtype = resolve_accumulator_dtype(self.accumulator_dtype, fused_y.dtype)
         aw = global_context["attention_weights"].to(device=fused_y.device, dtype=acc_dtype)
         r = global_context["r"].to(device=fused_y.device, dtype=acc_dtype)
@@ -333,10 +352,7 @@ class StreamingFusedAttentionGeMReducer(BaseStreamingGlobalReducer):
         weighted_mean = global_context["weighted_mean"].to(device=fused_y.device, dtype=acc_dtype)
 
         x_pow = fused_y.to(acc_dtype).clamp_min(self.eps).pow(r)
-        logits = torch.stack(
-            [logit.to(device=fused_y.device, dtype=acc_dtype) for logit in _normalize_three_logits(logits1, logits2, logits3, fused_y)],
-            dim=1,
-        )
+        logits = logits_stacked.to(device=fused_y.device, dtype=acc_dtype)[:, :, None]
 
         valid5d = valid_mask[None, None, None].to(device=fused_y.device, dtype=torch.bool)
         neg_inf = torch.finfo(acc_dtype).min

--- a/tests/test_scnn.py
+++ b/tests/test_scnn.py
@@ -561,7 +561,7 @@ def test_scnn_multi_input_reducer_failure_on_input_order_mismatch():
         scnn._stitch_forward_outputs([None, None, None], (torch.randn(1, 3, 3, 3),) * 3, 0, 0, type('S', (), dict(top=False,left=False,right=False,bottom=False))(), None)
 
 
-def test_streaming_fused_attention_gem_reducer_exposes_four_tensor_payload():
+def test_streaming_fused_attention_gem_reducer_exposes_two_tensor_payload():
     torch.manual_seed(127)
     reducer = FusedAttentionGeMReducer(value_weights=(0.2, 0.5, 0.3)).to_streaming()
     y1 = torch.rand(1, 2, 4, 5) + 0.1
@@ -569,17 +569,26 @@ def test_streaming_fused_attention_gem_reducer_exposes_four_tensor_payload():
     y3 = torch.rand(1, 2, 4, 5) + 0.1
     logits = [torch.randn(1, 1, 4, 5) for _ in range(3)]
 
+    base_reducer = FusedAttentionGeMReducer(value_weights=(0.2, 0.5, 0.3))
+    base_reducer._streaming_passthrough = True
+    base_payload = base_reducer(y1, y2, y3, *logits)
     payload = reducer(y1, y2, y3, *logits)
 
+    assert len(base_payload) == 2
+    assert torch.allclose(base_payload[0], 0.2 * y1 + 0.5 * y2 + 0.3 * y3)
+    assert base_payload[1].shape == (1, 3, 4, 5)
+    assert torch.allclose(base_payload[1], torch.cat(logits, dim=1))
     assert isinstance(reducer, StreamingFusedAttentionGeMReducer)
-    assert len(payload) == 4
+    assert len(payload) == 2
     expected_fused = 0.2 * y1 + 0.5 * y2 + 0.3 * y3
     assert torch.allclose(payload[0], expected_fused)
+    assert payload[1].shape == (1, 3, 4, 5)
+    assert torch.allclose(payload[1], torch.cat(logits, dim=1))
     assert reducer._last_inputs is payload
     assert reducer._last_output is payload[0]
 
 
-def test_scnn_fused_attention_gem_internal_payload_count_shrinks_to_four():
+def test_scnn_fused_attention_gem_internal_payload_count_shrinks_to_two():
     torch.manual_seed(131)
     model = FusedAttentionGeMHeadNet().eval()
     image = torch.rand(1, 3, 9, 11) + 0.05
@@ -590,7 +599,7 @@ def test_scnn_fused_attention_gem_internal_payload_count_shrinks_to_four():
 
     scnn = _make_streaming(model, tile_size=4)
     assert isinstance(scnn.stream_module.reducer, StreamingFusedAttentionGeMReducer)
-    assert len(scnn._tile_output_shapes) == 4
+    assert len(scnn._tile_output_shapes) == 2
 
     with torch.no_grad():
         streamed = scnn.forward(image, mask=mask)


### PR DESCRIPTION
### Motivation
- Reduce the internal payload arity and memory overhead by combining the three attention-logit tensors into a single stacked tensor with shape `[N, 3, H, W]` for tiled accumulation and backward replay.
- Simplify streaming bookkeeping and validation by standardizing on a two-tensor payload `(fused_y, logits_stacked)` across non-streaming passthrough and streaming codepaths.

### Description
- Update README to document the new two-tensor internal payload `(fused_y, logits_stacked)` and the stacked logits shape `[N,3,H,W]` for `StreamingFusedAttentionGeMReducer`.
- Add `_validate_stacked_logits` helper to validate stacked-logits shape and update `FusedAttentionGeMReducer.forward` to produce `logits_stacked = torch.cat(logits, dim=1)` for streaming passthrough.
- Refactor `StreamingFusedAttentionGeMReducer` to expect payload arity `2`, validate `logits_stacked` at parse sites, and replace the per-branch tuple handling with the compact `logits_stacked` representation (converted to accumulator dtype as `[:, :, None]` where needed).
- Update accumulation, finalize, backward replay, and extra-state code to consume the stacked logits and preserve previous reduction semantics while keeping attention branches in a compact axis.
- Update unit tests in `tests/test_scnn.py` to assert the new payload arity/shape and to check that tile output bookkeeping reflects `2` outputs rather than `4`.

### Testing
- Ran the updated unit tests in `tests/test_scnn.py`, including `test_streaming_fused_attention_gem_reducer_exposes_two_tensor_payload` and `test_scnn_fused_attention_gem_internal_payload_count_shrinks_to_two`, and they passed.
- Ran `pytest tests/test_scnn.py -q` to exercise streaming reducer integration and the modified assertions, and the test run succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a22a65744248330b3b882f3dfe24543)