### PR TITLE
Support learnable GeM `r` parameter and `r` alias for reducers

### DIFF
--- a/lightstream/core/reducer/gem.py
+++ b/lightstream/core/reducer/gem.py
@@ -15,13 +15,21 @@ class GeMReducer(BaseReducer):
         r_init: float = 4.0,
         eps: float = 1e-6,
         accumulator_dtype: torch.dtype | None = None,
+        learnable_r: bool = False,
+        r: float | None = None,
     ):
         super().__init__()
         self.eps = float(eps)
         self.accumulator_dtype = accumulator_dtype
+        self.learnable_r = bool(learnable_r)
+        if r is not None:
+            r_init = r
 
         init_r = torch.tensor(float(r_init), dtype=torch.float32)
-        self.register_buffer("r", init_r)
+        if self.learnable_r:
+            self.r = torch.nn.Parameter(init_r)
+        else:
+            self.register_buffer("r", init_r)
 
     @property
     def current_r(self) -> torch.Tensor:
@@ -58,8 +66,10 @@ class GeMReducer(BaseReducer):
             r_init=float(self.current_r.detach().item()),
             eps=self.eps,
             accumulator_dtype=self.accumulator_dtype,
+            learnable_r=self.learnable_r,
         )
-        reducer.r.data.copy_(self.current_r.detach().to(device=reducer.r.device, dtype=reducer.r.dtype))
+        with torch.no_grad():
+            reducer.r.copy_(self.current_r.detach().to(device=reducer.r.device, dtype=reducer.r.dtype))
         return reducer
 
 
@@ -71,11 +81,20 @@ class StreamingGeMReducer(BaseStreamingGlobalReducer):
         r_init: float = 4.0,
         eps: float = 1e-6,
         accumulator_dtype: torch.dtype | None = None,
+        learnable_r: bool = False,
+        r: float | None = None,
     ):
         super().__init__(mode="mean", accumulator_dtype=accumulator_dtype)
         self.eps = float(eps)
+        self.learnable_r = bool(learnable_r)
+        if r is not None:
+            r_init = r
+
         init_r = torch.tensor(float(r_init), dtype=torch.float32)
-        self.register_buffer("r", init_r)
+        if self.learnable_r:
+            self.r = torch.nn.Parameter(init_r)
+        else:
+            self.register_buffer("r", init_r)
 
         self.register_buffer("running_q", torch.zeros(0), persistent=False)
 
@@ -153,6 +172,8 @@ class StreamingGeMReducer(BaseStreamingGlobalReducer):
             r_init=float(self.current_r.detach().item()),
             eps=self.eps,
             accumulator_dtype=self.accumulator_dtype,
+            learnable_r=self.learnable_r,
         )
-        reducer.r.data.copy_(self.current_r.detach().to(device=reducer.r.device, dtype=reducer.r.dtype))
+        with torch.no_grad():
+            reducer.r.copy_(self.current_r.detach().to(device=reducer.r.device, dtype=reducer.r.dtype))
         return reducer


### PR DESCRIPTION
### Motivation
- Allow the GeM reduction exponent `r` to be learnable while preserving the existing buffer behavior and backwards-compatible constructor usage.
- Ensure consistent behavior when converting between offline and streaming reducers so the `learnable_r` flag and raw `r` value are preserved.

### Description
- Update `GeMReducer.__init__` to accept `learnable_r: bool = False` and `r: float | None = None` as an alias for `r_init`, and store `self.learnable_r = bool(learnable_r)`; create `init_r = torch.tensor(float(r_init), dtype=torch.float32)` and register `r` as `torch.nn.Parameter(init_r)` when learnable or as a buffer otherwise.
- Apply the same constructor pattern to `StreamingGeMReducer`, including `learnable_r` and `r` alias handling and `init_r` creation.
- Preserve forward math and `current_r` usage unchanged (use `self.current_r.to(device=..., dtype=...)` and do not apply softplus/clamps/positivity transforms).
- Ensure conversions carry over the `learnable_r` setting by constructing the counterpart reducer with `learnable_r=self.learnable_r` and copying `r` under `torch.no_grad()` (using `copy_`) in `to_streaming()` and `to_reducer()`.

### Testing
- `python -m py_compile lightstream/core/reducer/gem.py` succeeded.
- Custom import/roundtrip assertion script validated both fixed (`r=...`) and learnable (`r_init=..., learnable_r=True`) constructors and the GeM ↔ StreamingGeM roundtrip, and it passed.
- `pytest -q tests/test_scnn.py` could not complete collection due to a missing external dependency (`lightning`) in the test environment, so full test run was not possible.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a26d78b6cec8330b35717dc4a5a0c5d)