### PR TITLE
Fix streaming GeM exponent backward replay

### DIFF
--- a/lightstream/core/reducer/gem.py
+++ b/lightstream/core/reducer/gem.py
@@ -161,19 +161,26 @@ class StreamingGeMReducer(BaseStreamingGlobalReducer):
         r = global_context["r"].to(device=trimmed_output.device, dtype=acc_dtype)
         n = global_context["normalization"].to(device=trimmed_output.device, dtype=acc_dtype).clamp_min(1)
 
-        x_pow = x_clamped.pow(r)
+        x_pow = x_clamped.pow(r.detach())
         local_m = streaming_reduce_tile(x_pow, valid_mask, n)
 
-        global_m = global_context["m"].to(device=trimmed_output.device, dtype=acc_dtype)
-        y = global_m.clamp_min(self.eps).pow(1.0 / r)
-        scale = ((1.0 / r) * global_m.clamp_min(self.eps).pow(1.0 / r - 1.0)).detach()
+        global_m = global_context["m"].to(device=trimmed_output.device, dtype=acc_dtype).clamp_min(self.eps)
+        scale = ((1.0 / r) * global_m.pow(1.0 / r - 1.0)).detach()
+        input_surrogate = scale * local_m
 
-        n_t = valid_mask.sum().to(device=trimmed_output.device, dtype=acc_dtype)
-        tile_fraction = n_t / n
-        missing_dr = (-y * global_m.log() / (r * r)).detach()
-        correction = (r - r.detach()) * tile_fraction * missing_dr
+        s = global_context["s"].to(device=trimmed_output.device, dtype=acc_dtype)
+        q = global_context["q"].to(device=trimmed_output.device, dtype=acc_dtype)
+        y = global_m.pow(1.0 / r)
+        dr_per_output = (
+            y
+            * (
+                q / (r * s.clamp_min(self.eps))
+                - global_m.log() / (r * r)
+            )
+        ).detach()
+        r_correction = (r - r.detach()) * dr_per_output
 
-        return (scale * local_m + correction).to(dtype=trimmed_output.dtype)
+        return (input_surrogate + r_correction).to(dtype=trimmed_output.dtype)
 
     def to_reducer(self) -> GeMReducer:
         reducer = GeMReducer(


### PR DESCRIPTION
### Motivation
- Prevent the tile-local backward replay from contributing gradients to the GeM exponent `r` by making the tile replay only responsible for `∂y/∂x`, and supply the full `∂y/∂r` term explicitly from global statistics.

### Description
- In `lightstream/core/reducer/gem.py` updated `StreamingGeMReducer.reduce_tile_for_backward` to use `r.detach()` for the tile-local power (`x_clamped.pow(r.detach())`) so replay does not produce any `r` gradients.
- Kept the existing detached `scale` for input-gradient parity and formed an `input_surrogate = scale * local_m` that accounts only for `∂y/∂x`.
- Computed an explicit detached per-output exponent gradient `dr_per_output` using global `s`, `q`, and `m` from `extra_state_for_backward`, then formed `r_correction = (r - r.detach()) * dr_per_output` and added it to the surrogate.
- Returned the sum `(input_surrogate + r_correction)` cast back to the trimmed output dtype so the replay supplies the full closed-form `r` gradient without double-counting from `x.pow(r)`.

### Testing
- `python -m py_compile lightstream/core/reducer/gem.py` succeeded.
- `pytest tests/test_scnn.py -k gem -q` was attempted but test collection failed due to a missing environment dependency (`ModuleNotFoundError: No module named 'lightning'`), so unit test assertions for gradient parity were not executed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a27195fd218833082cd3b8751df126c)