### PR TITLE
Emit learnable-r correction once in StreamingGeMReducer replay

### DIFF
--- a/lightstream/core/reducer/gem.py
+++ b/lightstream/core/reducer/gem.py
@@ -97,6 +97,7 @@ class StreamingGeMReducer(BaseStreamingGlobalReducer):
             self.register_buffer("r", init_r)
 
         self.register_buffer("running_q", torch.zeros(0), persistent=False)
+        self._r_correction_emitted = False
 
     @property
     def current_r(self) -> torch.Tensor:
@@ -151,6 +152,10 @@ class StreamingGeMReducer(BaseStreamingGlobalReducer):
             "q": self.running_q.to(dtype=acc_dtype),
         }
 
+    def start_backward_replay(self):
+        super().start_backward_replay()
+        self._r_correction_emitted = False
+
     def reduce_tile_for_backward(self, trimmed_output: torch.Tensor, valid_mask: torch.Tensor | None, global_context: dict[str, torch.Tensor | int | float | None]) -> torch.Tensor:
         if valid_mask is None:
             raise ValueError("StreamingGeMReducer backward replay requires a valid_mask.")
@@ -178,7 +183,11 @@ class StreamingGeMReducer(BaseStreamingGlobalReducer):
                 - global_m.log() / (r * r)
             )
         ).detach()
-        r_correction = (r - r.detach()) * dr_per_output
+        if self.learnable_r and not self._r_correction_emitted:
+            self._r_correction_emitted = True
+            r_correction = (r - r.detach()) * dr_per_output
+        else:
+            r_correction = torch.zeros_like(input_surrogate)
 
         return (input_surrogate + r_correction).to(dtype=trimmed_output.dtype)
 


### PR DESCRIPTION
### Motivation
- Ensure the closed-form learnable-`r` correction (`dr_per_output`) is applied exactly once per backward replay for `StreamingGeMReducer`, so the global correction is not partitioned across replay tiles and gradient accounting matches full-frame behavior.

### Description
- Add a transient boolean flag `self._r_correction_emitted` to `StreamingGeMReducer` and initialize it in the constructor.
- Override `start_backward_replay()` to reset `self._r_correction_emitted` at the beginning of each backward replay.
- Change `reduce_tile_for_backward()` to emit the full `r` correction only on the first tile replay when `learnable_r` is true and otherwise return a zero-valued correction, and continue to return `(input_surrogate + r_correction).to(dtype=trimmed_output.dtype)`.
- Avoid partitioning the correction by tile masks (do not use `tile_fraction`) so the closed-form `dr_per_output` is applied globally and emitted once.

### Testing
- `python -m py_compile lightstream/core/reducer/gem.py` succeeded.
- Ran a manual unit check script exercising `StreamingGeMReducer.start_backward_replay()` and `reduce_tile_for_backward()` which printed `manual StreamingGeMReducer r correction single-emission check passed` indicating the single-emission behavior and gradient accumulation are correct.
- Attempted `pytest tests/test_scnn.py::test_scnn_gem_conversion_forward_backward_parity -q` but it could not run due to an import error for the `lightning` dependency in the environment, so full test-suite parity was not executed.
- Attempted to install `numpy`/`lightning` to run the pytest but the environment blocked package index access (network `403`), so dependency installation failed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a27208c25fc8330b7ee68dbc5cedd91)