### PR TITLE
Allow GeM reducers to share r parameter

### DIFF
--- a/lightstream/core/reducer/gem.py
+++ b/lightstream/core/reducer/gem.py
@@ -17,19 +17,25 @@ class GeMReducer(BaseReducer):
         accumulator_dtype: torch.dtype | None = None,
         learnable_r: bool = False,
         r: float | None = None,
+        r_parameter: torch.nn.Parameter | None = None,
     ):
         super().__init__()
         self.eps = float(eps)
         self.accumulator_dtype = accumulator_dtype
-        self.learnable_r = bool(learnable_r)
+
         if r is not None:
             r_init = r
 
-        init_r = torch.tensor(float(r_init), dtype=torch.float32)
-        if self.learnable_r:
-            self.r = torch.nn.Parameter(init_r)
+        if r_parameter is not None:
+            self.r = r_parameter
+            self.learnable_r = True
         else:
-            self.register_buffer("r", init_r)
+            self.learnable_r = bool(learnable_r)
+            init_r = torch.tensor(float(r_init), dtype=torch.float32)
+            if self.learnable_r:
+                self.r = torch.nn.Parameter(init_r)
+            else:
+                self.register_buffer("r", init_r)
 
     @property
     def current_r(self) -> torch.Tensor:

--- a/tests/test_scnn.py
+++ b/tests/test_scnn.py
@@ -391,6 +391,20 @@ def test_gem_reducer_legacy_r_constructor_registers_learnable_parameter():
     assert dict(reducer.named_parameters())["r"] is reducer.r
 
 
+def test_gem_reducer_accepts_shared_r_parameter():
+    shared_r = torch.nn.Parameter(torch.tensor(3.5))
+
+    first = GeMReducer(r_parameter=shared_r)
+    second = GeMReducer(r_parameter=shared_r, r_init=1.0, learnable_r=False, r=2.0)
+
+    assert first.r is shared_r
+    assert second.r is shared_r
+    assert first.learnable_r is True
+    assert second.learnable_r is True
+    assert dict(first.named_parameters())["r"] is shared_r
+    assert dict(second.named_parameters())["r"] is shared_r
+
+
 def test_scnn_mixed_head_reducer_mapping_stable():
     torch.manual_seed(61)
     model = MixedHeadsNet().eval()


### PR DESCRIPTION
### Motivation
- Allow multiple `GeMReducer` instances to reference a single `torch.nn.Parameter` for `r` so reducer instances can share and update the exact same parameter object without copying or detaching it.

### Description
- Add an optional `r_parameter: torch.nn.Parameter | None = None` argument to `GeMReducer.__init__` while keeping the existing `r_init`, `eps`, `accumulator_dtype`, `learnable_r`, and `r` arguments.
- When `r_parameter` is provided assign it directly via `self.r = r_parameter` and set `self.learnable_r = True`, without cloning, detaching, or copying `.data`.
- Preserve the existing initialization path when `r_parameter` is not provided, including honoring `r` overriding `r_init` and registering either a learnable `Parameter` or a buffer for `r` depending on `learnable_r`.
- Add `test_gem_reducer_accepts_shared_r_parameter` which asserts two `GeMReducer` instances can share the exact same `torch.nn.Parameter` and that it appears in `named_parameters()` for both.

### Testing
- Ran `python -m py_compile lightstream/core/reducer/gem.py`, which succeeded.
- Ran `pytest -q tests/test_scnn.py -k "gem_reducer"`, which failed during collection due to the environment missing the external `lightning` dependency so the new test could not be executed end-to-end.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a27314dc9148330a7357c52eace4254)