### PR TITLE
Support shared GeM `r` parameter in StreamingGeMReducer

### DIFF
--- a/lightstream/core/reducer/gem.py
+++ b/lightstream/core/reducer/gem.py
@@ -68,6 +68,13 @@ class GeMReducer(BaseReducer):
         return y.to(dtype=x.dtype)
 
     def to_streaming(self) -> BaseStreamingGlobalReducer:
+        if self.learnable_r:
+            return StreamingGeMReducer(
+                eps=self.eps,
+                accumulator_dtype=self.accumulator_dtype,
+                r_parameter=self.r,
+            )
+
         reducer = StreamingGeMReducer(
             r_init=float(self.current_r.detach().item()),
             eps=self.eps,
@@ -89,18 +96,24 @@ class StreamingGeMReducer(BaseStreamingGlobalReducer):
         accumulator_dtype: torch.dtype | None = None,
         learnable_r: bool = False,
         r: float | None = None,
+        r_parameter: torch.nn.Parameter | None = None,
     ):
         super().__init__(mode="mean", accumulator_dtype=accumulator_dtype)
         self.eps = float(eps)
-        self.learnable_r = bool(learnable_r)
+
         if r is not None:
             r_init = r
 
-        init_r = torch.tensor(float(r_init), dtype=torch.float32)
-        if self.learnable_r:
-            self.r = torch.nn.Parameter(init_r)
+        if r_parameter is not None:
+            self.r = r_parameter
+            self.learnable_r = True
         else:
-            self.register_buffer("r", init_r)
+            self.learnable_r = bool(learnable_r)
+            init_r = torch.tensor(float(r_init), dtype=torch.float32)
+            if self.learnable_r:
+                self.r = torch.nn.Parameter(init_r)
+            else:
+                self.register_buffer("r", init_r)
 
         self.register_buffer("running_q", torch.zeros(0), persistent=False)
         self._r_correction_emitted = False
@@ -198,6 +211,13 @@ class StreamingGeMReducer(BaseStreamingGlobalReducer):
         return (input_surrogate + r_correction).to(dtype=trimmed_output.dtype)
 
     def to_reducer(self) -> GeMReducer:
+        if self.learnable_r:
+            return GeMReducer(
+                eps=self.eps,
+                accumulator_dtype=self.accumulator_dtype,
+                r_parameter=self.r,
+            )
+
         reducer = GeMReducer(
             r_init=float(self.current_r.detach().item()),
             eps=self.eps,

--- a/tests/test_scnn.py
+++ b/tests/test_scnn.py
@@ -405,6 +405,46 @@ def test_gem_reducer_accepts_shared_r_parameter():
     assert dict(second.named_parameters())["r"] is shared_r
 
 
+def test_streaming_gem_reducer_accepts_shared_r_parameter_with_separate_state():
+    shared_r = torch.nn.Parameter(torch.tensor(3.5))
+
+    first = StreamingGeMReducer(r_parameter=shared_r)
+    second = StreamingGeMReducer(r_parameter=shared_r, r_init=1.0, learnable_r=False, r=2.0)
+
+    assert first.r is shared_r
+    assert second.r is shared_r
+    assert first.learnable_r is True
+    assert second.learnable_r is True
+    assert dict(first.named_parameters())["r"] is shared_r
+    assert dict(second.named_parameters())["r"] is shared_r
+
+    first.reset_stream_state(batch_size=1, channels=2, device=torch.device("cpu"), dtype=torch.float32)
+    second.reset_stream_state(batch_size=1, channels=2, device=torch.device("cpu"), dtype=torch.float32)
+
+    assert first.running_sum is not second.running_sum
+    assert first.running_q is not second.running_q
+    assert first.running_count is not second.running_count
+    assert first.running_sum.data_ptr() != second.running_sum.data_ptr()
+    assert first.running_q.data_ptr() != second.running_q.data_ptr()
+    assert first.running_count.data_ptr() != second.running_count.data_ptr()
+
+
+def test_gem_reducer_to_streaming_shares_learnable_r_only():
+    reducer = GeMReducer(r_init=2.75, learnable_r=True)
+
+    streaming_reducer = reducer.to_streaming()
+
+    assert isinstance(streaming_reducer, StreamingGeMReducer)
+    assert streaming_reducer.r is reducer.r
+    assert streaming_reducer.learnable_r is True
+    assert dict(streaming_reducer.named_parameters())["r"] is reducer.r
+
+    streaming_reducer.reset_stream_state(batch_size=1, channels=2, device=torch.device("cpu"), dtype=torch.float32)
+    assert streaming_reducer.running_sum is not reducer.r
+    assert streaming_reducer.running_q is not reducer.r
+    assert streaming_reducer.running_count is not reducer.r
+
+
 def test_scnn_mixed_head_reducer_mapping_stable():
     torch.manual_seed(61)
     model = MixedHeadsNet().eval()


### PR DESCRIPTION
### Motivation
- Bring `StreamingGeMReducer` ownership semantics in line with `GeMReducer` so a shared learnable exponent `r` can be passed into streaming reducers.
- Ensure only the `r` parameter can be shared between offline and streaming reducers while keeping all streaming accumulator/buffer state distinct per reducer instance.

### Description
- Added an optional `r_parameter: torch.nn.Parameter | None = None` argument to `StreamingGeMReducer.__init__` and implemented the same ownership logic used by `GeMReducer` so a provided `r_parameter` becomes the module `r` and forces `learnable_r=True`.
- Preserved the existing behavior for non-shared `r` by initializing `r` either as a `torch.nn.Parameter` when `learnable_r` is true or registering it as a buffer otherwise.
- Kept streaming state buffers separate by continuing to register `running_q` (and the inherited `running_sum`/`running_count`) as independent buffers; only `r` is shared across reducers.
- Updated conversion helpers so `GeMReducer.to_streaming()` and `StreamingGeMReducer.to_reducer()` will share the `r` parameter when it is learnable, and added tests exercising these codepaths in `tests/test_scnn.py`.

### Testing
- Ran `python -m py_compile lightstream/core/reducer/gem.py tests/test_scnn.py` which succeeded.
- Attempted `pytest -q tests/test_scnn.py -k 'gem_reducer_accepts_shared_r_parameter or gem_reducer_to_streaming_shares_learnable_r_only or gem_reducer_learnable_r_constructor or gem_reducer_legacy'` but collection failed due to a missing external dependency (`ModuleNotFoundError: No module named 'lightning'`), so the pytest assertions were not executed in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a27358ccd54833083f82c9f24fb370d)