### PR TITLE
Preserve shared GeM `r` parameter when converting to streaming reducer

### DIFF
--- a/lightstream/core/reducer/gem.py
+++ b/lightstream/core/reducer/gem.py
@@ -79,7 +79,7 @@ class GeMReducer(BaseReducer):
             r_init=float(self.current_r.detach().item()),
             eps=self.eps,
             accumulator_dtype=self.accumulator_dtype,
-            learnable_r=self.learnable_r,
+            learnable_r=False,
         )
         with torch.no_grad():
             reducer.r.copy_(self.current_r.detach().to(device=reducer.r.device, dtype=reducer.r.dtype))


### PR DESCRIPTION
### Motivation
- Ensure a learnable shared GeM `r` parameter remains shared when converting via `GeMReducer.to_streaming()`, and use an explicit path for non-learnable `r` buffers to avoid copying a trainable parameter into a new `Parameter`.

### Description
- Update `GeMReducer.to_streaming()` to return `StreamingGeMReducer(..., r_parameter=self.r)` when `self.learnable_r` is true, and otherwise construct `StreamingGeMReducer(..., learnable_r=False)` and copy the detached buffer value into `reducer.r` under `torch.no_grad()`.

### Testing
- `python -m py_compile lightstream/core/reducer/gem.py` succeeded.
- `pytest -q tests/test_scnn.py::test_gem_reducer_to_streaming_shares_learnable_r_only` was executed but errored due to a missing environment dependency (`ModuleNotFoundError: No module named 'lightning'`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a27379a9ed88330b8791d6cc98bee4f)