### PR TITLE
Add tests for `uniform_attention_eps` validation and conversion on attention GeM reducers

### DIFF
--- a/tests/test_scnn.py
+++ b/tests/test_scnn.py
@@ -11,12 +11,83 @@ from lightstream.core.reducer import (
     FusedAttentionGeMReducer,
     GeMReducer,
     MeanReducer,
+    StreamingAttentionGeMReducer,
     StreamingFusedAttentionGeMReducer,
     StreamingGeMReducer,
     StreamingMeanReducer,
     StreamingSumReducer,
     SumReducer,
 )
+
+
+@pytest.mark.parametrize(
+    "reducer_cls",
+    [
+        AttentionGeMReducer,
+        StreamingAttentionGeMReducer,
+        FusedAttentionGeMReducer,
+        StreamingFusedAttentionGeMReducer,
+    ],
+)
+@pytest.mark.parametrize("bad_eps", [-0.01, 1.01, float("inf"), float("nan")])
+def test_attention_gem_uniform_attention_eps_validation(reducer_cls, bad_eps):
+    with pytest.raises(ValueError, match="uniform_attention_eps"):
+        reducer_cls(uniform_attention_eps=bad_eps)
+
+
+def test_attention_gem_uniform_attention_eps_conversion_round_trip_preserves_value():
+    reducer = AttentionGeMReducer(r_init=2.25, eps=1e-5, uniform_attention_eps=0.125)
+
+    streaming = reducer.to_streaming()
+    round_tripped = streaming.to_reducer()
+
+    assert isinstance(streaming, StreamingAttentionGeMReducer)
+    assert streaming.uniform_attention_eps == pytest.approx(0.125)
+    assert round_tripped.uniform_attention_eps == pytest.approx(0.125)
+    assert reducer.uniform_attention_eps == pytest.approx(0.125)
+
+
+def test_fused_attention_gem_uniform_attention_eps_conversion_round_trip_preserves_value():
+    reducer = FusedAttentionGeMReducer(
+        r_init=2.25,
+        eps=1e-5,
+        value_weights=(0.2, 0.5, 0.3),
+        attention_weights=(0.1, 0.7, 0.2),
+        uniform_attention_eps=0.125,
+    )
+
+    streaming = reducer.to_streaming()
+    round_tripped = streaming.to_reducer()
+
+    assert isinstance(streaming, StreamingFusedAttentionGeMReducer)
+    assert streaming.uniform_attention_eps == pytest.approx(0.125)
+    assert round_tripped.uniform_attention_eps == pytest.approx(0.125)
+    assert reducer.uniform_attention_eps == pytest.approx(0.125)
+
+
+def test_attention_gem_uniform_attention_eps_default_matches_explicit_zero():
+    torch.manual_seed(133)
+    x = torch.rand(2, 3, 4, 5) + 0.05
+    logits = torch.randn(2, 1, 4, 5)
+    y1 = torch.rand(2, 3, 4, 5) + 0.05
+    y2 = torch.rand(2, 3, 4, 5) + 0.05
+    y3 = torch.rand(2, 3, 4, 5) + 0.05
+    logits_triplet = [torch.randn(2, 1, 4, 5) for _ in range(3)]
+
+    default_attention = AttentionGeMReducer(r_init=2.0, eps=1e-6)
+    zero_attention = AttentionGeMReducer(r_init=2.0, eps=1e-6, uniform_attention_eps=0.0)
+    default_fused = FusedAttentionGeMReducer(r_init=2.0, eps=1e-6)
+    zero_fused = FusedAttentionGeMReducer(r_init=2.0, eps=1e-6, uniform_attention_eps=0.0)
+
+    assert default_attention.uniform_attention_eps == 0.0
+    assert default_fused.uniform_attention_eps == 0.0
+    assert torch.allclose(default_attention(x, logits), zero_attention(x, logits), atol=0, rtol=0)
+    assert torch.allclose(
+        default_fused(y1, y2, y3, *logits_triplet),
+        zero_fused(y1, y2, y3, *logits_triplet),
+        atol=0,
+        rtol=0,
+    )
 
 
 class AllReducerHeadsNet(nn.Module):


### PR DESCRIPTION
### Motivation
- Ensure `uniform_attention_eps` is validated and preserved across reducer conversions to prevent regressions and make behavior explicit. 

### Description
- Added `StreamingAttentionGeMReducer` to the test imports and several tests in `tests/test_scnn.py` to exercise all four attention GeM reducer variants. 
- Added parameterized validation test `test_attention_gem_uniform_attention_eps_validation` asserting invalid `uniform_attention_eps` values raise `ValueError` for `AttentionGeMReducer`, `StreamingAttentionGeMReducer`, `FusedAttentionGeMReducer`, and `StreamingFusedAttentionGeMReducer`. 
- Added round-trip conversion tests `test_attention_gem_uniform_attention_eps_conversion_round_trip_preserves_value` and `test_fused_attention_gem_uniform_attention_eps_conversion_round_trip_preserves_value` to assert `uniform_attention_eps` is copied through `to_streaming()` and `to_reducer()`. 
- Added regression test `test_attention_gem_uniform_attention_eps_default_matches_explicit_zero` to confirm the default `uniform_attention_eps=0.0` is equivalent to explicitly passing `0.0`. 

### Testing
- Ran `python -m py_compile tests/test_scnn.py lightstream/core/reducer/attention_gem.py lightstream/core/reducer/fused_attention_gem.py`, which succeeded. 
- Ran `pytest tests/test_scnn.py -q`, which failed during collection with `ModuleNotFoundError: No module named 'lightning'` due to a missing environment dependency.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a293c5221d083308699219575c8527a)