### PR TITLE
Fix uniform-attention mixing: mix uniform term after attention (non-streaming and streaming fused paths)

### DIFF
--- a/lightstream/core/reducer/attention_gem.py
+++ b/lightstream/core/reducer/attention_gem.py
@@ -88,19 +88,21 @@ class AttentionGeMReducer(BaseReducer):
 
         z = exp_shifted.sum(dim=(-2, -1), keepdim=True, dtype=acc_dtype)
         weights = exp_shifted / z.clamp_min(self.eps)
-        weighted = (weights * x_pow).sum(dim=(-2, -1), keepdim=True, dtype=acc_dtype)
+        attention_mean = (weights * x_pow).sum(dim=(-2, -1), keepdim=True, dtype=acc_dtype)
         if self.uniform_attention_eps:
             if mask is not None:
                 valid = mask_nchw.to(dtype=acc_dtype)
                 uniform_z = valid.sum(dim=(-2, -1), keepdim=True, dtype=acc_dtype).clamp_min(self.eps)
-                uniform_weighted = (x_pow * valid).sum(dim=(-2, -1), keepdim=True, dtype=acc_dtype) / uniform_z
+                uniform_mean = (x_pow * valid).sum(dim=(-2, -1), keepdim=True, dtype=acc_dtype) / uniform_z
             else:
-                uniform_weighted = x_pow.mean(dim=(-2, -1), keepdim=True, dtype=acc_dtype)
-            weighted = (1.0 - self.uniform_attention_eps) * weighted + self.uniform_attention_eps * uniform_weighted
+                uniform_mean = x_pow.mean(dim=(-2, -1), keepdim=True, dtype=acc_dtype)
+            mixed_mean = (1.0 - self.uniform_attention_eps) * attention_mean + self.uniform_attention_eps * uniform_mean
+        else:
+            mixed_mean = attention_mean
 
         # If a sample is fully masked, return a numerically safe zero contribution.
-        weighted = torch.where(any_valid, weighted, torch.zeros_like(weighted))
-        y = weighted.clamp_min(self.eps).pow(1.0 / self.current_r.to(device=x.device, dtype=acc_dtype))
+        mixed_mean = torch.where(any_valid, mixed_mean, torch.zeros_like(mixed_mean))
+        y = mixed_mean.clamp_min(self.eps).pow(1.0 / self.current_r.to(device=x.device, dtype=acc_dtype))
         return y.to(dtype=x.dtype)
 
     def to_streaming(self) -> BaseStreamingGlobalReducer:

--- a/lightstream/core/reducer/fused_attention_gem.py
+++ b/lightstream/core/reducer/fused_attention_gem.py
@@ -137,6 +137,7 @@ class FusedAttentionGeMReducer(BaseReducer):
             branch = (weights * x_pow).sum(dim=(-2, -1), keepdim=True, dtype=acc_dtype)
             branch_means.append(torch.where(any_valid, branch, torch.zeros_like(branch)))
 
+        attention_mean = aw[0] * branch_means[0] + aw[1] * branch_means[1] + aw[2] * branch_means[2]
         if self.uniform_attention_eps:
             if mask_nchw is not None:
                 valid = mask_nchw.to(dtype=acc_dtype)
@@ -144,10 +145,11 @@ class FusedAttentionGeMReducer(BaseReducer):
                 uniform_mean = (x_pow * valid).sum(dim=(-2, -1), keepdim=True, dtype=acc_dtype) / uniform_z
             else:
                 uniform_mean = x_pow.mean(dim=(-2, -1), keepdim=True, dtype=acc_dtype)
-            branch_means = [(1.0 - self.uniform_attention_eps) * branch + self.uniform_attention_eps * uniform_mean for branch in branch_means]
+            mixed_mean = (1.0 - self.uniform_attention_eps) * attention_mean + self.uniform_attention_eps * uniform_mean
+        else:
+            mixed_mean = attention_mean
 
-        weighted_mean = aw[0] * branch_means[0] + aw[1] * branch_means[1] + aw[2] * branch_means[2]
-        return weighted_mean.clamp_min(self.eps).pow(1.0 / r).to(dtype=y1.dtype)
+        return mixed_mean.clamp_min(self.eps).pow(1.0 / r).to(dtype=y1.dtype)
 
     def to_streaming(self) -> BaseStreamingGlobalReducer:
         reducer = StreamingFusedAttentionGeMReducer(
@@ -332,13 +334,13 @@ class StreamingFusedAttentionGeMReducer(BaseStreamingGlobalReducer):
         r = self.current_r.to(device=self.running_shat.device, dtype=acc_dtype)
         aw = self.attention_weights.to(device=self.running_shat.device, dtype=acc_dtype)
         branch_means = self.running_shat.to(dtype=acc_dtype) / self.running_zhat.to(dtype=acc_dtype).clamp_min(self.eps)
-        if self.uniform_attention_eps:
-            uniform_mean = self.running_uniform_sum.to(dtype=acc_dtype) / self.running_uniform_count.to(dtype=acc_dtype).clamp_min(self.eps)
-            branch_means = (1.0 - self.uniform_attention_eps) * branch_means + self.uniform_attention_eps * uniform_mean[:, None]
         # Sum_j attention_weights[j] * E_{softmax(att_j)}[fused_y ** r],
         # which is equivalent to GeM over fused_y weighted by
         # fused_a = sum_j attention_weights[j] * softmax(att_j).
         weighted_mean = (branch_means * aw.view(1, 3, 1, 1, 1)).sum(dim=1)
+        if self.uniform_attention_eps:
+            uniform_mean = self.running_uniform_sum.to(dtype=acc_dtype) / self.running_uniform_count.to(dtype=acc_dtype).clamp_min(self.eps)
+            weighted_mean = (1.0 - self.uniform_attention_eps) * weighted_mean + self.uniform_attention_eps * uniform_mean
         output_dtype = self._stream_output_dtype or self.running_shat.dtype
         return weighted_mean.clamp_min(self.eps).pow(1.0 / r).to(dtype=output_dtype)
 
@@ -346,16 +348,17 @@ class StreamingFusedAttentionGeMReducer(BaseStreamingGlobalReducer):
         acc_dtype = resolve_accumulator_dtype(self.accumulator_dtype, self.running_shat.dtype)
         zhat = self.running_zhat.to(dtype=acc_dtype).clamp_min(self.eps)
         attention_branch_means = self.running_shat.to(dtype=acc_dtype) / zhat
+        aw = self.attention_weights.to(device=self.running_shat.device, dtype=acc_dtype)
+        attention_mean = (attention_branch_means * aw.view(1, 3, 1, 1, 1)).sum(dim=1)
         if self.uniform_attention_eps:
             uniform_count = self.running_uniform_count.to(dtype=acc_dtype).clamp_min(self.eps)
             uniform_mean = self.running_uniform_sum.to(dtype=acc_dtype) / uniform_count
-            branch_means = (1.0 - self.uniform_attention_eps) * attention_branch_means + self.uniform_attention_eps * uniform_mean[:, None]
+            weighted_mean = (1.0 - self.uniform_attention_eps) * attention_mean + self.uniform_attention_eps * uniform_mean
         else:
             uniform_count = None
             uniform_mean = None
-            branch_means = attention_branch_means
-        aw = self.attention_weights.to(device=self.running_shat.device, dtype=acc_dtype)
-        weighted_mean = (branch_means * aw.view(1, 3, 1, 1, 1)).sum(dim=1)
+            weighted_mean = attention_mean
+        branch_means = attention_branch_means
         r = self.current_r.to(device=self.running_shat.device, dtype=acc_dtype)
         return {
             "m": self.running_m.to(dtype=acc_dtype),
@@ -409,13 +412,16 @@ class StreamingFusedAttentionGeMReducer(BaseStreamingGlobalReducer):
         ).reshape(n, branches, 1, 1, 1)
 
         branch_terms = local_s_over_z - attention_branch_means.detach() * local_z_over_z
+        attention_replay_term = (branch_terms * aw.view(1, 3, 1, 1, 1)).sum(dim=1)
         if self.uniform_attention_eps:
             uniform_mean = global_context["uniform_mean"].to(device=fused_y.device, dtype=acc_dtype)
             uniform_count = global_context["uniform_count"].to(device=fused_y.device, dtype=acc_dtype).clamp_min(self.eps)
             uniform_replay_term = streaming_reduce_tile(x_pow - uniform_mean.detach(), valid_mask, uniform_count)
-            branch_terms = (1.0 - self.uniform_attention_eps) * branch_terms + self.uniform_attention_eps * uniform_replay_term[:, None]
+            replay_term = (1.0 - self.uniform_attention_eps) * attention_replay_term + self.uniform_attention_eps * uniform_replay_term
+        else:
+            replay_term = attention_replay_term
         scale = (1.0 / r) * weighted_mean.clamp_min(self.eps).pow(1.0 / r - 1.0)
-        surrogate = scale.detach() * (branch_terms * aw.view(1, 3, 1, 1, 1)).sum(dim=1)
+        surrogate = scale.detach() * replay_term
         return surrogate.to(dtype=fused_y.dtype)
 
     def to_reducer(self) -> FusedAttentionGeMReducer:

--- a/tests/test_scnn.py
+++ b/tests/test_scnn.py
@@ -65,6 +65,22 @@ def test_fused_attention_gem_uniform_attention_eps_conversion_round_trip_preserv
     assert reducer.uniform_attention_eps == pytest.approx(0.125)
 
 
+def test_attention_gem_uniform_attention_eps_mixes_attention_and_uniform_valid_means():
+    x = torch.tensor([[[[1.0, 2.0], [4.0, 8.0]]]])
+    logits = torch.tensor([[[[0.0, 2.0], [-3.0, 10.0]]]])
+    mask = torch.tensor([[True, False], [True, True]])
+    reducer = AttentionGeMReducer(r_init=1.0, eps=1e-6, uniform_attention_eps=0.25)
+
+    actual = reducer(x, logits, mask=mask)
+
+    valid_x = torch.tensor([1.0, 4.0, 8.0])
+    valid_logits = torch.tensor([0.0, -3.0, 10.0])
+    attention_mean = (torch.softmax(valid_logits, dim=0) * valid_x).sum().view(1, 1, 1, 1)
+    uniform_mean = valid_x.mean().view(1, 1, 1, 1)
+    expected = 0.75 * attention_mean + 0.25 * uniform_mean
+    assert torch.allclose(actual, expected, atol=1e-6, rtol=1e-6)
+
+
 def test_attention_gem_uniform_attention_eps_default_matches_explicit_zero():
     torch.manual_seed(133)
     x = torch.rand(2, 3, 4, 5) + 0.05
@@ -88,6 +104,38 @@ def test_attention_gem_uniform_attention_eps_default_matches_explicit_zero():
         atol=0,
         rtol=0,
     )
+
+
+def test_fused_attention_gem_uniform_attention_eps_adds_uniform_term_after_branch_fusion():
+    y1 = torch.tensor([[[[1.0, 2.0], [4.0, 8.0]]]])
+    y2 = torch.tensor([[[[3.0, 5.0], [7.0, 11.0]]]])
+    y3 = torch.tensor([[[[13.0, 17.0], [19.0, 23.0]]]])
+    logits = (
+        torch.tensor([[[[0.0, 1.0], [2.0, 3.0]]]]),
+        torch.tensor([[[[3.0, 2.0], [1.0, 0.0]]]]),
+        torch.tensor([[[[0.5, -0.5], [1.5, -1.5]]]]),
+    )
+    value_weights = (0.5, 0.25, 0.25)
+    attention_weights = (0.2, 0.3, 1.0)
+    reducer = FusedAttentionGeMReducer(
+        r_init=1.0,
+        eps=1e-6,
+        value_weights=value_weights,
+        attention_weights=attention_weights,
+        uniform_attention_eps=0.4,
+    )
+
+    actual = reducer(y1, y2, y3, *logits)
+
+    fused_y = value_weights[0] * y1 + value_weights[1] * y2 + value_weights[2] * y3
+    branch_means = [
+        (torch.softmax(logit.flatten(), dim=0) * fused_y.flatten()).sum().view(1, 1, 1, 1)
+        for logit in logits
+    ]
+    attention_mean = sum(weight * branch for weight, branch in zip(attention_weights, branch_means))
+    uniform_mean = fused_y.mean(dim=(-2, -1), keepdim=True)
+    expected = 0.6 * attention_mean + 0.4 * uniform_mean
+    assert torch.allclose(actual, expected, atol=1e-6, rtol=1e-6)
 
 
 class AllReducerHeadsNet(nn.Module):


### PR DESCRIPTION
### Motivation
- Ensure the uniform-attention epsilon mixes a uniform valid-pixel mean with the existing attention-weighted mean as a single combined term rather than applying the uniform mix per-attention-branch.
- Align non-streaming and streaming fused reducer semantics so the fused multi-branch attention mean is computed from branches first and the uniform term is applied once to the fused result.

### Description
- In `AttentionGeMReducer.forward` compute `attention_mean`, compute the `uniform_mean` over valid pixels, then form `mixed_mean = (1 - uniform_attention_eps) * attention_mean + uniform_attention_eps * uniform_mean` before final GeM exponentiation; replace the previous in-place per-weighted mixing.  (file: `lightstream/core/reducer/attention_gem.py`)
- In `FusedAttentionGeMReducer.forward` compute per-branch attention means as before, combine them into a single `attention_mean = sum_j attention_weights[j] * branch_mean_j`, then compute one `uniform_mean` over the fused value tensor and form `mixed_mean` from the fused `attention_mean` plus `uniform_mean` rather than applying the uniform mix to each branch. (file: `lightstream/core/reducer/fused_attention_gem.py`)
- Update streaming fused reducer paths (`finalize_from_state`, `extra_state_for_backward`, `reduce_tile_for_backward`) to follow the same "mix once after branch fusion" semantics and adjust replay-term computation to first produce the attention replay term then mix with the uniform replay term as one combined replay. (file: `lightstream/core/reducer/fused_attention_gem.py`)
- Add regression tests to `tests/test_scnn.py` that verify the attention/uniform mixture behavior for `AttentionGeMReducer` and `FusedAttentionGeMReducer` (`test_attention_gem_uniform_attention_eps_mixes_attention_and_uniform_valid_means` and `test_fused_attention_gem_uniform_attention_eps_adds_uniform_term_after_branch_fusion`).

### Testing
- Ran Python compile check with `python -m py_compile lightstream/core/reducer/attention_gem.py lightstream/core/reducer/fused_attention_gem.py tests/test_scnn.py`, which succeeded.  
- Executed manual reducer checks via short Python scripts that instantiate `AttentionGeMReducer` and `FusedAttentionGeMReducer` and compare outputs against the new expected formulas, and a manual streaming/finalize equivalence check, all of which passed.  
- Attempted to run `pytest -q tests/test_scnn.py -k 'uniform_attention_eps'` but test collection was blocked by missing optional dependencies in the execution environment (`lightning` / `numpy`), so full automated test run could not be completed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a293f56839c83308d7094db0cf58b1d)