### PR TITLE
Track valid GeM uniform state in streaming reducers

### DIFF
--- a/lightstream/core/reducer/attention_gem.py
+++ b/lightstream/core/reducer/attention_gem.py
@@ -127,6 +127,9 @@ class StreamingAttentionGeMReducer(BaseStreamingGlobalReducer):
         self.register_buffer("running_m", torch.zeros(0), persistent=False)
         self.register_buffer("running_zhat", torch.zeros(0), persistent=False)
         self.register_buffer("running_shat", torch.zeros(0), persistent=False)
+        self.register_buffer("running_valid_x_pow_sum", torch.zeros(0), persistent=False)
+        self.register_buffer("running_valid_count", torch.zeros(0), persistent=False)
+        # Backward-compatible aliases for the uniform-mixing path.
         self.register_buffer("running_uniform_sum", torch.zeros(0), persistent=False)
         self.register_buffer("running_uniform_count", torch.zeros(0), persistent=False)
 
@@ -204,8 +207,10 @@ class StreamingAttentionGeMReducer(BaseStreamingGlobalReducer):
         self.running_m = torch.full((batch_size, 1, 1, 1), torch.finfo(accumulator_dtype).min, device=device, dtype=accumulator_dtype)
         self.running_zhat = torch.zeros((batch_size, 1, 1, 1), device=device, dtype=accumulator_dtype)
         self.running_shat = torch.zeros((batch_size, channels, 1, 1), device=device, dtype=accumulator_dtype)
-        self.running_uniform_sum = torch.zeros((batch_size, channels, 1, 1), device=device, dtype=accumulator_dtype)
-        self.running_uniform_count = torch.zeros((batch_size, 1, 1, 1), device=device, dtype=accumulator_dtype)
+        self.running_valid_x_pow_sum = torch.zeros((batch_size, channels, 1, 1), device=device, dtype=accumulator_dtype)
+        self.running_valid_count = torch.zeros((batch_size, 1, 1, 1), device=device, dtype=accumulator_dtype)
+        self.running_uniform_sum = self.running_valid_x_pow_sum
+        self.running_uniform_count = self.running_valid_count
 
     def accumulate_valid_tile(self, tile, valid_mask: torch.Tensor) -> None:
         x_tile, logits_tile = self._parse_multi_input_payload(tile)
@@ -235,29 +240,31 @@ class StreamingAttentionGeMReducer(BaseStreamingGlobalReducer):
         self.running_zhat = self.running_zhat.to(dtype=acc_dtype) * alpha_prev + z_tile * alpha_tile
         self.running_shat = self.running_shat.to(dtype=acc_dtype) * alpha_prev + s_tile * alpha_tile
         self.running_m = m_new
-        if self.uniform_attention_eps:
-            valid = valid4d.to(dtype=acc_dtype)
-            self.running_uniform_sum = self.running_uniform_sum.to(dtype=acc_dtype) + (x_pow * valid).sum(dim=(-2, -1), keepdim=True, dtype=acc_dtype)
-            self.running_uniform_count = self.running_uniform_count.to(dtype=acc_dtype) + valid.sum(dim=(-2, -1), keepdim=True, dtype=acc_dtype)
+        valid = valid4d.to(dtype=acc_dtype)
+        valid_x_pow_sum = self.running_valid_x_pow_sum.to(dtype=acc_dtype) + (x_pow * valid).sum(dim=(-2, -1), keepdim=True, dtype=acc_dtype)
+        valid_count = self.running_valid_count.to(dtype=acc_dtype) + valid.sum(dim=(-2, -1), keepdim=True, dtype=acc_dtype)
+        self.running_valid_x_pow_sum = valid_x_pow_sum
+        self.running_valid_count = valid_count
+        self.running_uniform_sum = valid_x_pow_sum
+        self.running_uniform_count = valid_count
 
     def finalize_from_state(self) -> torch.Tensor:
         if self.running_shat.numel() == 0:
             raise RuntimeError("StreamingAttentionGeMReducer state is empty, accumulate_stream_tile() was not called.")
         acc_dtype = resolve_accumulator_dtype(self.accumulator_dtype, self.running_shat.dtype)
         r = self.current_r.to(device=self.running_shat.device, dtype=acc_dtype)
-        weighted_mean = self.running_shat.to(dtype=acc_dtype) / self.running_zhat.to(dtype=acc_dtype).clamp_min(self.eps)
-        if self.uniform_attention_eps:
-            uniform_mean = self.running_uniform_sum.to(dtype=acc_dtype) / self.running_uniform_count.to(dtype=acc_dtype).clamp_min(self.eps)
-            weighted_mean = (1.0 - self.uniform_attention_eps) * weighted_mean + self.uniform_attention_eps * uniform_mean
-        return weighted_mean.clamp_min(self.eps).pow(1.0 / r).to(dtype=self.running_shat.dtype)
+        attention_mean = self.running_shat.to(dtype=acc_dtype) / self.running_zhat.to(dtype=acc_dtype).clamp_min(self.eps)
+        uniform_mean = self.running_valid_x_pow_sum.to(dtype=acc_dtype) / self.running_valid_count.to(dtype=acc_dtype).clamp_min(self.eps)
+        mixed_mean = (1.0 - self.uniform_attention_eps) * attention_mean + self.uniform_attention_eps * uniform_mean
+        return mixed_mean.clamp_min(self.eps).pow(1.0 / r).to(dtype=self.running_shat.dtype)
 
     def extra_state_for_backward(self) -> dict[str, torch.Tensor | int | float | None]:
         acc_dtype = resolve_accumulator_dtype(self.accumulator_dtype, self.running_shat.dtype)
         zhat = self.running_zhat.to(dtype=acc_dtype).clamp_min(self.eps)
         attention_mean = self.running_shat.to(dtype=acc_dtype) / zhat
         if self.uniform_attention_eps:
-            uniform_count = self.running_uniform_count.to(dtype=acc_dtype).clamp_min(self.eps)
-            uniform_mean = self.running_uniform_sum.to(dtype=acc_dtype) / uniform_count
+            uniform_count = self.running_valid_count.to(dtype=acc_dtype).clamp_min(self.eps)
+            uniform_mean = self.running_valid_x_pow_sum.to(dtype=acc_dtype) / uniform_count
             mean = (1.0 - self.uniform_attention_eps) * attention_mean + self.uniform_attention_eps * uniform_mean
         else:
             uniform_count = None

--- a/lightstream/core/reducer/fused_attention_gem.py
+++ b/lightstream/core/reducer/fused_attention_gem.py
@@ -187,6 +187,9 @@ class StreamingFusedAttentionGeMReducer(BaseStreamingGlobalReducer):
         self.register_buffer("running_m", torch.zeros(0), persistent=False)
         self.register_buffer("running_zhat", torch.zeros(0), persistent=False)
         self.register_buffer("running_shat", torch.zeros(0), persistent=False)
+        self.register_buffer("running_valid_x_pow_sum", torch.zeros(0), persistent=False)
+        self.register_buffer("running_valid_count", torch.zeros(0), persistent=False)
+        # Backward-compatible aliases for the uniform-mixing path.
         self.register_buffer("running_uniform_sum", torch.zeros(0), persistent=False)
         self.register_buffer("running_uniform_count", torch.zeros(0), persistent=False)
         self._stream_output_dtype: torch.dtype | None = None
@@ -286,8 +289,10 @@ class StreamingFusedAttentionGeMReducer(BaseStreamingGlobalReducer):
         self.running_m = torch.full((batch_size, 3, 1, 1, 1), torch.finfo(accumulator_dtype).min, device=device, dtype=accumulator_dtype)
         self.running_zhat = torch.zeros((batch_size, 3, 1, 1, 1), device=device, dtype=accumulator_dtype)
         self.running_shat = torch.zeros((batch_size, 3, channels, 1, 1), device=device, dtype=accumulator_dtype)
-        self.running_uniform_sum = torch.zeros((batch_size, channels, 1, 1), device=device, dtype=accumulator_dtype)
-        self.running_uniform_count = torch.zeros((batch_size, 1, 1, 1), device=device, dtype=accumulator_dtype)
+        self.running_valid_x_pow_sum = torch.zeros((batch_size, channels, 1, 1), device=device, dtype=accumulator_dtype)
+        self.running_valid_count = torch.zeros((batch_size, 1, 1, 1), device=device, dtype=accumulator_dtype)
+        self.running_uniform_sum = self.running_valid_x_pow_sum
+        self.running_uniform_count = self.running_valid_count
 
     def accumulate_valid_tile(self, tile, valid_mask: torch.Tensor) -> None:
         payload = self._parse_multi_input_payload(tile)
@@ -322,10 +327,13 @@ class StreamingFusedAttentionGeMReducer(BaseStreamingGlobalReducer):
         self.running_zhat = self.running_zhat.to(dtype=acc_dtype) * alpha_prev + z_tile * alpha_tile
         self.running_shat = self.running_shat.to(dtype=acc_dtype) * alpha_prev + s_tile * alpha_tile
         self.running_m = m_new
-        if self.uniform_attention_eps:
-            valid = valid5d[:, 0].to(dtype=acc_dtype)
-            self.running_uniform_sum = self.running_uniform_sum.to(dtype=acc_dtype) + (x_pow * valid).sum(dim=(-2, -1), keepdim=True, dtype=acc_dtype)
-            self.running_uniform_count = self.running_uniform_count.to(dtype=acc_dtype) + valid.sum(dim=(-2, -1), keepdim=True, dtype=acc_dtype)
+        valid = valid5d[:, 0].to(dtype=acc_dtype)
+        valid_x_pow_sum = self.running_valid_x_pow_sum.to(dtype=acc_dtype) + (x_pow * valid).sum(dim=(-2, -1), keepdim=True, dtype=acc_dtype)
+        valid_count = self.running_valid_count.to(dtype=acc_dtype) + valid.sum(dim=(-2, -1), keepdim=True, dtype=acc_dtype)
+        self.running_valid_x_pow_sum = valid_x_pow_sum
+        self.running_valid_count = valid_count
+        self.running_uniform_sum = valid_x_pow_sum
+        self.running_uniform_count = valid_count
 
     def finalize_from_state(self) -> torch.Tensor:
         if self.running_shat.numel() == 0:
@@ -337,12 +345,11 @@ class StreamingFusedAttentionGeMReducer(BaseStreamingGlobalReducer):
         # Sum_j attention_weights[j] * E_{softmax(att_j)}[fused_y ** r],
         # which is equivalent to GeM over fused_y weighted by
         # fused_a = sum_j attention_weights[j] * softmax(att_j).
-        weighted_mean = (branch_means * aw.view(1, 3, 1, 1, 1)).sum(dim=1)
-        if self.uniform_attention_eps:
-            uniform_mean = self.running_uniform_sum.to(dtype=acc_dtype) / self.running_uniform_count.to(dtype=acc_dtype).clamp_min(self.eps)
-            weighted_mean = (1.0 - self.uniform_attention_eps) * weighted_mean + self.uniform_attention_eps * uniform_mean
+        attention_mean = (branch_means * aw.view(1, 3, 1, 1, 1)).sum(dim=1)
+        uniform_mean = self.running_valid_x_pow_sum.to(dtype=acc_dtype) / self.running_valid_count.to(dtype=acc_dtype).clamp_min(self.eps)
+        mixed_mean = (1.0 - self.uniform_attention_eps) * attention_mean + self.uniform_attention_eps * uniform_mean
         output_dtype = self._stream_output_dtype or self.running_shat.dtype
-        return weighted_mean.clamp_min(self.eps).pow(1.0 / r).to(dtype=output_dtype)
+        return mixed_mean.clamp_min(self.eps).pow(1.0 / r).to(dtype=output_dtype)
 
     def extra_state_for_backward(self) -> dict[str, torch.Tensor | int | float | None]:
         acc_dtype = resolve_accumulator_dtype(self.accumulator_dtype, self.running_shat.dtype)
@@ -351,8 +358,8 @@ class StreamingFusedAttentionGeMReducer(BaseStreamingGlobalReducer):
         aw = self.attention_weights.to(device=self.running_shat.device, dtype=acc_dtype)
         attention_mean = (attention_branch_means * aw.view(1, 3, 1, 1, 1)).sum(dim=1)
         if self.uniform_attention_eps:
-            uniform_count = self.running_uniform_count.to(dtype=acc_dtype).clamp_min(self.eps)
-            uniform_mean = self.running_uniform_sum.to(dtype=acc_dtype) / uniform_count
+            uniform_count = self.running_valid_count.to(dtype=acc_dtype).clamp_min(self.eps)
+            uniform_mean = self.running_valid_x_pow_sum.to(dtype=acc_dtype) / uniform_count
             weighted_mean = (1.0 - self.uniform_attention_eps) * attention_mean + self.uniform_attention_eps * uniform_mean
         else:
             uniform_count = None


### PR DESCRIPTION
### Motivation
- Ensure streaming GeM reducers accumulate an explicit, overlap-safe uniform statistic (summed `x_pow` and valid pixel count) so the uniform-mean mixing path matches full-frame behavior and avoids double-counting in fused attention.

### Description
- Added streaming buffers `running_valid_x_pow_sum` and `running_valid_count` (with backward-compatible aliases `running_uniform_sum`/`running_uniform_count`) to `StreamingAttentionGeMReducer` and `StreamingFusedAttentionGeMReducer` in `lightstream/core/reducer/attention_gem.py` and `lightstream/core/reducer/fused_attention_gem.py`.
- Updated `init_reduction_state` and `accumulate_valid_tile()` to use the overlap-safe `valid_mask` to accumulate `uniform_sum += sum_valid(x_pow)` and `valid_count += number_of_valid_pixels`, and in the fused reducer the uniform accumulation is done once over the fused value tensor rather than per attention branch.
- Refactored finalization to compute `attention_mean`, `uniform_mean`, and `mixed_mean` from the running state and only then apply the GeM exponent in `finalize_from_state()`; updated `extra_state_for_backward()` to expose the new uniform statistics.

### Testing
- Ran `python -m py_compile lightstream/core/reducer/attention_gem.py lightstream/core/reducer/fused_attention_gem.py` with no syntax errors.
- Executed a direct parity smoke script comparing full-frame vs streaming outputs for `AttentionGeMReducer` and `FusedAttentionGeMReducer` for `uniform_attention_eps` values `0.0` and `0.2`, which validated numerical parity and that `running_valid_count` equals the expected valid pixel count.
- Attempted `pytest tests/test_scnn.py -q` but collection failed due to a missing optional dependency (`lightning`), so the full test suite could not be run in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2940eec7e0833082b3304162d21d69)