### PR TITLE
Add ChannelLayerNorm streaming layer

### DIFF
--- a/lightstream/core/constructor.py
+++ b/lightstream/core/constructor.py
@@ -16,6 +16,7 @@ import torch.nn as nn
 from copy import deepcopy
 from lightstream.core.scnn.scnn import StreamingCNN
 from lightstream.core.reducer import BaseReducer
+from lightstream.core.scnn.streaminglayernorm import ChannelLayerNorm
 from typing import Any, Callable, Optional
 
 
@@ -83,6 +84,7 @@ class StreamingConstructor:
             torch.nn.MaxPool2d,
             torch.nn.MaxPool3d,
             torch.nn.Upsample,
+            ChannelLayerNorm,
             BaseReducer,
         ]
 

--- a/lightstream/core/scnn/__init__.py
+++ b/lightstream/core/scnn/__init__.py
@@ -1,0 +1,3 @@
+from lightstream.core.scnn.streaminglayernorm import ChannelLayerNorm
+
+__all__ = ["ChannelLayerNorm"]

--- a/lightstream/core/scnn/streaminglayernorm.py
+++ b/lightstream/core/scnn/streaminglayernorm.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+
+import torch
+import torch.nn as nn
+
+
+class ChannelLayerNorm(nn.Module):
+    """Apply layer normalization across channels for NCHW tensors."""
+
+    def __init__(self, num_channels: int, eps: float = 1e-6, elementwise_affine: bool = True):
+        super().__init__()
+        self.num_channels = num_channels
+        self.norm = nn.LayerNorm(num_channels, eps=eps, elementwise_affine=elementwise_affine)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        if x.ndim != 4:
+            raise ValueError(f"ChannelLayerNorm expects 4D NCHW input, got {x.ndim}D input with shape {tuple(x.shape)}.")
+        if x.shape[1] != self.num_channels:
+            raise ValueError(
+                f"ChannelLayerNorm expected {self.num_channels} channels at dimension 1, "
+                f"got {x.shape[1]} channels for input shape {tuple(x.shape)}."
+            )
+
+        x = x.permute(0, 2, 3, 1)
+        x = self.norm(x)
+        return x.permute(0, 3, 1, 2)

--- a/tests/test_streaminglayernorm.py
+++ b/tests/test_streaminglayernorm.py
@@ -1,0 +1,57 @@
+import sys
+import types
+
+import pytest
+import torch
+
+from lightstream.core.scnn import ChannelLayerNorm
+from lightstream.core.scnn.streaminglayernorm import ChannelLayerNorm as ImportedChannelLayerNorm
+
+
+def test_channel_layer_norm_matches_nhwc_layer_norm():
+    torch.manual_seed(7)
+    module = ChannelLayerNorm(3, eps=1e-6, elementwise_affine=True)
+    reference = torch.nn.LayerNorm(3, eps=1e-6, elementwise_affine=True)
+    reference.load_state_dict(module.norm.state_dict())
+
+    x = torch.randn(2, 3, 5, 7)
+    expected = reference(x.permute(0, 2, 3, 1)).permute(0, 3, 1, 2)
+
+    torch.testing.assert_close(module(x), expected)
+
+
+def test_channel_layer_norm_rejects_non_4d_input():
+    module = ChannelLayerNorm(3)
+
+    with pytest.raises(ValueError, match="expects 4D NCHW input"):
+        module(torch.randn(2, 3, 5))
+
+
+def test_channel_layer_norm_rejects_channel_mismatch():
+    module = ChannelLayerNorm(3)
+
+    with pytest.raises(ValueError, match="expected 3 channels"):
+        module(torch.randn(2, 4, 5, 7))
+
+
+def test_channel_layer_norm_is_public_from_scnn_package():
+    assert ImportedChannelLayerNorm is ChannelLayerNorm
+
+
+def test_constructor_considers_only_channel_layer_norm_streamable(monkeypatch):
+    # The constructor imports StreamingCNN, whose module imports numpy for full
+    # streaming execution. This test only needs the constructor keep-list, so a
+    # minimal import-time stub keeps the unit test focused when numpy is not
+    # installed in the local environment.
+    monkeypatch.setitem(sys.modules, "numpy", types.ModuleType("numpy"))
+    from lightstream.core.constructor import StreamingConstructor
+
+    model = torch.nn.Sequential(
+        torch.nn.Conv2d(3, 3, 1),
+        ChannelLayerNorm(3),
+        torch.nn.LayerNorm(3),
+    )
+    constructor = StreamingConstructor(model, tile_size=32, verbose=False, statistics_on_cpu=True)
+
+    assert ChannelLayerNorm in constructor.keep_modules
+    assert torch.nn.LayerNorm not in constructor.keep_modules


### PR DESCRIPTION
### Motivation
- Provide an explicit NCHW-aware LayerNorm that is safe to use in the streaming pipeline by normalizing over the channel axis only. 
- Ensure streaming conversion logic only recognizes this explicit class rather than arbitrary `nn.LayerNorm` instances.

### Description
- Add `ChannelLayerNorm` in `lightstream/core/scnn/streaminglayernorm.py` that accepts `num_channels`, `eps=1e-6`, and `elementwise_affine=True`, internally wraps `nn.LayerNorm(num_channels, eps=eps, elementwise_affine=elementwise_affine)`, validates 4D NCHW input, checks channel count, permutes to NHWC, applies the layer norm, and permutes back to NCHW. 
- Export `ChannelLayerNorm` from the `lightstream.core.scnn` package by updating `lightstream/core/scnn/__init__.py`. 
- Register `ChannelLayerNorm` in the `StreamingConstructor.keep_modules` list in `lightstream/core/constructor.py` so the constructor treats only this explicit class as streamable and does not add general `nn.LayerNorm` support. 
- Add unit tests in `tests/test_streaminglayernorm.py` verifying numerical equivalence to NHWC `LayerNorm`, validation errors for bad shapes/channels, public import, and that the constructor keep-list includes only `ChannelLayerNorm` and not `nn.LayerNorm`.

### Testing
- Ran `pytest -q tests/test_streaminglayernorm.py` and all tests passed (`5 passed`) with one PyTorch warning about missing optional NumPy integration. 
- Attempting `pytest -q tests/test_streaminglayernorm.py tests/test_streamingupsample.py` failed to collect due to a missing `numpy` package in the execution environment, so broader suite runs were not executed here. 
- Ran `python -m py_compile` on the new/modified Python modules (`lightstream/core/scnn/streaminglayernorm.py`, `lightstream/core/scnn/__init__.py`, `lightstream/core/constructor.py`) and compilation succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2961338b348330875fa6a630460d28)