### PR TITLE
Add StreamingChannelLayerNorm with streaming state and gradient deduplication

### DIFF
--- a/lightstream/core/scnn/__init__.py
+++ b/lightstream/core/scnn/__init__.py
@@ -1,3 +1,3 @@
-from lightstream.core.scnn.streaminglayernorm import ChannelLayerNorm
+from lightstream.core.scnn.streaminglayernorm import ChannelLayerNorm, StreamingChannelLayerNorm
 
-__all__ = ["ChannelLayerNorm"]
+__all__ = ["ChannelLayerNorm", "StreamingChannelLayerNorm"]

--- a/lightstream/core/scnn/scnn.py
+++ b/lightstream/core/scnn/scnn.py
@@ -17,7 +17,7 @@ import torch.nn.functional
 from lightstream.core.scnn.utils import Sides, Box, Lost, _ntuple, _new_value_indices, B_DIM, C_DIM, H_DIM, W_DIM
 from lightstream.core.scnn.streamingconv import StreamingConv2d
 from lightstream.core.scnn.streamingupsample import StreamingUpsample2d
-from lightstream.core.scnn.streaminglayernorm import ChannelLayerNorm
+from lightstream.core.scnn.streaminglayernorm import ChannelLayerNorm, StreamingChannelLayerNorm
 from lightstream.core.reducer import BaseReducer, BaseStreamingGlobalReducer
 
 
@@ -28,7 +28,7 @@ _triple = _ntuple(3)
 
 def _is_pointwise_channel_norm(module):
     """Return True for channel-only normalization layers that preserve spatial support."""
-    return isinstance(module, ChannelLayerNorm)
+    return isinstance(module, (ChannelLayerNorm, StreamingChannelLayerNorm))
 
 
 @dataclass(frozen=True)
@@ -547,6 +547,15 @@ class StreamingCNN(torch.nn.Module):
                 mod.output_stride = self._module_stats[module].get("output_stride", torch.tensor([1, 1, 1]))
                 self._module_stats[mod] = self._module_stats[module]
                 del self._module_stats[module]
+        elif isinstance(module, ChannelLayerNorm):
+            mod = StreamingChannelLayerNorm.from_channel_layer_norm(module)
+            if module in self._module_stats:
+                mod.grad_lost = self._module_stats[module].get("grad_lost", Lost(0, 0, 0, 0))
+                mod.output_stride = self._module_stats[module].get("output_stride", torch.tensor([1, 1, 1]))
+                self._module_stats[mod] = self._module_stats[module]
+                del self._module_stats[module]
+            del module
+            return mod
         elif isinstance(module, BaseReducer):
             mod = module.to_streaming()
             self._streaming_reducers.append(mod)
@@ -569,6 +578,16 @@ class StreamingCNN(torch.nn.Module):
                 del self._module_stats[module]
         elif isinstance(module, StreamingUpsample2d):
             mod = module.to_torch_upsample()
+            if module not in self._module_stats:
+                stats = {}
+                stats["grad_lost"] = module.grad_lost
+                stats["output_stride"] = module.output_stride
+                self._module_stats[mod] = stats
+            else:
+                self._module_stats[mod] = self._module_stats[module]
+                del self._module_stats[module]
+        elif isinstance(module, StreamingChannelLayerNorm):
+            mod = module.to_channel_layer_norm()
             if module not in self._module_stats:
                 stats = {}
                 stats["grad_lost"] = module.grad_lost
@@ -1115,7 +1134,7 @@ class StreamingCNN(torch.nn.Module):
             tile = tile.to(self.device, non_blocking=True)
 
         for mod in self.stream_module.modules():
-            if isinstance(mod, (StreamingConv2d, StreamingUpsample2d)):
+            if isinstance(mod, (StreamingConv2d, StreamingUpsample2d, StreamingChannelLayerNorm)):
                 mod.input_loc = input_loc
 
         if self.should_normalize:
@@ -1369,7 +1388,7 @@ class StreamingCNN(torch.nn.Module):
         self._saved_tensors = {}
 
         for mod in self.stream_module.modules():
-            if isinstance(mod, (StreamingConv2d, StreamingUpsample2d)):
+            if isinstance(mod, (StreamingConv2d, StreamingUpsample2d, StreamingChannelLayerNorm)):
                 mod.input_loc = None
                 mod.reset()
 

--- a/lightstream/core/scnn/streaminglayernorm.py
+++ b/lightstream/core/scnn/streaminglayernorm.py
@@ -2,6 +2,10 @@ from __future__ import annotations
 
 import torch
 import torch.nn as nn
+import torch.nn.functional as F
+from torch.amp import custom_bwd, custom_fwd
+
+from lightstream.core.scnn.utils import Box, Lost, _new_value_indices, H_DIM, W_DIM
 
 
 class ChannelLayerNorm(nn.Module):
@@ -24,3 +28,175 @@ class ChannelLayerNorm(nn.Module):
         x = x.permute(0, 2, 3, 1)
         x = self.norm(x)
         return x.permute(0, 3, 1, 2)
+
+
+class StreamingChannelLayerNormF(torch.autograd.Function):
+    @staticmethod
+    @custom_fwd(device_type="cuda", cast_inputs=torch.bfloat16 if torch.cuda.is_bf16_supported() else torch.float16)
+    def forward(ctx, inpt, weight, bias, num_channels, eps, grad_lost, seen_indices, output_stride, input_loc):
+        ctx.num_channels = num_channels
+        ctx.eps = eps
+        ctx.has_weight = weight is not None
+        ctx.has_bias = bias is not None
+        ctx.grad_lost = grad_lost
+        ctx.seen_indices = seen_indices
+        ctx.output_stride = output_stride
+        ctx.input_loc = input_loc
+
+        tensors = (inpt, weight) if weight is not None else (inpt,)
+        ctx.save_for_backward(*tensors)
+
+        out = F.layer_norm(inpt.permute(0, 2, 3, 1), (num_channels,), weight, bias, eps)
+        return out.permute(0, 3, 1, 2)
+
+    @staticmethod
+    @custom_bwd(device_type="cuda")
+    def backward(ctx, grad_output):
+        saved = ctx.saved_tensors
+        inpt = saved[0]
+        weight = saved[1] if ctx.has_weight else None
+
+        centered = inpt - inpt.mean(dim=1, keepdim=True)
+        inv_std = torch.rsqrt(centered.pow(2).mean(dim=1, keepdim=True) + ctx.eps)
+        x_hat = centered * inv_std
+
+        grad_in = None
+        if ctx.needs_input_grad[0]:
+            grad_norm = grad_output
+            if weight is not None:
+                grad_norm = grad_norm * weight.to(dtype=grad_output.dtype).view(1, -1, 1, 1)
+
+            channels = inpt.shape[1]
+            grad_mean = grad_norm.mean(dim=1, keepdim=True)
+            grad_xhat_mean = (grad_norm * x_hat).mean(dim=1, keepdim=True)
+            grad_in = (grad_norm - grad_mean - x_hat * grad_xhat_mean) * inv_std
+
+        grad_weight = grad_bias = None
+        if ctx.has_weight or ctx.has_bias:
+            input_loc = ctx.input_loc
+            sides = input_loc.sides if input_loc is not None else None
+            grad_lost = ctx.grad_lost
+            seen_indices = ctx.seen_indices
+
+            lost_top = grad_lost.top if not (sides is not None and sides.top) else 0
+            lost_bottom = grad_lost.bottom if not (sides is not None and sides.bottom) else 0
+            lost_left = grad_lost.left if not (sides is not None and sides.left) else 0
+            lost_right = grad_lost.right if not (sides is not None and sides.right) else 0
+
+            valid_grad = grad_output[
+                :,
+                :,
+                lost_top : grad_output.shape[H_DIM] - lost_bottom,
+                lost_left : grad_output.shape[W_DIM] - lost_right,
+            ]
+
+            if input_loc is None:
+                data_loc = Box(lost_top, 0, lost_left, 0, sides)
+            else:
+                output_stride = ctx.output_stride
+                stride_h = int(output_stride[1].item()) if isinstance(output_stride, torch.Tensor) else int(output_stride[1])
+                stride_w = int(output_stride[2].item()) if isinstance(output_stride, torch.Tensor) else int(output_stride[2])
+                data_loc_y = int(input_loc.y // stride_h) + lost_top
+                data_loc_x = int(input_loc.x // stride_w) + lost_left
+                data_loc = Box(data_loc_y, 0, data_loc_x, 0, input_loc.sides)
+
+            new_output_box, updated_total_indices = _new_value_indices(valid_grad.shape, data_loc, seen_indices)
+
+            seen_indices.y = updated_total_indices.y
+            seen_indices.height = updated_total_indices.height
+            seen_indices.x = updated_total_indices.x
+            seen_indices.width = updated_total_indices.width
+            seen_indices.sides = updated_total_indices.sides
+
+            if new_output_box.height > 0 and new_output_box.width > 0:
+                y0 = lost_top + new_output_box.y
+                y1 = y0 + new_output_box.height
+                x0 = lost_left + new_output_box.x
+                x1 = x0 + new_output_box.width
+                relevant_grad = grad_output[:, :, y0:y1, x0:x1]
+                if ctx.has_weight:
+                    relevant_x_hat = x_hat[:, :, y0:y1, x0:x1]
+                    grad_weight = (relevant_grad * relevant_x_hat).sum(dim=(0, 2, 3)).to(dtype=weight.dtype)
+                if ctx.has_bias:
+                    grad_bias = relevant_grad.sum(dim=(0, 2, 3)).to(dtype=weight.dtype)
+            else:
+                if ctx.has_weight:
+                    grad_weight = torch.zeros_like(weight)
+                if ctx.has_bias:
+                    grad_bias = torch.zeros_like(weight)
+
+        return grad_in, grad_weight, grad_bias, None, None, None, None, None, None
+
+
+channel_layer_norm = StreamingChannelLayerNormF.apply
+
+
+class StreamingChannelLayerNorm(nn.Module):
+    """Streaming channel layer normalization for NCHW tensors."""
+
+    def __init__(self, num_channels: int, eps: float = 1e-6, elementwise_affine: bool = True):
+        super().__init__()
+        self.num_channels = num_channels
+        self.eps = eps
+        self.elementwise_affine = elementwise_affine
+
+        if elementwise_affine:
+            self.weight = nn.Parameter(torch.ones(num_channels))
+            self.bias = nn.Parameter(torch.zeros(num_channels))
+        else:
+            self.register_parameter("weight", None)
+            self.register_parameter("bias", None)
+
+        self.grad_lost = Lost(0, 0, 0, 0)
+        self.output_stride = torch.tensor([1, 1, 1])
+        self.reset()
+
+    def reset(self):
+        self.seen_indices = Box(0, 0, 0, 0, None)
+        self.input_loc = Box(0, 0, 0, 0, None)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        if x.ndim != 4:
+            raise ValueError(
+                f"StreamingChannelLayerNorm expects 4D NCHW input, got {x.ndim}D input with shape {tuple(x.shape)}."
+            )
+        if x.shape[1] != self.num_channels:
+            raise ValueError(
+                f"StreamingChannelLayerNorm expected {self.num_channels} channels at dimension 1, "
+                f"got {x.shape[1]} channels for input shape {tuple(x.shape)}."
+            )
+
+        return channel_layer_norm(
+            x,
+            self.weight,
+            self.bias,
+            self.num_channels,
+            self.eps,
+            self.grad_lost,
+            self.seen_indices,
+            self.output_stride,
+            self.input_loc,
+        )
+
+    @classmethod
+    def from_channel_layer_norm(cls, module: ChannelLayerNorm) -> "StreamingChannelLayerNorm":
+        mod = cls(module.num_channels, module.norm.eps, module.norm.elementwise_affine)
+        if module.norm.elementwise_affine:
+            mod = mod.to(module.norm.weight.device, non_blocking=True)
+            mod = mod.to(module.norm.weight.dtype)
+            mod.weight.data.copy_(module.norm.weight.data)
+            mod.bias.data.copy_(module.norm.bias.data)
+            mod.weight.requires_grad = module.norm.weight.requires_grad
+            mod.bias.requires_grad = module.norm.bias.requires_grad
+        return mod
+
+    def to_channel_layer_norm(self) -> ChannelLayerNorm:
+        mod = ChannelLayerNorm(self.num_channels, self.eps, self.elementwise_affine)
+        if self.elementwise_affine:
+            mod = mod.to(self.weight.device, non_blocking=True)
+            mod = mod.to(self.weight.dtype)
+            mod.norm.weight.data.copy_(self.weight.data)
+            mod.norm.bias.data.copy_(self.bias.data)
+            mod.norm.weight.requires_grad = self.weight.requires_grad
+            mod.norm.bias.requires_grad = self.bias.requires_grad
+        return mod

--- a/tests/test_streaminglayernorm.py
+++ b/tests/test_streaminglayernorm.py
@@ -86,3 +86,96 @@ def test_streaming_statistics_hooks_include_channel_layer_norm(monkeypatch):
     assert stats["lost"] == Lost(1, 1, 1, 1)
     assert stats["grad_lost"] == Lost(1, 1, 1, 1)
     assert stats["output_stride"].tolist() == [1, 1, 1]
+
+
+def test_streaming_channel_layer_norm_conversion_preserves_parameters_and_metadata():
+    from lightstream.core.scnn.streaminglayernorm import StreamingChannelLayerNorm
+
+    module = ChannelLayerNorm(3, eps=1e-4, elementwise_affine=True).to(dtype=torch.float64)
+    module.norm.weight.data.copy_(torch.tensor([1.0, 2.0, 3.0], dtype=torch.float64))
+    module.norm.bias.data.copy_(torch.tensor([-1.0, 0.0, 1.0], dtype=torch.float64))
+    module.norm.weight.requires_grad = False
+    module.norm.bias.requires_grad = True
+
+    streaming = StreamingChannelLayerNorm.from_channel_layer_norm(module)
+
+    assert streaming.num_channels == module.num_channels
+    assert streaming.eps == module.norm.eps
+    assert streaming.elementwise_affine == module.norm.elementwise_affine
+    assert streaming.weight.dtype == module.norm.weight.dtype
+    assert streaming.weight.device == module.norm.weight.device
+    assert streaming.weight.requires_grad == module.norm.weight.requires_grad
+    assert streaming.bias.requires_grad == module.norm.bias.requires_grad
+    torch.testing.assert_close(streaming.weight, module.norm.weight)
+    torch.testing.assert_close(streaming.bias, module.norm.bias)
+
+    restored = streaming.to_channel_layer_norm()
+    assert restored.num_channels == module.num_channels
+    assert restored.norm.eps == module.norm.eps
+    assert restored.norm.elementwise_affine == module.norm.elementwise_affine
+    assert restored.norm.weight.requires_grad == module.norm.weight.requires_grad
+    assert restored.norm.bias.requires_grad == module.norm.bias.requires_grad
+    torch.testing.assert_close(restored.norm.weight, module.norm.weight)
+    torch.testing.assert_close(restored.norm.bias, module.norm.bias)
+
+
+def test_streaming_channel_layer_norm_matches_channel_layer_norm_forward_and_backward():
+    from lightstream.core.scnn.streaminglayernorm import StreamingChannelLayerNorm
+
+    torch.manual_seed(11)
+    module = ChannelLayerNorm(4, eps=1e-5, elementwise_affine=True)
+    streaming = StreamingChannelLayerNorm.from_channel_layer_norm(module)
+
+    x = torch.randn(2, 4, 3, 5, requires_grad=True)
+    x_streaming = x.detach().clone().requires_grad_(True)
+    grad = torch.randn(2, 4, 3, 5)
+
+    module(x).backward(grad)
+    streaming(x_streaming).backward(grad)
+
+    torch.testing.assert_close(x_streaming.grad, x.grad)
+    torch.testing.assert_close(streaming.weight.grad, module.norm.weight.grad)
+    torch.testing.assert_close(streaming.bias.grad, module.norm.bias.grad)
+
+
+def test_streaming_channel_layer_norm_affine_grads_use_only_unique_valid_region():
+    from lightstream.core.scnn.streaminglayernorm import StreamingChannelLayerNorm
+    from lightstream.core.scnn.utils import Box, Lost, Sides
+
+    torch.manual_seed(13)
+    streaming = StreamingChannelLayerNorm(3, eps=1e-5, elementwise_affine=True)
+    streaming.grad_lost = Lost(top=1, left=1, bottom=1, right=0)
+    streaming.input_loc = Box(y=0, height=4, x=0, width=5, sides=Sides(left=1, top=1, right=0, bottom=0))
+    streaming.output_stride = torch.tensor([1, 1, 1])
+
+    x = torch.randn(2, 3, 4, 5, requires_grad=True)
+    grad = torch.randn(2, 3, 4, 5)
+    streaming(x).backward(grad)
+
+    with torch.no_grad():
+        centered = x - x.mean(dim=1, keepdim=True)
+        x_hat = centered * torch.rsqrt(centered.pow(2).mean(dim=1, keepdim=True) + streaming.eps)
+        expected_grad_weight = (grad[:, :, :3, :] * x_hat[:, :, :3, :]).sum(dim=(0, 2, 3))
+        expected_grad_bias = grad[:, :, :3, :].sum(dim=(0, 2, 3))
+
+    torch.testing.assert_close(streaming.weight.grad, expected_grad_weight)
+    torch.testing.assert_close(streaming.bias.grad, expected_grad_bias)
+
+
+def test_streaming_channel_layer_norm_without_affine_backpropagates_input():
+    from lightstream.core.scnn.streaminglayernorm import StreamingChannelLayerNorm
+
+    torch.manual_seed(17)
+    module = ChannelLayerNorm(3, elementwise_affine=False)
+    streaming = StreamingChannelLayerNorm.from_channel_layer_norm(module)
+
+    x = torch.randn(2, 3, 4, 4, requires_grad=True)
+    x_streaming = x.detach().clone().requires_grad_(True)
+    grad = torch.randn(2, 3, 4, 4)
+
+    module(x).backward(grad)
+    streaming(x_streaming).backward(grad)
+
+    assert streaming.weight is None
+    assert streaming.bias is None
+    torch.testing.assert_close(x_streaming.grad, x.grad)


### PR DESCRIPTION
### Motivation
- Provide a streaming-aware channel-wise LayerNorm that mirrors `ChannelLayerNorm` behavior for NCHW tensors while maintaining per-module streaming state required by the streaming execution pipeline. 
- Ensure affine parameter gradients are computed only once per unique valid spatial region when tiles overlap to avoid duplicated parameter updates during the tiled backward pass.

### Description
- Added `StreamingChannelLayerNorm` and a corresponding custom autograd function `StreamingChannelLayerNormF` in `lightstream/core/scnn/streaminglayernorm.py` implementing NCHW channel normalization and preserving `num_channels`, `eps`, `elementwise_affine`, parameter values, dtype, device, and `requires_grad` flags. 
- Stored and maintained streaming state on the module: `grad_lost`, `output_stride`, `seen_indices`, and `input_loc`, and added a `reset()` method that reinitializes `seen_indices` and `input_loc`. 
- Implemented conversion helpers `from_channel_layer_norm(module)` and `to_channel_layer_norm()` to convert to/from the non-streaming `ChannelLayerNorm` while preserving metadata and parameter state. 
- Implemented a custom backward that computes full-tile `grad_input` and computes affine `grad_weight`/`grad_bias` only from the unique valid spatial region using `grad_lost`, `input_loc`, `output_stride`, `seen_indices`, and `_new_value_indices`, and correctly handles `elementwise_affine=False`. 
- Wired streaming conversion, reset, and input-location lifecycle for `StreamingChannelLayerNorm` into `StreamingCNN` and exported `StreamingChannelLayerNorm` from `lightstream.core.scnn` (changes to `scnn.py` and `__init__.py`).

### Testing
- Ran `pytest -q tests/test_streaminglayernorm.py`, which executed the new and existing unit tests and reported `10 passed` (all tests in that file succeeded). 
- Ran `python -m compileall lightstream tests/test_streaminglayernorm.py`, which succeeded with no syntax/compile errors. 
- Ran full `pytest -q` which failed during collection due to `ModuleNotFoundError: No module named 'numpy'` in the environment; this is an external dependency/environment issue and unrelated to the new code.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a296e3dc3988330a70de453f2824a01)