### PR TITLE
Handle layer norm in backward streaming state

### DIFF
--- a/lightstream/core/scnn/scnn.py
+++ b/lightstream/core/scnn/scnn.py
@@ -26,9 +26,17 @@ logger = logging.getLogger(__name__)
 _triple = _ntuple(3)
 
 
+BACKWARD_STREAMING_MODULE_TYPES = (StreamingConv2d, StreamingUpsample2d, StreamingChannelLayerNorm)
+
+
 def _is_pointwise_channel_norm(module):
     """Return True for channel-only normalization layers that preserve spatial support."""
     return isinstance(module, (ChannelLayerNorm, StreamingChannelLayerNorm))
+
+
+def _is_backward_streaming_module(module):
+    """Return True for streaming modules that need backward tile location state."""
+    return isinstance(module, BACKWARD_STREAMING_MODULE_TYPES)
 
 
 @dataclass(frozen=True)
@@ -1140,7 +1148,7 @@ class StreamingCNN(torch.nn.Module):
             tile = tile.to(self.device, non_blocking=True)
 
         for mod in self.stream_module.modules():
-            if isinstance(mod, (StreamingConv2d, StreamingUpsample2d, StreamingChannelLayerNorm)):
+            if _is_backward_streaming_module(mod):
                 mod.input_loc = input_loc
 
         if self.should_normalize:
@@ -1394,7 +1402,7 @@ class StreamingCNN(torch.nn.Module):
         self._saved_tensors = {}
 
         for mod in self.stream_module.modules():
-            if isinstance(mod, (StreamingConv2d, StreamingUpsample2d, StreamingChannelLayerNorm)):
+            if _is_backward_streaming_module(mod):
                 mod.input_loc = None
                 mod.reset()
 

--- a/tests/test_streaminglayernorm.py
+++ b/tests/test_streaminglayernorm.py
@@ -224,3 +224,17 @@ def test_streaming_channel_layer_norm_without_affine_backpropagates_input():
     assert streaming.weight is None
     assert streaming.bias is None
     torch.testing.assert_close(x_streaming.grad, x.grad)
+
+
+def test_backward_streaming_module_predicate_includes_existing_and_layer_norm_types(monkeypatch):
+    monkeypatch.setitem(sys.modules, "numpy", types.ModuleType("numpy"))
+
+    from lightstream.core.scnn.scnn import _is_backward_streaming_module
+    from lightstream.core.scnn.streamingconv import StreamingConv2d
+    from lightstream.core.scnn.streaminglayernorm import StreamingChannelLayerNorm
+    from lightstream.core.scnn.streamingupsample import StreamingUpsample2d
+
+    assert _is_backward_streaming_module(StreamingConv2d(3, 3, kernel_size=1))
+    assert _is_backward_streaming_module(StreamingUpsample2d(scale_factor=2.0, mode="bilinear"))
+    assert _is_backward_streaming_module(StreamingChannelLayerNorm(3))
+    assert not _is_backward_streaming_module(torch.nn.ReLU())


### PR DESCRIPTION
### Motivation
- Ensure `StreamingChannelLayerNorm` receives the same backward tile location and reset lifecycle as other streaming modules during backward replay.
- Centralize the predicate for backward-streaming module detection to keep handling consistent and extensible.

### Description
- Add `BACKWARD_STREAMING_MODULE_TYPES = (StreamingConv2d, StreamingUpsample2d, StreamingChannelLayerNorm)` and a helper `def _is_backward_streaming_module(module):` to centralize the module predicate.
- Replace inline `isinstance(... (StreamingConv2d, StreamingUpsample2d, StreamingChannelLayerNorm))` checks in `_run_backward_tile()` and post-backward cleanup with `if _is_backward_streaming_module(mod):` so `input_loc` is assigned and cleared via the shared predicate.
- Add a unit test `test_backward_streaming_module_predicate_includes_existing_and_layer_norm_types` to `tests/test_streaminglayernorm.py` that verifies the predicate includes `StreamingConv2d`, `StreamingUpsample2d`, and `StreamingChannelLayerNorm` and excludes non-streaming modules.

### Testing
- Ran `pytest -q tests/test_streaminglayernorm.py` and all tests passed (`13 passed, 1 warning`).
- Ran `python -m compileall -q lightstream/core/scnn/scnn.py tests/test_streaminglayernorm.py` with no syntax errors.
- Attempted `pytest` including `tests/test_streamingupsample.py` but collection failed due to missing `numpy` in the environment, and `pip install numpy` was blocked by a `403 Forbidden` from the package index.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2978a97b388330a1c3c4597e9b27a3)