### PR TITLE
Export ChannelLayerNorm and StreamingChannelLayerNorm from public scnn package

### DIFF
--- a/docs/modules/scnn.md
+++ b/docs/modules/scnn.md
@@ -1,0 +1,11 @@
+# Streaming CNN layers
+
+`lightstream.core.scnn` is the documented public module for streaming CNN layer
+building blocks. Import channel layer normalization from this package instead of
+private implementation modules:
+
+```python
+from lightstream.core.scnn import ChannelLayerNorm, StreamingChannelLayerNorm
+```
+
+::: lightstream.core.scnn

--- a/lightstream/core/scnn/__init__.py
+++ b/lightstream/core/scnn/__init__.py
@@ -1,3 +1,11 @@
+"""Public streaming-CNN layer exports.
+
+The :mod:`lightstream.core.scnn` package is the stable public import location
+for streaming CNN building blocks. Users should import channel layer-normalizing
+modules from here instead of from implementation modules such as
+``lightstream.core.scnn.streaminglayernorm``.
+"""
+
 from lightstream.core.scnn.streaminglayernorm import ChannelLayerNorm, StreamingChannelLayerNorm
 
 __all__ = ["ChannelLayerNorm", "StreamingChannelLayerNorm"]

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -17,6 +17,7 @@ nav:
       streaming: modules/streamingmodule.md
       imagenet: modules/imagenettemplate.md
       constructor: modules/constructor.md
+      scnn: modules/scnn.md
 
 
 theme:

--- a/tests/test_streaminglayernorm.py
+++ b/tests/test_streaminglayernorm.py
@@ -4,7 +4,7 @@ import types
 import pytest
 import torch
 
-from lightstream.core.scnn import ChannelLayerNorm
+from lightstream.core.scnn import ChannelLayerNorm, StreamingChannelLayerNorm
 from lightstream.core.scnn.streaminglayernorm import ChannelLayerNorm as ImportedChannelLayerNorm
 
 
@@ -36,6 +36,7 @@ def test_channel_layer_norm_rejects_channel_mismatch():
 
 def test_channel_layer_norm_is_public_from_scnn_package():
     assert ImportedChannelLayerNorm is ChannelLayerNorm
+    assert StreamingChannelLayerNorm.__name__ == "StreamingChannelLayerNorm"
 
 
 def test_constructor_considers_only_channel_layer_norm_streamable(monkeypatch):


### PR DESCRIPTION
### Motivation

- Provide a stable, documented public import path for channel-wise layer normalization so users don't import private implementation modules.
- Make `ChannelLayerNorm` and `StreamingChannelLayerNorm` available from `lightstream.core.scnn` and document that as the recommended import location.

### Description

- Added a public module docstring and re-exports in `lightstream/core/scnn/__init__.py` that import `ChannelLayerNorm` and `StreamingChannelLayerNorm` from the implementation module and expose them in `__all__`.
- Added documentation page `docs/modules/scnn.md` that documents the public import path `from lightstream.core.scnn import ChannelLayerNorm, StreamingChannelLayerNorm`.
- Added the new docs page to the MkDocs navigation in `mkdocs.yml`.
- Updated `tests/test_streaminglayernorm.py` to import both classes from the public `lightstream.core.scnn` package and to assert the public exports are available.

### Testing

- Ran `python -m pytest tests/test_streaminglayernorm.py` and all tests in that file passed (`13 passed`).
- Ran a quick import check (`python - <<'PY' ...`) that imported `ChannelLayerNorm` and `StreamingChannelLayerNorm` from `lightstream.core.scnn` and printed their names, which succeeded.
- Attempted `python -m mkdocs build --strict` to validate docs, which failed in the CI environment because `mkdocs` is not installed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a297af752a483308e0643ebeace3833)