### PR TITLE
Preserve kept module children during identity conversion

### DIFF
--- a/lightstream/core/constructor.py
+++ b/lightstream/core/constructor.py
@@ -188,6 +188,9 @@ class StreamingConstructor:
         """
 
         for n, module in model.named_children():
+            if isinstance(module, tuple(self.keep_modules)):
+                continue
+
             if len(list(module.children())) > 0:
                 # compound module, go inside it
                 self.convert_to_identity(module)
@@ -195,12 +198,11 @@ class StreamingConstructor:
 
             # if new module is assigned to a variable, e.g. new = nn.Identity(), then it's considered a duplicate in
             # module.named_children used later. Instead, we use in-place assignment, so each new module is unique
-            if not isinstance(module, tuple(self.keep_modules)):
-                try:
-                    n = int(n)
-                    model[n] = torch.nn.Identity()
-                except ValueError:
-                    setattr(model, str(n), torch.nn.Identity())
+            try:
+                n = int(n)
+                model[n] = torch.nn.Identity()
+            except ValueError:
+                setattr(model, str(n), torch.nn.Identity())
 
     def restore_model_layers(self, model_ref: nn.Module, model_rep: nn.Module) -> None:
         """Restore model layers from Identity to what they were before

--- a/tests/test_streaminglayernorm.py
+++ b/tests/test_streaminglayernorm.py
@@ -58,6 +58,26 @@ def test_constructor_considers_only_channel_layer_norm_streamable(monkeypatch):
     assert torch.nn.LayerNorm not in constructor.keep_modules
 
 
+def test_convert_to_identity_skips_children_of_kept_channel_layer_norm(monkeypatch):
+    monkeypatch.setitem(sys.modules, "numpy", types.ModuleType("numpy"))
+    from lightstream.core.constructor import StreamingConstructor
+
+    model = torch.nn.Sequential(
+        torch.nn.Sequential(
+            ChannelLayerNorm(3, eps=1e-6),
+            torch.nn.ReLU(),
+        ),
+    )
+    constructor = StreamingConstructor(model, tile_size=32, verbose=False, statistics_on_cpu=True)
+
+    constructor.convert_to_identity(model)
+
+    assert isinstance(model[0][0], ChannelLayerNorm)
+    assert isinstance(model[0][0].norm, torch.nn.LayerNorm)
+    assert model[0][0].norm.eps == 1e-6
+    assert isinstance(model[0][1], torch.nn.Identity)
+
+
 def test_streaming_statistics_hooks_include_channel_layer_norm(monkeypatch):
     monkeypatch.setitem(sys.modules, "numpy", types.ModuleType("numpy"))
 


### PR DESCRIPTION
### Motivation
- `convert_to_identity` previously recursed into child modules before checking the keep-list, which allowed internals of special wrappers (e.g. `ChannelLayerNorm.norm`) to be replaced with `nn.Identity` and lose attributes like `eps`.
- The intent is to treat modules in `keep_modules` as atomic and avoid descending into them so their internals remain intact for later conversion to streaming equivalents.

### Description
- Change `StreamingConstructor.convert_to_identity` to check `isinstance(module, tuple(self.keep_modules))` first and `continue` when true, so kept modules are not recursed into.
- Preserve the existing leaf replacement behavior by still replacing non-kept leaf modules with `torch.nn.Identity()` in-place.
- Add the regression test `test_convert_to_identity_skips_children_of_kept_channel_layer_norm` to `tests/test_streaminglayernorm.py` which asserts that a `ChannelLayerNorm` and its internal `nn.LayerNorm` are preserved while a sibling non-kept `ReLU` is converted to `Identity`.

### Testing
- Ran `pytest tests/test_streaminglayernorm.py::test_convert_to_identity_skips_children_of_kept_channel_layer_norm tests/test_streaminglayernorm.py::test_constructor_considers_only_channel_layer_norm_streamable -q`, and both tests passed.
- Ran `pytest tests/test_streaminglayernorm.py -q`, and the full test file passed (all tests green).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2a97e8e4d083309d4da9979976ceb5)