### PR TITLE
Harden channel layer norm conversion

### DIFF
--- a/lightstream/core/scnn/streaminglayernorm.py
+++ b/lightstream/core/scnn/streaminglayernorm.py
@@ -14,6 +14,8 @@ class ChannelLayerNorm(nn.Module):
     def __init__(self, num_channels: int, eps: float = 1e-6, elementwise_affine: bool = True):
         super().__init__()
         self.num_channels = num_channels
+        self.eps = eps
+        self.elementwise_affine = elementwise_affine
         self.norm = nn.LayerNorm(num_channels, eps=eps, elementwise_affine=elementwise_affine)
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:
@@ -180,8 +182,14 @@ class StreamingChannelLayerNorm(nn.Module):
 
     @classmethod
     def from_channel_layer_norm(cls, module: ChannelLayerNorm) -> "StreamingChannelLayerNorm":
-        mod = cls(module.num_channels, module.norm.eps, module.norm.elementwise_affine)
-        if module.norm.elementwise_affine:
+        if not isinstance(module.norm, nn.LayerNorm):
+            raise TypeError(
+                "StreamingChannelLayerNorm.from_channel_layer_norm expected "
+                f"module.norm to be nn.LayerNorm, got {type(module.norm).__name__}."
+            )
+
+        mod = cls(module.num_channels, module.eps, module.elementwise_affine)
+        if module.elementwise_affine:
             mod = mod.to(module.norm.weight.device, non_blocking=True)
             mod = mod.to(module.norm.weight.dtype)
             mod.weight.data.copy_(module.norm.weight.data)

--- a/tests/test_streaminglayernorm.py
+++ b/tests/test_streaminglayernorm.py
@@ -101,8 +101,8 @@ def test_streaming_channel_layer_norm_conversion_preserves_parameters_and_metada
     streaming = StreamingChannelLayerNorm.from_channel_layer_norm(module)
 
     assert streaming.num_channels == module.num_channels
-    assert streaming.eps == module.norm.eps
-    assert streaming.elementwise_affine == module.norm.elementwise_affine
+    assert streaming.eps == module.eps
+    assert streaming.elementwise_affine == module.elementwise_affine
     assert streaming.weight.dtype == module.norm.weight.dtype
     assert streaming.weight.device == module.norm.weight.device
     assert streaming.weight.requires_grad == module.norm.weight.requires_grad
@@ -112,13 +112,45 @@ def test_streaming_channel_layer_norm_conversion_preserves_parameters_and_metada
 
     restored = streaming.to_channel_layer_norm()
     assert restored.num_channels == module.num_channels
-    assert restored.norm.eps == module.norm.eps
-    assert restored.norm.elementwise_affine == module.norm.elementwise_affine
+    assert restored.eps == module.eps
+    assert restored.elementwise_affine == module.elementwise_affine
+    assert restored.norm.eps == module.eps
+    assert restored.norm.elementwise_affine == module.elementwise_affine
     assert restored.norm.weight.requires_grad == module.norm.weight.requires_grad
     assert restored.norm.bias.requires_grad == module.norm.bias.requires_grad
     torch.testing.assert_close(restored.norm.weight, module.norm.weight)
     torch.testing.assert_close(restored.norm.bias, module.norm.bias)
 
+
+def test_channel_layer_norm_stores_constructor_metadata():
+    module = ChannelLayerNorm(5, eps=1e-3, elementwise_affine=False)
+
+    assert module.num_channels == 5
+    assert module.eps == 1e-3
+    assert module.elementwise_affine is False
+
+
+def test_streaming_channel_layer_norm_conversion_uses_channel_layer_norm_metadata():
+    from lightstream.core.scnn.streaminglayernorm import StreamingChannelLayerNorm
+
+    module = ChannelLayerNorm(3, eps=1e-4, elementwise_affine=True)
+    module.norm = torch.nn.LayerNorm(3, eps=1e-2, elementwise_affine=True)
+
+    streaming = StreamingChannelLayerNorm.from_channel_layer_norm(module)
+
+    assert streaming.num_channels == module.num_channels
+    assert streaming.eps == module.eps
+    assert streaming.elementwise_affine == module.elementwise_affine
+
+
+def test_streaming_channel_layer_norm_conversion_rejects_replaced_norm():
+    from lightstream.core.scnn.streaminglayernorm import StreamingChannelLayerNorm
+
+    module = ChannelLayerNorm(3)
+    module.norm = torch.nn.Identity()
+
+    with pytest.raises(TypeError, match="module.norm to be nn.LayerNorm"):
+        StreamingChannelLayerNorm.from_channel_layer_norm(module)
 
 def test_scnn_converts_nested_channel_layer_norm_and_transfers_stats():
     from lightstream.core.scnn.scnn import StreamingCNN


### PR DESCRIPTION
### Motivation
- Prevent fragile reads of `module.norm` attributes by storing `ChannelLayerNorm` constructor metadata directly on the module.
- Ensure converting a `ChannelLayerNorm` to `StreamingChannelLayerNorm` uses the original module metadata (`num_channels`, `eps`, `elementwise_affine`) and fails clearly if the wrapped norm has been replaced.

### Description
- Store `self.eps` and `self.elementwise_affine` in `ChannelLayerNorm.__init__` alongside the existing `self.num_channels` attribute.
- Update `StreamingChannelLayerNorm.from_channel_layer_norm()` to validate that `module.norm` is an instance of `nn.LayerNorm` and raise a `TypeError` with a clear message if not.
- Make `from_channel_layer_norm()` construct the streaming module using `module.num_channels`, `module.eps`, and `module.elementwise_affine` instead of reading `eps`/`elementwise_affine` from `module.norm`.
- Preserve existing behavior for affine parameters by copying `module.norm.weight` and `module.norm.bias`, including device/dtype alignment and `requires_grad` propagation when `elementwise_affine` is `True`.
- Add unit tests to verify constructor metadata storage, conversion uses `ChannelLayerNorm` metadata, and conversion rejects an unexpectedly replaced `module.norm`.

### Testing
- Ran `pytest tests/test_streaminglayernorm.py -q`, which completed successfully with `20 passed, 1 warning`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2a97f6aa188330a379dd470e575f27)