### PR TITLE
Avoid ChannelLayerNorm statistics reinitialization

### DIFF
--- a/lightstream/core/scnn/scnn.py
+++ b/lightstream/core/scnn/scnn.py
@@ -689,10 +689,14 @@ class StreamingCNN(torch.nn.Module):
                 if mod.bias is not None:
                     torch.nn.init.constant_(mod.bias, 0)
 
-
+        # Only BatchNorm has running statistics that can be frozen into a
+        # deterministic affine-like transform while gathering tile statistics.
+        # ChannelLayerNorm/LayerNorm computes per-sample channel statistics from
+        # the current tensor, and its default affine parameters are already
+        # weight=1 and bias=0; changing those parameters does not prevent
+        # constant setup tensors from producing zero LayerNorm input gradients.
         for m in self.stream_module.modules():
             if isinstance(m, torch.nn.BatchNorm2d):
-                # Perhaps change to torch.nn.init.ones_(m.weight) and zeros?
                 m.weight.data.fill_(1)
                 m.bias.data.zero_()
                 m.eval()

--- a/tests/test_streaminglayernorm.py
+++ b/tests/test_streaminglayernorm.py
@@ -78,6 +78,35 @@ def test_convert_to_identity_skips_children_of_kept_channel_layer_norm(monkeypat
     assert isinstance(model[0][1], torch.nn.Identity)
 
 
+def test_constant_statistics_setup_does_not_reinitialize_channel_layer_norm(monkeypatch):
+    monkeypatch.setitem(sys.modules, "numpy", types.ModuleType("numpy"))
+
+    from lightstream.core.scnn.scnn import StreamingCNN
+
+    model = torch.nn.Sequential(
+        torch.nn.Conv2d(3, 3, kernel_size=3, padding=1, bias=False),
+        torch.nn.BatchNorm2d(3),
+        ChannelLayerNorm(3),
+    ).eval()
+    with torch.no_grad():
+        model[1].weight.copy_(torch.tensor([2.0, 3.0, 4.0]))
+        model[1].bias.copy_(torch.tensor([0.5, 0.25, -0.5]))
+        model[2].norm.weight.copy_(torch.tensor([1.5, 2.5, 3.5]))
+        model[2].norm.bias.copy_(torch.tensor([-1.0, 0.0, 1.0]))
+
+    scnn = StreamingCNN.__new__(StreamingCNN)
+    torch.nn.Module.__init__(scnn)
+    scnn.stream_module = model
+
+    StreamingCNN._reset_parameters_to_constant(scnn)
+
+    torch.testing.assert_close(model[1].weight, torch.ones(3))
+    torch.testing.assert_close(model[1].bias, torch.zeros(3))
+    assert model[1].training is False
+    torch.testing.assert_close(model[2].norm.weight, torch.tensor([1.5, 2.5, 3.5]))
+    torch.testing.assert_close(model[2].norm.bias, torch.tensor([-1.0, 0.0, 1.0]))
+
+
 def test_streaming_statistics_hooks_include_channel_layer_norm(monkeypatch):
     monkeypatch.setitem(sys.modules, "numpy", types.ModuleType("numpy"))
 


### PR DESCRIPTION
### Motivation
- Prevent `ChannelLayerNorm`/`LayerNorm` affine parameters from being reinitialized during tile-statistics setup because only `BatchNorm2d` has running statistics that can be frozen into a deterministic affine-like transform, while `LayerNorm` computes per-sample channel statistics and its defaults already behave as `weight=1` and `bias=0`.

### Description
- Add a clarifying comment in `StreamingCNN._reset_parameters_to_constant` explaining that only `BatchNorm2d` is reset/evaluated for deterministic affine-like behavior while `ChannelLayerNorm` is intentionally left alone (`lightstream/core/scnn/scnn.py`).
- Ensure the code continues to reset `BatchNorm2d` affine parameters (`weight` -> ones, `bias` -> zeros) and call `eval()` for those modules only.
- Add a regression test `test_constant_statistics_setup_does_not_reinitialize_channel_layer_norm` to `tests/test_streaminglayernorm.py` which verifies `BatchNorm2d` is reset and `ChannelLayerNorm` affine parameters remain unchanged.

### Testing
- Ran `pytest -q tests/test_streaminglayernorm.py`, which completed successfully with `22 passed, 1 warning`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2a9e5b0ef083309b1ba2b3201d1770)