### PR TITLE
Make ChannelLayerNorm passthrough during SCNN statistics

### DIFF
--- a/lightstream/core/scnn/scnn.py
+++ b/lightstream/core/scnn/scnn.py
@@ -244,6 +244,7 @@ class StreamingCNN(torch.nn.Module):
         # Add hooks to each layer to gather statistics
         self._add_hooks_for_statistics()
         self._set_reducer_passthrough(True)
+        self._set_channel_layer_norm_statistics_passthrough(True)
 
         # We need to temporary store statistics per layer to keep track of the
         # total output stride at each layer
@@ -271,6 +272,7 @@ class StreamingCNN(torch.nn.Module):
         # during lightstream
         self._remove_hooks()
         self._set_reducer_passthrough(False)
+        self._set_channel_layer_norm_statistics_passthrough(False)
         #
         self._restore_parameters(state_dict)
         self._capture_public_output_spec()
@@ -302,6 +304,11 @@ class StreamingCNN(torch.nn.Module):
         for mod in self.stream_module.modules():
             if isinstance(mod, BaseReducer):
                 mod._streaming_passthrough = enabled
+
+    def _set_channel_layer_norm_statistics_passthrough(self, enabled: bool):
+        for mod in self.stream_module.modules():
+            if isinstance(mod, ChannelLayerNorm):
+                mod._streaming_statistics_passthrough = enabled
 
     def _gather_backward_statistics(self, tile):
         # Forward pass with grads enabled

--- a/lightstream/core/scnn/streaminglayernorm.py
+++ b/lightstream/core/scnn/streaminglayernorm.py
@@ -16,6 +16,7 @@ class ChannelLayerNorm(nn.Module):
         self.num_channels = num_channels
         self.eps = eps
         self.elementwise_affine = elementwise_affine
+        self._streaming_statistics_passthrough = False
         self.norm = nn.LayerNorm(num_channels, eps=eps, elementwise_affine=elementwise_affine)
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:
@@ -26,6 +27,8 @@ class ChannelLayerNorm(nn.Module):
                 f"ChannelLayerNorm expected {self.num_channels} channels at dimension 1, "
                 f"got {x.shape[1]} channels for input shape {tuple(x.shape)}."
             )
+        if self._streaming_statistics_passthrough:
+            return x
 
         x = x.permute(0, 2, 3, 1)
         x = self.norm(x)

--- a/tests/test_streaminglayernorm.py
+++ b/tests/test_streaminglayernorm.py
@@ -20,6 +20,40 @@ def test_channel_layer_norm_matches_nhwc_layer_norm():
     torch.testing.assert_close(module(x), expected)
 
 
+def test_channel_layer_norm_statistics_passthrough_returns_input_identity():
+    torch.manual_seed(8)
+    module = ChannelLayerNorm(3, eps=1e-6, elementwise_affine=True)
+    x = torch.randn(2, 3, 5, 7)
+
+    normal_output = module(x)
+    module._streaming_statistics_passthrough = True
+    passthrough_output = module(x)
+    module._streaming_statistics_passthrough = False
+
+    assert passthrough_output is x
+    torch.testing.assert_close(passthrough_output, x)
+    assert not torch.allclose(normal_output, x)
+    torch.testing.assert_close(module(x), normal_output)
+
+
+def test_scnn_toggles_channel_layer_norm_statistics_passthrough(monkeypatch):
+    monkeypatch.setitem(sys.modules, "numpy", types.ModuleType("numpy"))
+
+    from lightstream.core.scnn.scnn import StreamingCNN
+
+    norm = ChannelLayerNorm(3)
+    model = torch.nn.Sequential(norm)
+    scnn = StreamingCNN.__new__(StreamingCNN)
+    torch.nn.Module.__init__(scnn)
+    scnn.stream_module = model
+
+    scnn._set_channel_layer_norm_statistics_passthrough(True)
+    assert norm._streaming_statistics_passthrough is True
+
+    scnn._set_channel_layer_norm_statistics_passthrough(False)
+    assert norm._streaming_statistics_passthrough is False
+
+
 def test_channel_layer_norm_rejects_non_4d_input():
     module = ChannelLayerNorm(3)
 


### PR DESCRIPTION
### Motivation
- During SCNN setup statistics gathering, channel-wise LayerNorm layers should act as a spatial identity so the statistics reflect stride-1/no-spatial-loss behavior.

### Description
- Add a boolean flag `_streaming_statistics_passthrough` to `ChannelLayerNorm` and return the original input from `forward()` when the flag is enabled so the module behaves as a spatial identity during stats collection (`lightstream/core/scnn/streaminglayernorm.py`).
- Add `StreamingCNN._set_channel_layer_norm_statistics_passthrough(enabled: bool)` to toggle the new flag across all `ChannelLayerNorm` modules in the model (`lightstream/core/scnn/scnn.py`).
- Enable the passthrough before `_gather_forward_statistics(tile)` and `_gather_backward_statistics(tile)` in `_configure()` and disable it again before restoring parameters and converting modules for streaming, ensuring normal LayerNorm behavior for real execution (`lightstream/core/scnn/scnn.py`).
- Add unit tests covering direct passthrough identity behavior and that `StreamingCNN` toggles the flag (`tests/test_streaminglayernorm.py`).

### Testing
- Ran focused unit tests with `pytest -q tests/test_streaminglayernorm.py`, which passed (23 tests, 1 warning about missing NumPy initialization). 
- Ran full test collection with `pytest -q`, which failed during collection due to the environment lacking the `numpy` package (this is an external dependency issue, not related to the changes).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2a9e5ec15083308f3ba518c1ce8fd4)