### PR TITLE
Fix streaming ChannelLayerNorm state dict compatibility

### DIFF
--- a/lightstream/core/scnn/streaminglayernorm.py
+++ b/lightstream/core/scnn/streaminglayernorm.py
@@ -144,17 +144,19 @@ class StreamingChannelLayerNorm(nn.Module):
         self.num_channels = num_channels
         self.eps = eps
         self.elementwise_affine = elementwise_affine
-
-        if elementwise_affine:
-            self.weight = nn.Parameter(torch.ones(num_channels))
-            self.bias = nn.Parameter(torch.zeros(num_channels))
-        else:
-            self.register_parameter("weight", None)
-            self.register_parameter("bias", None)
+        self.norm = nn.LayerNorm(num_channels, eps=eps, elementwise_affine=elementwise_affine)
 
         self.grad_lost = Lost(0, 0, 0, 0)
         self.output_stride = torch.tensor([1, 1, 1])
         self.reset()
+
+    @property
+    def weight(self) -> torch.nn.Parameter | None:
+        return self.norm.weight
+
+    @property
+    def bias(self) -> torch.nn.Parameter | None:
+        return self.norm.bias
 
     def reset(self):
         self.seen_indices = Box(0, 0, 0, 0, None)
@@ -173,8 +175,8 @@ class StreamingChannelLayerNorm(nn.Module):
 
         return channel_layer_norm(
             x,
-            self.weight,
-            self.bias,
+            self.norm.weight,
+            self.norm.bias,
             self.num_channels,
             self.eps,
             self.grad_lost,
@@ -195,19 +197,17 @@ class StreamingChannelLayerNorm(nn.Module):
         if module.elementwise_affine:
             mod = mod.to(module.norm.weight.device, non_blocking=True)
             mod = mod.to(module.norm.weight.dtype)
-            mod.weight.data.copy_(module.norm.weight.data)
-            mod.bias.data.copy_(module.norm.bias.data)
-            mod.weight.requires_grad = module.norm.weight.requires_grad
-            mod.bias.requires_grad = module.norm.bias.requires_grad
+            mod.norm.weight.requires_grad = module.norm.weight.requires_grad
+            mod.norm.bias.requires_grad = module.norm.bias.requires_grad
+        mod.norm.load_state_dict(module.norm.state_dict())
         return mod
 
     def to_channel_layer_norm(self) -> ChannelLayerNorm:
         mod = ChannelLayerNorm(self.num_channels, self.eps, self.elementwise_affine)
         if self.elementwise_affine:
-            mod = mod.to(self.weight.device, non_blocking=True)
-            mod = mod.to(self.weight.dtype)
-            mod.norm.weight.data.copy_(self.weight.data)
-            mod.norm.bias.data.copy_(self.bias.data)
-            mod.norm.weight.requires_grad = self.weight.requires_grad
-            mod.norm.bias.requires_grad = self.bias.requires_grad
+            mod = mod.to(self.norm.weight.device, non_blocking=True)
+            mod = mod.to(self.norm.weight.dtype)
+            mod.norm.weight.requires_grad = self.norm.weight.requires_grad
+            mod.norm.bias.requires_grad = self.norm.bias.requires_grad
+        mod.norm.load_state_dict(self.norm.state_dict())
         return mod

--- a/tests/test_streaminglayernorm.py
+++ b/tests/test_streaminglayernorm.py
@@ -205,6 +205,27 @@ def test_streaming_channel_layer_norm_conversion_preserves_parameters_and_metada
     torch.testing.assert_close(restored.norm.bias, module.norm.bias)
 
 
+def test_streaming_channel_layer_norm_state_dict_matches_channel_layer_norm_keys():
+    module = ChannelLayerNorm(3, eps=1e-4, elementwise_affine=True)
+    streaming = StreamingChannelLayerNorm.from_channel_layer_norm(module)
+
+    assert list(module.state_dict().keys()) == ["norm.weight", "norm.bias"]
+    assert list(streaming.state_dict().keys()) == ["norm.weight", "norm.bias"]
+
+    streaming.load_state_dict(module.state_dict())
+    torch.testing.assert_close(streaming.norm.weight, module.norm.weight)
+    torch.testing.assert_close(streaming.norm.bias, module.norm.bias)
+
+
+def test_streaming_channel_layer_norm_state_dict_without_affine_matches_channel_layer_norm_keys():
+    module = ChannelLayerNorm(3, eps=1e-4, elementwise_affine=False)
+    streaming = StreamingChannelLayerNorm.from_channel_layer_norm(module)
+
+    assert list(module.state_dict().keys()) == []
+    assert list(streaming.state_dict().keys()) == []
+    streaming.load_state_dict(module.state_dict())
+
+
 def test_channel_layer_norm_stores_constructor_metadata():
     module = ChannelLayerNorm(5, eps=1e-3, elementwise_affine=False)
 


### PR DESCRIPTION
### Motivation
- Converting a `ChannelLayerNorm` to `StreamingChannelLayerNorm` produced mismatched parameter keys (`norm.weight`/`norm.bias` vs `weight`/`bias`) causing `StreamingConstructor.prepare_streaming_model()` to fail when loading the original state dict. 
- The change aims to keep streaming modules state-dict-compatible with the original `ChannelLayerNorm` while preserving runtime streaming behavior and gradient accounting.

### Description
- `StreamingChannelLayerNorm` now owns an internal `self.norm = nn.LayerNorm(...)` so the module exposes the same nested keys as `ChannelLayerNorm`.
- The streaming forward call passes `self.norm.weight` and `self.norm.bias` into the custom autograd function instead of top-level parameters, and top-level `weight`/`bias` are replaced with properties that delegate to `self.norm`.
- `from_channel_layer_norm()` now loads/copies `module.norm.state_dict()` into `mod.norm` and preserves `device`, `dtype`, and `requires_grad` metadata.
- `to_channel_layer_norm()` now loads/copies `self.norm.state_dict()` into the returned `ChannelLayerNorm` and preserves `eps`, `elementwise_affine`, `dtype`, `device`, and `requires_grad`.
- Added unit tests that assert `state_dict()` keys match between `ChannelLayerNorm` and `StreamingChannelLayerNorm` for both affine and non-affine cases.

### Testing
- Ran `pytest -q tests/test_streaminglayernorm.py` and all tests in that file passed (`26 passed, 1 warning`).
- Attempting to run the full test suite (`pytest -q`) halted at collection due to the environment missing `numpy` (module-not-found), so broader suite collection did not complete in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2aa10f2214833082af1e90c40d3f57)