### PR TITLE
Make StreamingChannelLayerNorm own affine params via internal LayerNorm and forward them conditionally

### DIFF
--- a/lightstream/core/scnn/streaminglayernorm.py
+++ b/lightstream/core/scnn/streaminglayernorm.py
@@ -145,16 +145,19 @@ class StreamingChannelLayerNorm(nn.Module):
         self.eps = eps
         self.elementwise_affine = elementwise_affine
 
-        if elementwise_affine:
-            self.weight = nn.Parameter(torch.ones(num_channels))
-            self.bias = nn.Parameter(torch.zeros(num_channels))
-        else:
-            self.register_parameter("weight", None)
-            self.register_parameter("bias", None)
+        self.norm = nn.LayerNorm(num_channels, eps=eps, elementwise_affine=elementwise_affine)
 
         self.grad_lost = Lost(0, 0, 0, 0)
         self.output_stride = torch.tensor([1, 1, 1])
         self.reset()
+
+    @property
+    def weight(self) -> nn.Parameter | None:
+        return self.norm.weight
+
+    @property
+    def bias(self) -> nn.Parameter | None:
+        return self.norm.bias
 
     def reset(self):
         self.seen_indices = Box(0, 0, 0, 0, None)
@@ -171,10 +174,13 @@ class StreamingChannelLayerNorm(nn.Module):
                 f"got {x.shape[1]} channels for input shape {tuple(x.shape)}."
             )
 
+        weight = self.norm.weight if self.elementwise_affine else None
+        bias = self.norm.bias if self.elementwise_affine else None
+
         return channel_layer_norm(
             x,
-            self.weight,
-            self.bias,
+            weight,
+            bias,
             self.num_channels,
             self.eps,
             self.grad_lost,

--- a/tests/test_streaminglayernorm.py
+++ b/tests/test_streaminglayernorm.py
@@ -190,8 +190,9 @@ def test_streaming_channel_layer_norm_conversion_preserves_parameters_and_metada
     assert streaming.weight.device == module.norm.weight.device
     assert streaming.weight.requires_grad == module.norm.weight.requires_grad
     assert streaming.bias.requires_grad == module.norm.bias.requires_grad
-    torch.testing.assert_close(streaming.weight, module.norm.weight)
-    torch.testing.assert_close(streaming.bias, module.norm.bias)
+    assert list(streaming.named_parameters()) == [("norm.weight", streaming.norm.weight), ("norm.bias", streaming.norm.bias)]
+    torch.testing.assert_close(streaming.norm.weight, module.norm.weight)
+    torch.testing.assert_close(streaming.norm.bias, module.norm.bias)
 
     restored = streaming.to_channel_layer_norm()
     assert restored.num_channels == module.num_channels
@@ -295,8 +296,8 @@ def test_streaming_channel_layer_norm_matches_channel_layer_norm_forward_and_bac
     streaming(x_streaming).backward(grad)
 
     torch.testing.assert_close(x_streaming.grad, x.grad)
-    torch.testing.assert_close(streaming.weight.grad, module.norm.weight.grad)
-    torch.testing.assert_close(streaming.bias.grad, module.norm.bias.grad)
+    torch.testing.assert_close(streaming.norm.weight.grad, module.norm.weight.grad)
+    torch.testing.assert_close(streaming.norm.bias.grad, module.norm.bias.grad)
 
 
 def test_streaming_channel_layer_norm_affine_grads_use_only_unique_valid_region():
@@ -319,8 +320,8 @@ def test_streaming_channel_layer_norm_affine_grads_use_only_unique_valid_region(
         expected_grad_weight = (grad[:, :, :3, :] * x_hat[:, :, :3, :]).sum(dim=(0, 2, 3))
         expected_grad_bias = grad[:, :, :3, :].sum(dim=(0, 2, 3))
 
-    torch.testing.assert_close(streaming.weight.grad, expected_grad_weight)
-    torch.testing.assert_close(streaming.bias.grad, expected_grad_bias)
+    torch.testing.assert_close(streaming.norm.weight.grad, expected_grad_weight)
+    torch.testing.assert_close(streaming.norm.bias.grad, expected_grad_bias)
 
 
 def test_streaming_channel_layer_norm_without_affine_backpropagates_input():
@@ -337,8 +338,9 @@ def test_streaming_channel_layer_norm_without_affine_backpropagates_input():
     module(x).backward(grad)
     streaming(x_streaming).backward(grad)
 
-    assert streaming.weight is None
-    assert streaming.bias is None
+    assert streaming.norm.weight is None
+    assert streaming.norm.bias is None
+    assert dict(streaming.named_parameters()) == {}
     torch.testing.assert_close(x_streaming.grad, x.grad)
 
 
@@ -425,12 +427,12 @@ def _assert_channel_norm_scnn_parity(elementwise_affine: bool):
     torch.testing.assert_close(stream_module.downstream.bias.grad, reference.downstream.bias.grad, atol=1e-5, rtol=1e-4)
 
     if elementwise_affine:
-        torch.testing.assert_close(stream_module.norm.weight.grad, reference.norm.norm.weight.grad, atol=1e-5, rtol=1e-4)
-        torch.testing.assert_close(stream_module.norm.bias.grad, reference.norm.norm.bias.grad, atol=1e-5, rtol=1e-4)
+        torch.testing.assert_close(stream_module.norm.norm.weight.grad, reference.norm.norm.weight.grad, atol=1e-5, rtol=1e-4)
+        torch.testing.assert_close(stream_module.norm.norm.bias.grad, reference.norm.norm.bias.grad, atol=1e-5, rtol=1e-4)
     else:
-        assert stream_module.norm.weight is None
-        assert stream_module.norm.bias is None
-        assert not any(name.startswith("norm.") for name, _ in stream_module.named_parameters())
+        assert stream_module.norm.norm.weight is None
+        assert stream_module.norm.norm.bias is None
+        assert not any(name.startswith("norm.norm.") for name, _ in stream_module.named_parameters())
 
 
 def test_scnn_channel_layer_norm_forward_backward_parity():


### PR DESCRIPTION
### Motivation
- Ensure affine parameters of the streaming LayerNorm are owned by an internal `nn.LayerNorm` so they are reported as `norm.weight` / `norm.bias` by `named_parameters()` instead of top-level `weight`/`bias`.
- Ensure the custom autograd function receives `weight`/`bias` only when `elementwise_affine=True` and receives `None`/`None` otherwise, while keeping the autograd return-order unchanged.
- Guarantee gradients flow back to the internal `norm.weight` and `norm.bias` when affine is enabled and no affine parameters exist when disabled.

### Description
- Replace manual top-level `weight`/`bias` parameter registration with an internal `self.norm = nn.LayerNorm(...)` and expose `weight`/`bias` as read-only properties returning `self.norm.weight`/`self.norm.bias`.
- In `forward()`, pass `self.norm.weight` and `self.norm.bias` into the custom autograd `channel_layer_norm` only when `self.elementwise_affine` is `True`, otherwise pass `None` for both.
- Preserve the custom autograd function parameter and gradient return ordering so backward compatibility is kept.
- Update tests in `tests/test_streaminglayernorm.py` to assert `named_parameters()` reports `norm.weight`/`norm.bias`, and to check gradients and parameter visibility on `streaming.norm.weight` / `streaming.norm.bias` (and absence of params when `elementwise_affine=False`).

### Testing
- Ran `pytest tests/test_streaminglayernorm.py -q` which completed successfully with all tests passing (`24 passed, 1 warning`).
- Executed a small automated smoke script that validated `list(named_parameters()) == [("norm.weight", ...), ("norm.bias", ...)]` for the affine case, verified gradients arrive on `norm.weight`/`norm.bias`, and that no parameters are reported when `elementwise_affine=False`; the checks passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2aa11902fc83308267535e4507557c)