### PR TITLE
Account for bilinear Upsample border loss in forward statistics

### DIFF
--- a/lightstream/core/scnn/scnn.py
+++ b/lightstream/core/scnn/scnn.py
@@ -1686,6 +1686,21 @@ class StreamingCNN(torch.nn.Module):
             # make its actual output all zeros, so derive validity from its input.
             lost = self._non_max_border_amount(inpt[0] if is_pointwise_norm else output)
 
+            if (
+                is_upsample
+                and module.mode == "bilinear"
+                and module.align_corners in (None, False)
+                and module.scale_factor is not None
+            ):
+                scale_h, scale_w = self._resolve_upsample_scale(module, inpt, output)
+                if float(scale_h).is_integer() and float(scale_w).is_integer():
+                    loss_h = math.ceil(scale_h / 2.0 - 0.5)
+                    loss_w = math.ceil(scale_w / 2.0 - 0.5)
+                    lost.top += loss_h
+                    lost.bottom += loss_h
+                    lost.left += loss_w
+                    lost.right += loss_w
+
             # Make output between 0-1 again, so the values do not explode
             output.fill_(0)
             output[

--- a/tests/test_streamingupsample.py
+++ b/tests/test_streamingupsample.py
@@ -2,6 +2,7 @@ import pytest
 import torch
 
 from lightstream.core.constructor import StreamingConstructor
+from lightstream.core.scnn.scnn import StreamingCNN
 from lightstream.core.scnn.streamingupsample import StreamingUpsample2d
 
 
@@ -25,3 +26,61 @@ def test_constructor_keeps_upsample_modules():
     model = torch.nn.Sequential(torch.nn.Conv2d(3, 3, 1), torch.nn.Upsample(scale_factor=2.0, mode="nearest"))
     constructor = StreamingConstructor(model, tile_size=32, verbose=False, statistics_on_cpu=True)
     assert torch.nn.Upsample in constructor.keep_modules
+
+
+def test_bilinear_upsample_statistics_add_explicit_border_loss():
+    scnn = StreamingCNN.__new__(StreamingCNN)
+    scnn.eps = 1e-5
+    scnn.dtype = torch.float32
+    scnn.device = torch.device("cpu")
+    scnn._saved_tensors = {}
+    scnn._module_stats = {}
+    scnn._print_verbose = lambda *args, **kwargs: None
+
+    module = torch.nn.Upsample(scale_factor=2, mode="bilinear", align_corners=False)
+    inpt = torch.ones(1, 3, 5, 7)
+
+    with torch.no_grad():
+        output = module(inpt)
+        scnn._forward_gather_statistics_hook(module, (inpt,), output)
+
+    lost = scnn._module_stats[module]["lost"]
+    assert (lost.top, lost.bottom, lost.left, lost.right) == (1, 1, 1, 1)
+    assert torch.all(output[:, :, :1, :] == 0)
+    assert torch.all(output[:, :, -1:, :] == 0)
+    assert torch.all(output[:, :, :, :1] == 0)
+    assert torch.all(output[:, :, :, -1:] == 0)
+    assert torch.all(output[:, :, 1:-1, 1:-1] == 1)
+
+
+@pytest.mark.parametrize(
+    ("scale_factor", "expected_loss"),
+    [
+        (2, 1),
+        (4, 2),
+        (8, 4),
+    ],
+)
+def test_bilinear_upsample_statistics_scale_factor_loss_formula(scale_factor, expected_loss):
+    scnn = StreamingCNN.__new__(StreamingCNN)
+    scnn.eps = 1e-5
+    scnn.dtype = torch.float32
+    scnn.device = torch.device("cpu")
+    scnn._saved_tensors = {}
+    scnn._module_stats = {}
+    scnn._print_verbose = lambda *args, **kwargs: None
+
+    module = torch.nn.Upsample(scale_factor=scale_factor, mode="bilinear", align_corners=False)
+    inpt = torch.ones(1, 3, 5, 5)
+
+    with torch.no_grad():
+        output = module(inpt)
+        scnn._forward_gather_statistics_hook(module, (inpt,), output)
+
+    lost = scnn._module_stats[module]["lost"]
+    assert (lost.top, lost.bottom, lost.left, lost.right) == (
+        expected_loss,
+        expected_loss,
+        expected_loss,
+        expected_loss,
+    )


### PR DESCRIPTION
### Motivation
- Upsampling with bilinear interpolation and integer `scale_factor` introduces interior seam loss that must be visible to downstream conv statistics when gathering no-grad forward statistics. 
- The forward statistics hook currently only infers lost borders from outputs and may miss the explicit seam loss contributed by integer-factor bilinear `torch.nn.Upsample` modules.

### Description
- Update `StreamingCNN._forward_gather_statistics_hook` in `lightstream/core/scnn/scnn.py` to detect supported bilinear `torch.nn.Upsample` modules using `isinstance(module, torch.nn.Upsample)`, `module.mode == "bilinear"`, `module.align_corners in (None, False)`, and `module.scale_factor is not None` and resolve scale with `self._resolve_upsample_scale(module, inpt, output)`.
- For integer scale factors compute explicit seam loss with `loss_h = math.ceil(scale_h / 2.0 - 0.5)` and `loss_w = math.ceil(scale_w / 2.0 - 0.5)` and add to the inferred `lost` (`lost.top/bottom/left/right`).
- Preserve the existing behavior that rewrites the hook output to a 0/1 valid-region mask after updating `lost`, so downstream convolution statistics see the propagated seam loss, while keeping final trimming side-aware (image edges remain untrimmed, interior seams are trimmed).
- Add regression tests in `tests/test_streamingupsample.py` that validate the rewritten upsample mask for `scale_factor=2` and parameterized assertions for `scale_factor` values `2`, `4`, and `8` using the same loss formula.

### Testing
- Ran `python -m py_compile lightstream/core/scnn/scnn.py tests/test_streamingupsample.py` to validate syntax, which succeeded.
- Executed direct hook regression checks via a small Python script that instantiates `StreamingCNN` and calls `_forward_gather_statistics_hook` for `scale_factor` values `2`, `4`, and `8`, and those checks passed (explicit upsample statistics OK).
- Attempted `pytest -q tests/test_streamingupsample.py` but collection failed in this environment due to missing `numpy` (environment limitation), so full pytest run could not complete here.
- Removed any stale `testnet_tile_cache_*` files before re-testing; attempted segment testnet cache recompute was blocked by the environment lacking an NVIDIA driver (no GPU available).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2c60aba920833087f585b5a78ac11a)