### PR TITLE
Derive internal tile alignment from all downsampling modules

### DIFF
--- a/lightstream/core/scnn/scnn.py
+++ b/lightstream/core/scnn/scnn.py
@@ -493,26 +493,47 @@ class StreamingCNN(torch.nn.Module):
 
         return max(1, min(candidates_h)), max(1, min(candidates_w))
 
+    def _module_alignment_stats(self, module):
+        """Return module input-space stride stats used for tile-start alignment."""
+        stats = self._module_stats.get(module, {})
+
+        stride = stats.get("stride")
+        if stride is None:
+            stride = getattr(module, "stride", 1)
+            if stride is None:
+                stride = getattr(module, "kernel_size", 1)
+        stride = torch.as_tensor(_triple(stride), dtype=torch.long)
+
+        output_stride = stats.get("output_stride")
+        if output_stride is None:
+            output_stride = getattr(module, "output_stride", torch.tensor([1, 1, 1]))
+        output_stride = torch.as_tensor(_triple(output_stride), dtype=torch.long)
+
+        return output_stride, stride
+
     def _compute_internal_alignment(self):
-        """Compute input-space alignment constraints from internal streamed layers.
+        """Compute input-space alignment constraints from internal downsampling layers.
 
         When output heads are upsampled back to stride-1, alignment based only on
         head output stride becomes 1 and can lose the internal phase constraints
-        required by earlier strided conv layers.
+        required by earlier strided convolutions and pooling layers.
         """
 
         align_h = 1
         align_w = 1
-        for mod in self.stream_module.modules():
-            if not isinstance(mod, StreamingConv2d):
+        alignment_modules = (StreamingConv2d, torch.nn.Conv2d, torch.nn.MaxPool2d, torch.nn.AvgPool2d)
+        for module in self.stream_module.modules():
+            if not isinstance(module, alignment_modules):
                 continue
 
-            stride = _triple(mod.stride)
-            output_stride = getattr(mod, "output_stride", torch.tensor([1, 1, 1]))
-            eff_h = int(output_stride[1]) * int(stride[1])
-            eff_w = int(output_stride[2]) * int(stride[2])
-            align_h = math.lcm(align_h, max(1, eff_h))
-            align_w = math.lcm(align_w, max(1, eff_w))
+            output_stride, stride = self._module_alignment_stats(module)
+            if int(stride[1]) <= 1 and int(stride[2]) <= 1:
+                continue
+
+            effective_h = int(output_stride[1]) * int(stride[1])
+            effective_w = int(output_stride[2]) * int(stride[2])
+            align_h = math.lcm(align_h, max(1, effective_h))
+            align_w = math.lcm(align_w, max(1, effective_w))
 
         return align_h, align_w
 
@@ -783,6 +804,12 @@ class StreamingCNN(torch.nn.Module):
             1,
             valid_output_widths[0] * int(self._output_stride_per_output[0][2]),
         )
+
+        internal_align_h, internal_align_w = self._compute_internal_alignment()
+        align_h = math.lcm(int(self._output_stride_per_output[0][1]), internal_align_h)
+        align_w = math.lcm(int(self._output_stride_per_output[0][2]), internal_align_w)
+        valid_input_height = max(align_h, (valid_input_height // align_h) * align_h)
+        valid_input_width = max(align_w, (valid_input_width // align_w) * align_w)
         return valid_input_height, valid_input_width
 
     def _compute_tile_grid(self, image_height, image_width, tile_height, tile_width, valid_input_height, valid_input_width):
@@ -817,6 +844,28 @@ class StreamingCNN(torch.nn.Module):
                 input_y = input_y if not sides.top else 0
                 input_x = input_x if not sides.left else 0
                 yield int(input_y), int(input_x), sides
+
+    def _log_and_validate_tile_start(self, input_y, input_x, sides, internal_alignment):
+        """Log tile starts and verify non-edge starts keep internal sampling phase."""
+        align_h, align_w = internal_alignment
+        logger.debug(
+            "Forward tile start: y=%s, x=%s, sides=%s, internal_alignment=(%s, %s)",
+            input_y,
+            input_x,
+            sides,
+            align_h,
+            align_w,
+        )
+        if not sides.bottom:
+            assert input_y % align_h == 0, (
+                f"Non-bottom-edge tile y-start {input_y} is not a multiple of "
+                f"internal alignment {align_h}"
+            )
+        if not sides.right:
+            assert input_x % align_w == 0, (
+                f"Non-right-edge tile x-start {input_x} is not a multiple of "
+                f"internal alignment {align_w}"
+            )
 
     def _prepare_forward_outputs(self, image, output_heights, output_widths, result_device):
         outputs = [None] * len(self._tile_output_shapes)
@@ -1230,13 +1279,15 @@ class StreamingCNN(torch.nn.Module):
             self.saliency_map = torch.zeros(image.shape, dtype=self.dtype, device="cpu")
 
         self._last_forward_tiles = []
+        internal_alignment = self._compute_internal_alignment()
         logger.debug(
-            "Forward tiling step: valid_input_height=%s, valid_input_width=%s, tiles=%sx%s=%s",
+            "Forward tiling step: valid_input_height=%s, valid_input_width=%s, tiles=%sx%s=%s, internal_alignment=%s",
             valid_input_height,
             valid_input_width,
             n_rows,
             n_cols,
             n_rows * n_cols,
+            internal_alignment,
         )
 
         result_device = torch.device("cpu") if result_on_cpu else self.device
@@ -1275,6 +1326,7 @@ class StreamingCNN(torch.nn.Module):
             ):
                 last_sides = sides
                 self._last_forward_tiles.append((input_y, input_x, sides))
+                self._log_and_validate_tile_start(input_y, input_x, sides, internal_alignment)
                 tile, tile_outputs = self._run_forward_tile(forward_ctx.image, input_y, input_x, forward_ctx.tile_height, forward_ctx.tile_width)
 
                 self._resolve_reducer_head_map(tile_outputs)

--- a/tests/test_scnn.py
+++ b/tests/test_scnn.py
@@ -3,6 +3,8 @@ import torch.nn as nn
 import pytest
 
 from lightstream.core.constructor import StreamingConstructor
+from lightstream.core.scnn.scnn import StreamingCNN
+from lightstream.models.testnet.segment import StreamingTestNet
 
 from lightstream.core.reducer import (
     BaseReducer,
@@ -876,3 +878,100 @@ def test_scnn_fused_attention_gem_internal_payload_count_shrinks_to_two():
         streamed = scnn.forward(image, mask=mask)
 
     assert torch.allclose(streamed, expected, atol=1e-5, rtol=1e-4)
+
+
+def _assert_non_edge_starts_match_alignment(scnn: StreamingCNN) -> None:
+    align_h, align_w = scnn._compute_internal_alignment()
+    assert align_h > 1
+    assert align_w > 1
+    for input_y, input_x, sides in scnn._last_forward_tiles:
+        if not sides.bottom:
+            assert input_y % align_h == 0
+        if not sides.right:
+            assert input_x % align_w == 0
+
+
+def test_internal_alignment_includes_pools_and_streaming_convs_for_testnet_segment_model():
+    torch.manual_seed(123)
+    model = StreamingTestNet.create_model().eval()
+    scnn = StreamingCNN(
+        model,
+        tile_shape=(1, 3, 128, 128),
+        deterministic=True,
+        copy_to_gpu=False,
+        statistics_on_cpu=True,
+        normalize_on_gpu=False,
+        mean=[0, 0, 0],
+        std=[1, 1, 1],
+    )
+
+    alignment = scnn._compute_internal_alignment()
+    assert alignment == (8, 8)
+
+    valid_output_heights, valid_output_widths = scnn._compute_valid_output_sizes()
+    valid_input_height, valid_input_width = scnn._compute_valid_input_step(
+        valid_output_heights,
+        valid_output_widths,
+    )
+    assert valid_input_height % alignment[0] == 0
+    assert valid_input_width % alignment[1] == 0
+
+    image = torch.rand(1, 3, 224, 224)
+    scnn.forward(image)
+    _assert_non_edge_starts_match_alignment(scnn)
+
+
+class ResNetUpsamplingDecoder(nn.Module):
+    def __init__(self):
+        super().__init__()
+        from torchvision.models import resnet18
+
+        resnet = resnet18(weights=None)
+        self.encoder = nn.Sequential(
+            resnet.conv1,
+            resnet.bn1,
+            resnet.relu,
+            resnet.maxpool,
+            resnet.layer1,
+            resnet.layer2,
+        )
+        self.decoder = nn.Sequential(
+            nn.Upsample(scale_factor=8, mode="bilinear", align_corners=False),
+            nn.Conv2d(128, 8, kernel_size=3, padding=1),
+            nn.ReLU(),
+            nn.Conv2d(8, 1, kernel_size=1),
+        )
+
+    def forward(self, x):
+        return self.decoder(self.encoder(x))
+
+
+def test_internal_alignment_keeps_resnet_encoder_upsampling_decoder_tile_phase():
+    torch.manual_seed(456)
+    model = ResNetUpsamplingDecoder().eval()
+    scnn = StreamingCNN(
+        model,
+        tile_shape=(1, 3, 128, 128),
+        deterministic=True,
+        copy_to_gpu=False,
+        statistics_on_cpu=True,
+        normalize_on_gpu=False,
+        mean=[0, 0, 0],
+        std=[1, 1, 1],
+    )
+
+    alignment = scnn._compute_internal_alignment()
+    assert alignment[0] >= 8
+    assert alignment[1] >= 8
+
+    valid_output_heights, valid_output_widths = scnn._compute_valid_output_sizes()
+    valid_input_height, valid_input_width = scnn._compute_valid_input_step(
+        valid_output_heights,
+        valid_output_widths,
+    )
+    assert valid_input_height % alignment[0] == 0
+    assert valid_input_width % alignment[1] == 0
+
+    image = torch.rand(1, 3, 224, 224)
+    scnn.forward(image)
+    _assert_non_edge_starts_match_alignment(scnn)


### PR DESCRIPTION
### Motivation
- Internal tile-start alignment must respect the sampling phase of any module that changes spatial sampling, not only `StreamingConv2d`/`MaxPool2d`, to avoid misaligned tiles when later heads are upsampled to stride-1.
- Use stored per-module statistics (`output_stride`, `stride`) when available so alignment remains correct for modules that were observed during the statistics-gathering pass but not converted.

### Description
- Added helper `_module_alignment_stats()` to read per-module `stride` and `output_stride` from `self._module_stats` or fall back to the module attributes and normalize to tensors.
- Extended `_compute_internal_alignment()` to consider `(StreamingConv2d, torch.nn.Conv2d, torch.nn.MaxPool2d, torch.nn.AvgPool2d)` and compute each module’s effective input-space phase (`effective_h = output_stride[1] * stride[1]`, `effective_w = output_stride[2] * stride[2]`) and accumulate alignment via `math.lcm`.
- Adjusted single-output `_compute_valid_input_step()` to round the chosen valid input step down to a multiple of the combined output/internal alignment so tile starts honor internal phase constraints.
- Added `_log_and_validate_tile_start()` and integrated it into the forward loop to log tile starts and assert that all non-edge tile starts are multiples of the computed internal alignment.
- Added tests exercising the behavior: `test_internal_alignment_includes_pools_and_streaming_convs_for_testnet_segment_model` (custom testnet) and `test_internal_alignment_keeps_resnet_encoder_upsampling_decoder_tile_phase` (ResNet encoder + upsampling decoder) in `tests/test_scnn.py`.

### Testing
- Ran `python -m py_compile lightstream/core/scnn/scnn.py tests/test_scnn.py` which succeeded.
- Ran static checks (`git diff --check`) with no issues reported.
- Attempted to run the new pytest cases: `tests/test_scnn.py::test_internal_alignment_includes_pools_and_streaming_convs_for_testnet_segment_model` and `tests/test_scnn.py::test_internal_alignment_keeps_resnet_encoder_upsampling_decoder_tile_phase`, but `pytest` failed to import due to a missing `numpy` dependency in the execution environment, so the tests could not be executed end-to-end; attempts to install `numpy` from the environment were blocked by network/package index restrictions.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2c70fb33d48330b903f3e4f62d5e15)