### PR TITLE
Propagate pre/post upsample stride metadata to StreamingUpsample2d and deduplicate grad_input using pre-stride

### DIFF
--- a/lightstream/core/scnn/scnn.py
+++ b/lightstream/core/scnn/scnn.py
@@ -579,9 +579,14 @@ class StreamingCNN(torch.nn.Module):
         elif isinstance(module, torch.nn.Upsample):
             mod = StreamingUpsample2d.from_torch_upsample(module)
             if module in self._module_stats:
-                mod.grad_lost = self._module_stats[module].get("grad_lost", Lost(0, 0, 0, 0))
-                mod.output_stride = self._module_stats[module].get("output_stride", torch.tensor([1, 1, 1]))
-                self._module_stats[mod] = self._module_stats[module]
+                stats = self._module_stats[module]
+                mod.grad_lost = stats.get("grad_lost", Lost(0, 0, 0, 0))
+                mod.pre_upsample_output_stride = stats.get("pre_upsample_output_stride", torch.tensor([1, 1, 1]))
+                mod.output_stride = stats.get("output_stride", torch.tensor([1, 1, 1]))
+                mod.post_upsample_output_stride = stats.get("post_upsample_output_stride", mod.output_stride)
+                if "scale_factor_hw" in stats:
+                    mod.scale_factor_hw = stats["scale_factor_hw"]
+                self._module_stats[mod] = stats
                 del self._module_stats[module]
         elif isinstance(module, ChannelLayerNorm):
             mod = StreamingChannelLayerNorm.from_channel_layer_norm(module)
@@ -624,7 +629,11 @@ class StreamingCNN(torch.nn.Module):
             if module not in self._module_stats:
                 stats = {}
                 stats["grad_lost"] = module.grad_lost
+                stats["pre_upsample_output_stride"] = module.pre_upsample_output_stride
                 stats["output_stride"] = module.output_stride
+                stats["post_upsample_output_stride"] = getattr(module, "post_upsample_output_stride", module.output_stride)
+                if hasattr(module, "scale_factor_hw"):
+                    stats["scale_factor_hw"] = module.scale_factor_hw
                 self._module_stats[mod] = stats
             else:
                 self._module_stats[mod] = self._module_stats[module]
@@ -1765,8 +1774,10 @@ class StreamingCNN(torch.nn.Module):
                 prev_output_stride = torch.tensor([1, 1, 1])
 
             if is_upsample:
+                pre_upsample_output_stride = prev_output_stride.clone().detach()
                 scale_h, scale_w = self._resolve_upsample_scale(module, inpt, output)
-                output_stride = self._update_output_stride_for_upsample(prev_output_stride, scale_h, scale_w)
+                output_stride = self._update_output_stride_for_upsample(pre_upsample_output_stride, scale_h, scale_w)
+                module_stats["pre_upsample_output_stride"] = pre_upsample_output_stride
                 module_stats["scale_factor_hw"] = (scale_h, scale_w)
             else:
                 output_stride = prev_output_stride
@@ -1774,6 +1785,8 @@ class StreamingCNN(torch.nn.Module):
             output_stride = output_stride.clone().detach()
             output_stride[0] = 1
             module_stats["output_stride"] = output_stride
+            if is_upsample:
+                module_stats["post_upsample_output_stride"] = output_stride
             self._stats_per_grad_fn[output.grad_fn] = module_stats
             self._module_stats[module] = module_stats
 

--- a/lightstream/core/scnn/streamingupsample.py
+++ b/lightstream/core/scnn/streamingupsample.py
@@ -23,6 +23,7 @@ class StreamingUpsample2dF(torch.autograd.Function):
         recompute_scale_factor,
         grad_lost,
         seen_indices,
+        pre_upsample_output_stride,
         output_stride,
         input_loc,
     ):
@@ -34,6 +35,7 @@ class StreamingUpsample2dF(torch.autograd.Function):
         ctx.recompute_scale_factor = recompute_scale_factor
         ctx.grad_lost = grad_lost
         ctx.seen_indices = seen_indices
+        ctx.pre_upsample_output_stride = pre_upsample_output_stride
         ctx.output_stride = output_stride
         ctx.input_loc = input_loc
         return F.interpolate(
@@ -58,27 +60,6 @@ class StreamingUpsample2dF(torch.autograd.Function):
         lost_left = grad_lost.left if not sides.left else 0
         lost_right = grad_lost.right if not sides.right else 0
 
-        valid_grad = grad_output[:, :, lost_top : grad_output.shape[H_DIM] - lost_bottom, lost_left : grad_output.shape[W_DIM] - lost_right]
-
-        input_loc = ctx.input_loc
-        # `ctx.output_stride` already represents this module output's stride
-        # in input-image coordinates. Using this directly keeps data_loc aligned
-        # for mixed upsample factors (e.g. 2/4/8 heads).
-        data_loc_y = int(input_loc.y // int(ctx.output_stride[1])) + lost_top
-        data_loc_x = int(input_loc.x // int(ctx.output_stride[2])) + lost_left
-        data_loc = Box(data_loc_y, 0, data_loc_x, 0, input_loc.sides)
-
-        new_output_box, updated_total_indices = _new_value_indices(valid_grad.shape, data_loc, seen_indices)
-
-        # Keep state monotonic for debugging/introspection, but do not deduplicate
-        # gradients at upsample level. Deduplication for parameter gradients is handled
-        # by downstream streaming conv layers.
-        seen_indices.y = updated_total_indices.y
-        seen_indices.height = updated_total_indices.height
-        seen_indices.x = updated_total_indices.x
-        seen_indices.width = updated_total_indices.width
-        seen_indices.sides = updated_total_indices.sides
-
         grad_for_interp = grad_output.clone()
         grad_for_interp[:, :, :lost_top, :] = 0
         if lost_bottom > 0:
@@ -99,10 +80,33 @@ class StreamingUpsample2dF(torch.autograd.Function):
                     recompute_scale_factor=ctx.recompute_scale_factor,
                 )
                 grad_in = torch.autograd.grad(out, inpt_grad, grad_for_interp, retain_graph=False, allow_unused=False)[0]
+
+            input_loc = ctx.input_loc
+            pre_upsample_output_stride = ctx.pre_upsample_output_stride
+            data_loc_y = int(input_loc.y // int(pre_upsample_output_stride[1]))
+            data_loc_x = int(input_loc.x // int(pre_upsample_output_stride[2]))
+            data_loc = Box(data_loc_y, 0, data_loc_x, 0, input_loc.sides)
+
+            new_input_box, updated_total_indices = _new_value_indices(grad_in.shape, data_loc, seen_indices)
+
+            seen_indices.y = updated_total_indices.y
+            seen_indices.height = updated_total_indices.height
+            seen_indices.x = updated_total_indices.x
+            seen_indices.width = updated_total_indices.width
+            seen_indices.sides = updated_total_indices.sides
+
+            deduplicated_grad_in = torch.zeros_like(grad_in)
+            if new_input_box.height > 0 and new_input_box.width > 0:
+                y0 = new_input_box.y
+                y1 = y0 + new_input_box.height
+                x0 = new_input_box.x
+                x1 = x0 + new_input_box.width
+                deduplicated_grad_in[:, :, y0:y1, x0:x1] = grad_in[:, :, y0:y1, x0:x1]
+            grad_in = deduplicated_grad_in
         else:
             grad_in = None
 
-        return grad_in, None, None, None, None, None, None, None, None, None
+        return grad_in, None, None, None, None, None, None, None, None, None, None
 
 
 upsample2d = StreamingUpsample2dF.apply
@@ -137,7 +141,9 @@ class StreamingUpsample2d(nn.Module):
         self.recompute_scale_factor = recompute_scale_factor
 
         self.grad_lost = Lost(0, 0, 0, 0)
+        self.pre_upsample_output_stride = torch.tensor([1, 1, 1])
         self.output_stride = torch.tensor([1, 1, 1])
+        self.post_upsample_output_stride = self.output_stride
         self.reset()
 
     def reset(self):
@@ -154,6 +160,7 @@ class StreamingUpsample2d(nn.Module):
             self.recompute_scale_factor,
             self.grad_lost,
             self.seen_indices,
+            self.pre_upsample_output_stride,
             self.output_stride,
             self.input_loc,
         )

--- a/tests/test_streamingupsample.py
+++ b/tests/test_streamingupsample.py
@@ -4,6 +4,7 @@ import torch
 from lightstream.core.constructor import StreamingConstructor
 from lightstream.core.scnn.scnn import StreamingCNN
 from lightstream.core.scnn.streamingupsample import StreamingUpsample2d
+from lightstream.core.scnn.utils import Box, Sides
 
 
 def test_streaming_upsample_from_torch_matches_interpolate():
@@ -84,3 +85,57 @@ def test_bilinear_upsample_statistics_scale_factor_loss_formula(scale_factor, ex
         expected_loss,
         expected_loss,
     )
+
+
+def test_upsample_statistics_preserve_pre_and_post_stride_metadata():
+    scnn = StreamingCNN.__new__(StreamingCNN)
+    scnn._module_stats = {}
+    scnn._saved_tensors = {}
+    scnn._stats_per_grad_fn = {}
+    scnn.eps = 1e-5
+    scnn.dtype = torch.float32
+    scnn.device = torch.device("cpu")
+    scnn._print_verbose = lambda *args, **kwargs: None
+
+    module = torch.nn.Upsample(scale_factor=2.0, mode="nearest")
+    inpt = torch.ones(1, 3, 5, 5, requires_grad=True)
+
+    with torch.no_grad():
+        scnn._forward_gather_statistics_hook(module, (inpt,), module(inpt))
+
+    scnn._prev_stats = lambda _output: {
+        "output_stride": torch.tensor([1, 4, 8]),
+        "stride": torch.tensor([1, 2, 1]),
+    }
+    output = module(inpt)
+    scnn._forward_gather_statistics_hook(module, (inpt,), output)
+
+    stats = scnn._module_stats[module]
+    torch.testing.assert_close(stats["pre_upsample_output_stride"], torch.tensor([1, 8, 8]))
+    torch.testing.assert_close(stats["output_stride"], torch.tensor([1, 4, 4]))
+    torch.testing.assert_close(stats["post_upsample_output_stride"], torch.tensor([1, 4, 4]))
+    assert stats["scale_factor_hw"] == (2.0, 2.0)
+
+    converted = scnn._convert_modules_for_streaming(module)
+    torch.testing.assert_close(converted.pre_upsample_output_stride, torch.tensor([1, 8, 8]))
+    torch.testing.assert_close(converted.output_stride, torch.tensor([1, 4, 4]))
+    torch.testing.assert_close(converted.post_upsample_output_stride, torch.tensor([1, 4, 4]))
+    assert converted.scale_factor_hw == (2.0, 2.0)
+
+
+def test_streaming_upsample_backward_deduplicates_grad_input_with_pre_stride():
+    module = StreamingUpsample2d(scale_factor=2.0, mode="nearest")
+    module.pre_upsample_output_stride = torch.tensor([1, 2, 2])
+    module.output_stride = torch.tensor([1, 1, 1])
+
+    x = torch.ones(1, 1, 2, 2, requires_grad=True)
+    module.input_loc = Box(0, 0, 0, 0, Sides(left=True, top=True, right=False, bottom=False))
+    module(x).sum().backward()
+    torch.testing.assert_close(x.grad, torch.full_like(x, 4.0))
+
+    x.grad = None
+    module.input_loc = Box(0, 0, 2, 0, Sides(left=False, top=True, right=False, bottom=False))
+    module(x).sum().backward()
+
+    expected = torch.tensor([[[[0.0, 4.0], [0.0, 4.0]]]])
+    torch.testing.assert_close(x.grad, expected)


### PR DESCRIPTION
### Motivation
- Upsample layers need both pre- and post- upsample stride coordinate systems recorded so streaming modules can align locations consistently across mixed upsample factors and correctly deduplicate input gradients during backward.

### Description
- In `lightstream/core/scnn/scnn.py` the forward statistics hook now captures and stores `pre_upsample_output_stride`, `post_upsample_output_stride` (as `output_stride` after upsample), and `scale_factor_hw` for Upsample modules, and records `pre_upsample_output_stride` before calling `_update_output_stride_for_upsample`.
- `_convert_modules_for_streaming` and `_reset_converted_modules` copy and restore the new metadata (`pre_upsample_output_stride`, `post_upsample_output_stride`, `scale_factor_hw`, and `grad_lost`) when replacing `torch.nn.Upsample` with `StreamingUpsample2d` and back.
- In `lightstream/core/scnn/streamingupsample.py` `StreamingUpsample2d` now initializes `self.pre_upsample_output_stride = torch.tensor([1, 1, 1])` and `self.post_upsample_output_stride = self.output_stride`, forwards the `pre_upsample_output_stride` into `StreamingUpsample2dF.apply`, and stores it on the autograd context as `ctx.pre_upsample_output_stride`.
- `StreamingUpsample2dF.backward` uses `pre_upsample_output_stride` to compute a data location in input-space and deduplicate the returned `grad_in` (only returning the new portion of the input gradient), while preserving streaming `seen_indices` state.
- Added/updated tests in `tests/test_streamingupsample.py` to assert metadata preservation and that backward deduplication using `pre_upsample_output_stride` behaves as expected.

### Testing
- Ran `python -m compileall` on the modified modules and test file, which compiled successfully.
- Performed targeted Python smoke tests that exercise metadata propagation and the `StreamingUpsample2d` backward deduplication (ad-hoc scripts invoking the changed code), and those smoke checks passed (`ok`).
- Attempted to run `pytest -q tests/test_streamingupsample.py` but full pytest collection was blocked by the environment missing a system `numpy` installation; the failures were due to the test environment rather than the introduced changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2c8ffb1a54833095775ca29b51b081)