### PR TITLE
Deduplicate streaming upsample gradients

### DIFF
--- a/lightstream/core/scnn/scnn.py
+++ b/lightstream/core/scnn/scnn.py
@@ -579,8 +579,22 @@ class StreamingCNN(torch.nn.Module):
         elif isinstance(module, torch.nn.Upsample):
             mod = StreamingUpsample2d.from_torch_upsample(module)
             if module in self._module_stats:
-                mod.grad_lost = self._module_stats[module].get("grad_lost", Lost(0, 0, 0, 0))
-                mod.output_stride = self._module_stats[module].get("output_stride", torch.tensor([1, 1, 1]))
+                stats = self._module_stats[module]
+                mod.grad_lost = stats.get("grad_lost", Lost(0, 0, 0, 0))
+                mod.output_stride = stats.get("output_stride", torch.tensor([1, 1, 1]))
+                mod.pre_upsample_output_stride = stats.get("pre_upsample_output_stride")
+                if mod.pre_upsample_output_stride is None:
+                    scale_h, scale_w = stats.get("scale_factor_hw", (mod.scale_factor, mod.scale_factor))
+                    if isinstance(scale_h, tuple):
+                        scale_h, scale_w = scale_h[-2], scale_h[-1]
+                    if scale_h is None or scale_w is None:
+                        scale_h, scale_w = 1.0, 1.0
+                    mod.pre_upsample_output_stride = mod.output_stride.clone().detach().to(torch.float32)
+                    mod.pre_upsample_output_stride[1] *= float(scale_h)
+                    mod.pre_upsample_output_stride[2] *= float(scale_w)
+                    mod.pre_upsample_output_stride = torch.round(mod.pre_upsample_output_stride).to(torch.long)
+                    mod.pre_upsample_output_stride[0] = 1
+                    stats["pre_upsample_output_stride"] = mod.pre_upsample_output_stride
                 self._module_stats[mod] = self._module_stats[module]
                 del self._module_stats[module]
         elif isinstance(module, ChannelLayerNorm):
@@ -625,6 +639,7 @@ class StreamingCNN(torch.nn.Module):
                 stats = {}
                 stats["grad_lost"] = module.grad_lost
                 stats["output_stride"] = module.output_stride
+                stats["pre_upsample_output_stride"] = module.pre_upsample_output_stride
                 self._module_stats[mod] = stats
             else:
                 self._module_stats[mod] = self._module_stats[module]
@@ -1767,7 +1782,13 @@ class StreamingCNN(torch.nn.Module):
             if is_upsample:
                 scale_h, scale_w = self._resolve_upsample_scale(module, inpt, output)
                 output_stride = self._update_output_stride_for_upsample(prev_output_stride, scale_h, scale_w)
+                pre_upsample_output_stride = output_stride.clone().detach().to(torch.float32)
+                pre_upsample_output_stride[1] *= scale_h
+                pre_upsample_output_stride[2] *= scale_w
+                pre_upsample_output_stride = torch.round(pre_upsample_output_stride).to(torch.long)
+                pre_upsample_output_stride[0] = 1
                 module_stats["scale_factor_hw"] = (scale_h, scale_w)
+                module_stats["pre_upsample_output_stride"] = pre_upsample_output_stride
             else:
                 output_stride = prev_output_stride
 

--- a/lightstream/core/scnn/streamingupsample.py
+++ b/lightstream/core/scnn/streamingupsample.py
@@ -24,6 +24,7 @@ class StreamingUpsample2dF(torch.autograd.Function):
         grad_lost,
         seen_indices,
         output_stride,
+        pre_upsample_output_stride,
         input_loc,
     ):
         ctx.save_for_backward(inpt)
@@ -35,6 +36,7 @@ class StreamingUpsample2dF(torch.autograd.Function):
         ctx.grad_lost = grad_lost
         ctx.seen_indices = seen_indices
         ctx.output_stride = output_stride
+        ctx.pre_upsample_output_stride = pre_upsample_output_stride
         ctx.input_loc = input_loc
         return F.interpolate(
             inpt,
@@ -57,27 +59,6 @@ class StreamingUpsample2dF(torch.autograd.Function):
         lost_bottom = grad_lost.bottom if not sides.bottom else 0
         lost_left = grad_lost.left if not sides.left else 0
         lost_right = grad_lost.right if not sides.right else 0
-
-        valid_grad = grad_output[:, :, lost_top : grad_output.shape[H_DIM] - lost_bottom, lost_left : grad_output.shape[W_DIM] - lost_right]
-
-        input_loc = ctx.input_loc
-        # `ctx.output_stride` already represents this module output's stride
-        # in input-image coordinates. Using this directly keeps data_loc aligned
-        # for mixed upsample factors (e.g. 2/4/8 heads).
-        data_loc_y = int(input_loc.y // int(ctx.output_stride[1])) + lost_top
-        data_loc_x = int(input_loc.x // int(ctx.output_stride[2])) + lost_left
-        data_loc = Box(data_loc_y, 0, data_loc_x, 0, input_loc.sides)
-
-        new_output_box, updated_total_indices = _new_value_indices(valid_grad.shape, data_loc, seen_indices)
-
-        # Keep state monotonic for debugging/introspection, but do not deduplicate
-        # gradients at upsample level. Deduplication for parameter gradients is handled
-        # by downstream streaming conv layers.
-        seen_indices.y = updated_total_indices.y
-        seen_indices.height = updated_total_indices.height
-        seen_indices.x = updated_total_indices.x
-        seen_indices.width = updated_total_indices.width
-        seen_indices.sides = updated_total_indices.sides
 
         grad_for_interp = grad_output.clone()
         grad_for_interp[:, :, :lost_top, :] = 0
@@ -102,7 +83,31 @@ class StreamingUpsample2dF(torch.autograd.Function):
         else:
             grad_in = None
 
-        return grad_in, None, None, None, None, None, None, None, None, None
+        if grad_in is not None:
+            input_loc = ctx.input_loc
+            pre_upsample_output_stride = ctx.pre_upsample_output_stride
+            data_loc_y = int(input_loc.y // int(pre_upsample_output_stride[1]))
+            data_loc_x = int(input_loc.x // int(pre_upsample_output_stride[2]))
+            data_loc = Box(data_loc_y, 0, data_loc_x, 0, input_loc.sides)
+
+            new_output_box, updated_total_indices = _new_value_indices(grad_in.shape, data_loc, seen_indices)
+
+            seen_indices.y = updated_total_indices.y
+            seen_indices.height = updated_total_indices.height
+            seen_indices.x = updated_total_indices.x
+            seen_indices.width = updated_total_indices.width
+            seen_indices.sides = updated_total_indices.sides
+
+            deduped_grad_in = torch.zeros_like(grad_in)
+            if new_output_box.height > 0 and new_output_box.width > 0:
+                y0 = new_output_box.y
+                y1 = new_output_box.y + new_output_box.height
+                x0 = new_output_box.x
+                x1 = new_output_box.x + new_output_box.width
+                deduped_grad_in[:, :, y0:y1, x0:x1] = grad_in[:, :, y0:y1, x0:x1]
+            grad_in = deduped_grad_in
+
+        return grad_in, None, None, None, None, None, None, None, None, None, None
 
 
 upsample2d = StreamingUpsample2dF.apply
@@ -138,6 +143,7 @@ class StreamingUpsample2d(nn.Module):
 
         self.grad_lost = Lost(0, 0, 0, 0)
         self.output_stride = torch.tensor([1, 1, 1])
+        self.pre_upsample_output_stride = torch.tensor([1, 1, 1])
         self.reset()
 
     def reset(self):
@@ -155,6 +161,7 @@ class StreamingUpsample2d(nn.Module):
             self.grad_lost,
             self.seen_indices,
             self.output_stride,
+            self.pre_upsample_output_stride,
             self.input_loc,
         )
 

--- a/tests/test_streamingupsample.py
+++ b/tests/test_streamingupsample.py
@@ -4,6 +4,7 @@ import torch
 from lightstream.core.constructor import StreamingConstructor
 from lightstream.core.scnn.scnn import StreamingCNN
 from lightstream.core.scnn.streamingupsample import StreamingUpsample2d
+from lightstream.core.scnn.utils import Box, Sides
 
 
 def test_streaming_upsample_from_torch_matches_interpolate():
@@ -84,3 +85,44 @@ def test_bilinear_upsample_statistics_scale_factor_loss_formula(scale_factor, ex
         expected_loss,
         expected_loss,
     )
+
+
+def test_streaming_upsample_backward_deduplicates_pre_upsample_coordinates():
+    module = StreamingUpsample2d(scale_factor=2, mode="nearest")
+    module.output_stride = torch.tensor([1, 1, 1])
+    module.pre_upsample_output_stride = torch.tensor([1, 2, 2])
+
+    first = torch.ones(1, 1, 4, 4, requires_grad=True)
+    module.input_loc = Box(0, 0, 0, 0, Sides(left=0, top=0, right=0, bottom=0))
+    module(first).sum().backward()
+    assert torch.count_nonzero(first.grad).item() == first.numel()
+
+    second = torch.ones(1, 1, 4, 4, requires_grad=True)
+    module.input_loc = Box(0, 0, 4, 0, Sides(left=0, top=0, right=0, bottom=0))
+    module(second).sum().backward()
+
+    assert torch.count_nonzero(second.grad[:, :, :, :2]).item() == 0
+    assert torch.count_nonzero(second.grad[:, :, :, 2:]).item() == second[:, :, :, 2:].numel()
+
+
+def test_upsample_statistics_store_pre_upsample_output_stride():
+    scnn = StreamingCNN.__new__(StreamingCNN)
+    scnn.eps = 1e-5
+    scnn.dtype = torch.float32
+    scnn.device = torch.device("cpu")
+    scnn._saved_tensors = {}
+    scnn._module_stats = {}
+    scnn._stats_per_grad_fn = {}
+    scnn._print_verbose = lambda *args, **kwargs: None
+
+    module = torch.nn.Upsample(scale_factor=2, mode="bilinear", align_corners=False)
+    inpt = torch.ones(1, 3, 5, 5, requires_grad=True)
+    output = module(inpt)
+
+    with torch.no_grad():
+        scnn._forward_gather_statistics_hook(module, (inpt,), output.detach().clone())
+    scnn._forward_gather_statistics_hook(module, (inpt,), output)
+
+    stats = scnn._module_stats[module]
+    assert stats["output_stride"].tolist() == [1, 1, 1]
+    assert stats["pre_upsample_output_stride"].tolist() == [1, 2, 2]


### PR DESCRIPTION
### Motivation
- Avoid double-counting gradients produced by `F.interpolate` at the upsample level by deduplicating input gradients in the pre-upsample feature-map coordinate system.
- Preserve the original local interpolation backward computation (`grad_for_interp` → `torch.autograd.grad`) while adding a post-processing dedup step.
- Make streaming bookkeeping robust for chained/mixed upsample factors by exposing and persisting a `pre_upsample_output_stride` on `StreamingUpsample2d`.

### Description
- Keep the existing full local interpolation backward pass in `StreamingUpsample2dF.backward` (build `grad_for_interp`, zero border regions, call `torch.autograd.grad`), then deduplicate `grad_in` before returning it. 
- Deduplication uses `_new_value_indices(grad_in.shape, ...)` computed in the pre-upsample coordinate system using a new `pre_upsample_output_stride` value from `ctx` and copies only the unique low-resolution slice into a zero tensor before returning.
- Add and pass `pre_upsample_output_stride` through the autograd context and `StreamingUpsample2d` instance (new attribute and forwarded argument), and wire it through streaming statistics conversion so it is computed and persisted during `_forward_gather_statistics_hook`, `_convert_modules_for_streaming`, and `_reset_converted_modules`.
- Add unit tests to `tests/test_streamingupsample.py` that cover backward deduplication in pre-upsample coordinates and that `pre_upsample_output_stride` is stored correctly for a bilinear upsample with scale factor 2.

### Testing
- Ran `python -m py_compile lightstream/core/scnn/streamingupsample.py lightstream/core/scnn/scnn.py tests/test_streamingupsample.py`, which succeeded.
- Ran a small automated script exercising `StreamingUpsample2d` backward behavior (created modules, set `pre_upsample_output_stride`, called `.backward()` and inspected `grad`), which produced the expected deduplicated gradient patterns and succeeded.
- Ran `PYTHONPATH=. pytest -q tests/test_streamingupsample.py`, which failed during collection due to missing environment dependency `numpy` in the execution environment.
- Ran `PYTHONPATH=. python examples/compare_grads_segment.py`, which failed due to missing environment dependency `torchvision` in the execution environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2c8fe84ec88330bb325aa104904856)