### PR TITLE
Remove duplicate grad deduplication in StreamingUpsample2d.backward

### DIFF
--- a/lightstream/core/scnn/streamingupsample.py
+++ b/lightstream/core/scnn/streamingupsample.py
@@ -108,30 +108,6 @@ class StreamingUpsample2dF(torch.autograd.Function):
         else:
             grad_in = None
 
-        if grad_in is not None:
-            input_loc = ctx.input_loc
-            pre_upsample_output_stride = ctx.pre_upsample_output_stride
-            data_loc_y = int(input_loc.y // int(pre_upsample_output_stride[1]))
-            data_loc_x = int(input_loc.x // int(pre_upsample_output_stride[2]))
-            data_loc = Box(data_loc_y, 0, data_loc_x, 0, input_loc.sides)
-
-            new_output_box, updated_total_indices = _new_value_indices(grad_in.shape, data_loc, seen_indices)
-
-            seen_indices.y = updated_total_indices.y
-            seen_indices.height = updated_total_indices.height
-            seen_indices.x = updated_total_indices.x
-            seen_indices.width = updated_total_indices.width
-            seen_indices.sides = updated_total_indices.sides
-
-            deduped_grad_in = torch.zeros_like(grad_in)
-            if new_output_box.height > 0 and new_output_box.width > 0:
-                y0 = new_output_box.y
-                y1 = new_output_box.y + new_output_box.height
-                x0 = new_output_box.x
-                x1 = new_output_box.x + new_output_box.width
-                deduped_grad_in[:, :, y0:y1, x0:x1] = grad_in[:, :, y0:y1, x0:x1]
-            grad_in = deduped_grad_in
-
         return grad_in, None, None, None, None, None, None, None, None, None, None
 
 


### PR DESCRIPTION
### Motivation
- The upsample backward path was calling `_new_value_indices(...)` and performing a deduplication of `grad_in` twice for the same backward pass, which can lead to redundant computation and incorrect `seen_indices` updates.
- Ensure the backward flow computes a local gradient once, optionally deduplicates it once, updates `seen_indices` once, and returns the resulting `grad_in`.

### Description
- Removed the second deduplication/update block in `StreamingUpsample2dF.backward` in `lightstream/core/scnn/streamingupsample.py` so `_new_value_indices(...)` is invoked only once per backward pass. 
- Kept the flow: build `grad_for_interp`, compute `grad_in` via `torch.autograd.grad(...)`, call `_new_value_indices(...)` once to get `new_input_box`/`updated_total_indices`, deduplicate `grad_in` into a single zeroed tensor slice, update `seen_indices`, and return `grad_in`.
- The function return signature is unchanged and the change is limited to removing the duplicated block that included `new_output_box` and `deduped_grad_in = torch.zeros_like(grad_in)`.

### Testing
- Ran `git diff --check`, which completed without problems.
- Ran `pytest tests/test_streamingupsample.py tests/test_streaminglayernorm.py -q`, which failed during collection due to missing environment dependency (`ModuleNotFoundError: No module named 'numpy'`).
- Ran `python -m py_compile lightstream/core/scnn/streamingupsample.py` earlier and it reported a pre-existing `SyntaxError` due to a duplicate argument name in the file signature; that syntax issue was present before this deduplication change and was not introduced by this PR.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2c96ae9e808330a064297bd397a5b8)