### PR TITLE
Clean up streaming upsample arguments

### DIFF
--- a/lightstream/core/scnn/streamingupsample.py
+++ b/lightstream/core/scnn/streamingupsample.py
@@ -25,7 +25,6 @@ class StreamingUpsample2dF(torch.autograd.Function):
         seen_indices,
         pre_upsample_output_stride,
         output_stride,
-        pre_upsample_output_stride,
         input_loc,
     ):
         ctx.save_for_backward(inpt)
@@ -38,7 +37,6 @@ class StreamingUpsample2dF(torch.autograd.Function):
         ctx.seen_indices = seen_indices
         ctx.pre_upsample_output_stride = pre_upsample_output_stride
         ctx.output_stride = output_stride
-        ctx.pre_upsample_output_stride = pre_upsample_output_stride
         ctx.input_loc = input_loc
         return F.interpolate(
             inpt,
@@ -145,7 +143,6 @@ class StreamingUpsample2d(nn.Module):
         self.grad_lost = Lost(0, 0, 0, 0)
         self.pre_upsample_output_stride = torch.tensor([1, 1, 1])
         self.output_stride = torch.tensor([1, 1, 1])
-        self.pre_upsample_output_stride = torch.tensor([1, 1, 1])
         self.reset()
 
     def reset(self):
@@ -164,7 +161,6 @@ class StreamingUpsample2d(nn.Module):
             self.seen_indices,
             self.pre_upsample_output_stride,
             self.output_stride,
-            self.pre_upsample_output_stride,
             self.input_loc,
         )
 


### PR DESCRIPTION
### Motivation
- Remove a duplicated `pre_upsample_output_stride` argument and redundant assignments to simplify the `StreamingUpsample2d*` API and ensure the forward/backward signatures align.

### Description
- Remove the duplicate `pre_upsample_output_stride` parameter from `StreamingUpsample2dF.forward` and the redundant `ctx.pre_upsample_output_stride` assignment.
- Ensure the forward argument order is maintained from `inpt` through `input_loc` and pass `self.pre_upsample_output_stride` only once from `StreamingUpsample2d.forward`.
- Remove the duplicate initializer assignment of `self.pre_upsample_output_stride` in the module constructor while keeping `StreamingUpsample2dF.backward` returning one slot per non-`ctx` forward input (`grad_in` followed by `None`s for non-differentiable metadata).

### Testing
- Ran `python -m py_compile lightstream/core/scnn/streamingupsample.py` which succeeded.
- Ran `pytest tests/test_streamingupsample.py` which errored during collection due to `ModuleNotFoundError: No module named 'numpy'` in the test environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2dd61ea26c8330b4d2c069357cbdc3)