### PR TITLE
Remove upsample input-gradient deduplication

### DIFF
--- a/lightstream/core/scnn/streamingupsample.py
+++ b/lightstream/core/scnn/streamingupsample.py
@@ -7,7 +7,7 @@ import torch.nn as nn
 import torch.nn.functional as F
 from torch.amp import custom_bwd, custom_fwd
 
-from lightstream.core.scnn.utils import Box, Lost, _new_value_indices, H_DIM, W_DIM
+from lightstream.core.scnn.utils import Box, Lost, H_DIM, W_DIM
 
 
 class StreamingUpsample2dF(torch.autograd.Function):
@@ -53,7 +53,6 @@ class StreamingUpsample2dF(torch.autograd.Function):
         (inpt,) = ctx.saved_tensors
         sides = ctx.input_loc.sides
         grad_lost = ctx.grad_lost
-        seen_indices = ctx.seen_indices
 
         lost_top = grad_lost.top if not sides.top else 0
         lost_bottom = grad_lost.bottom if not sides.bottom else 0
@@ -80,29 +79,6 @@ class StreamingUpsample2dF(torch.autograd.Function):
                     recompute_scale_factor=ctx.recompute_scale_factor,
                 )
                 grad_in = torch.autograd.grad(out, inpt_grad, grad_for_interp, retain_graph=False, allow_unused=False)[0]
-
-            input_loc = ctx.input_loc
-            pre_upsample_output_stride = ctx.pre_upsample_output_stride
-            data_loc_y = int(input_loc.y // int(pre_upsample_output_stride[1]))
-            data_loc_x = int(input_loc.x // int(pre_upsample_output_stride[2]))
-            data_loc = Box(data_loc_y, 0, data_loc_x, 0, input_loc.sides)
-
-            new_input_box, updated_total_indices = _new_value_indices(grad_in.shape, data_loc, seen_indices)
-
-            seen_indices.y = updated_total_indices.y
-            seen_indices.height = updated_total_indices.height
-            seen_indices.x = updated_total_indices.x
-            seen_indices.width = updated_total_indices.width
-            seen_indices.sides = updated_total_indices.sides
-
-            deduplicated_grad_in = torch.zeros_like(grad_in)
-            if new_input_box.height > 0 and new_input_box.width > 0:
-                y0 = new_input_box.y
-                y1 = y0 + new_input_box.height
-                x0 = new_input_box.x
-                x1 = x0 + new_input_box.width
-                deduplicated_grad_in[:, :, y0:y1, x0:x1] = grad_in[:, :, y0:y1, x0:x1]
-            grad_in = deduplicated_grad_in
         else:
             grad_in = None
 

--- a/tests/test_streamingupsample.py
+++ b/tests/test_streamingupsample.py
@@ -87,7 +87,7 @@ def test_bilinear_upsample_statistics_scale_factor_loss_formula(scale_factor, ex
     )
 
 
-def test_streaming_upsample_backward_deduplicates_pre_upsample_coordinates():
+def test_streaming_upsample_backward_keeps_pre_upsample_coordinate_gradients():
     module = StreamingUpsample2d(scale_factor=2, mode="nearest")
     module.output_stride = torch.tensor([1, 1, 1])
     module.pre_upsample_output_stride = torch.tensor([1, 2, 2])
@@ -101,8 +101,7 @@ def test_streaming_upsample_backward_deduplicates_pre_upsample_coordinates():
     module.input_loc = Box(0, 0, 4, 0, Sides(left=0, top=0, right=0, bottom=0))
     module(second).sum().backward()
 
-    assert torch.count_nonzero(second.grad[:, :, :, :2]).item() == 0
-    assert torch.count_nonzero(second.grad[:, :, :, 2:]).item() == second[:, :, :, 2:].numel()
+    assert torch.count_nonzero(second.grad).item() == second.numel()
 
 
 def test_upsample_statistics_store_pre_upsample_output_stride():


### PR DESCRIPTION
### Motivation
- The upsample backward path previously deduplicated pre-upsample input-gradient coordinates which caused upstream gradients (input and some encoder parameters) to be zeroed across adjacent tiles.
- Remove the duplicated deduplication pass at the upsample level to restore expected upstream gradient flow and simplify the upsample backward logic.

### Description
- Removed the upsample-level deduplication code from `StreamingUpsample2dF.backward` so the function now computes the interpolation gradient (masked by `grad_lost`) and returns it directly without zeroing repeated pre-upsample coordinates.
- Dropped the unused import and local handling related to `_new_value_indices`/`seen_indices` in `lightstream/core/scnn/streamingupsample.py`.
- Updated the unit test in `tests/test_streamingupsample.py` (renamed to `test_streaming_upsample_backward_keeps_pre_upsample_coordinate_gradients`) to assert that gradients remain nonzero across the second adjacent tile instead of being deduplicated away.

### Testing
- Ran `python -m py_compile lightstream/core/scnn/streamingupsample.py tests/test_streamingupsample.py` which succeeded.
- Ran `python -m pytest tests/test_streamingupsample.py` which failed during collection due to a missing environment dependency (`numpy`) in the test environment.
- Ran the dense-segment comparison example (`PYTHONPATH=. python examples/compare_grads_segment.py --tile-size 256 --input-size 512 --dtype float32`) which was blocked by missing `torchvision` in the environment, and attempts to install `numpy` via `python -m pip install numpy` were blocked by the package proxy (403), so full gradient comparison could not be completed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2dd94f8b7483308fce35b537d224b5)