### PR TITLE
Reintroduce deduplication in StreamingUpsample2d.backward using _new_value_indices

### DIFF
--- a/lightstream/core/scnn/streamingupsample.py
+++ b/lightstream/core/scnn/streamingupsample.py
@@ -7,7 +7,7 @@ import torch.nn as nn
 import torch.nn.functional as F
 from torch.amp import custom_bwd, custom_fwd
 
-from lightstream.core.scnn.utils import Box, Lost, H_DIM, W_DIM
+from lightstream.core.scnn.utils import Box, Lost, _new_value_indices, H_DIM, W_DIM
 
 
 class StreamingUpsample2dF(torch.autograd.Function):
@@ -59,13 +59,38 @@ class StreamingUpsample2dF(torch.autograd.Function):
         lost_left = grad_lost.left if not sides.left else 0
         lost_right = grad_lost.right if not sides.right else 0
 
-        grad_for_interp = grad_output.clone()
-        grad_for_interp[:, :, :lost_top, :] = 0
-        if lost_bottom > 0:
-            grad_for_interp[:, :, grad_output.shape[H_DIM] - lost_bottom :, :] = 0
-        grad_for_interp[:, :, :, :lost_left] = 0
-        if lost_right > 0:
-            grad_for_interp[:, :, :, grad_output.shape[W_DIM] - lost_right :] = 0
+        H = grad_output.shape[H_DIM]
+        W = grad_output.shape[W_DIM]
+        valid_grad = grad_output[:, :, lost_top : H - lost_bottom, lost_left : W - lost_right]
+
+        output_stride = ctx.output_stride
+        stride_h = int(output_stride[1].item()) if isinstance(output_stride, torch.Tensor) else int(output_stride[1])
+        stride_w = int(output_stride[2].item()) if isinstance(output_stride, torch.Tensor) else int(output_stride[2])
+        data_loc_y = int(ctx.input_loc.y // stride_h) + lost_top
+        data_loc_x = int(ctx.input_loc.x // stride_w) + lost_left
+        data_loc = Box(data_loc_y, 0, data_loc_x, 0, ctx.input_loc.sides)
+
+        new_output_box, updated_total_indices = _new_value_indices(valid_grad.shape, data_loc, ctx.seen_indices)
+
+        ctx.seen_indices.y = updated_total_indices.y
+        ctx.seen_indices.height = updated_total_indices.height
+        ctx.seen_indices.x = updated_total_indices.x
+        ctx.seen_indices.width = updated_total_indices.width
+        ctx.seen_indices.sides = updated_total_indices.sides
+
+        grad_for_interp = torch.zeros_like(grad_output)
+        if new_output_box.height > 0 and new_output_box.width > 0:
+            grad_for_interp[
+                :,
+                :,
+                lost_top + new_output_box.y : lost_top + new_output_box.y + new_output_box.height,
+                lost_left + new_output_box.x : lost_left + new_output_box.x + new_output_box.width,
+            ] = valid_grad[
+                :,
+                :,
+                new_output_box.y : new_output_box.y + new_output_box.height,
+                new_output_box.x : new_output_box.x + new_output_box.width,
+            ]
 
         if ctx.needs_input_grad[0]:
             with torch.enable_grad():


### PR DESCRIPTION
### Motivation
- Restore correct streaming deduplication in upsample backward so only newly seen post-crop gradient regions are propagated to the pre- upsample gradient computation.
- Use post-upsampling coordinates (`ctx.output_stride`) and the tracked `ctx.seen_indices` to compute unique slices rather than sending duplicated gradients to the interpolator.

### Description
- Re-added import of `_new_value_indices` and use it inside `StreamingUpsample2dF.backward` to compute `new_output_box` and `updated_total_indices` from the cropped `valid_grad` and a data location computed with `ctx.output_stride`.
- Compute `valid_grad = grad_output[:, :, lost_top:H-lost_bottom, lost_left:W-lost_right]` and derive `data_loc_y`/`data_loc_x` using `ctx.output_stride` (post-upsample coordinates) and `ctx.input_loc`.
- Update `ctx.seen_indices` from `updated_total_indices` and build `grad_for_interp = torch.zeros_like(grad_output)` then copy only the unique slice of `valid_grad` into the correct offset region of `grad_for_interp` before calling `torch.autograd.grad(...)`.
- Preserve existing behavior of not deduplicating the returned `grad_in` in this patch and keep other backward-return slots unchanged.

### Testing
- Ran `python -m py_compile lightstream/core/scnn/streamingupsample.py` which succeeded.
- Executed a focused runtime check script that calls the module with different `input_loc` values and verified nonzero gradients and updated `seen_indices` (manual inspection of printed counts succeeded).
- Ran `pytest tests/test_streamingupsample.py -q` but collection failed due to a missing `numpy` dependency in the environment, and attempting `python -m pip install numpy` was blocked by network/package index access.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2ddeb266948330866052716613c854)