### PR TITLE
Fix streaming upsample backward ownership

### DIFF
--- a/lightstream/core/scnn/scnn.py
+++ b/lightstream/core/scnn/scnn.py
@@ -581,7 +581,9 @@ class StreamingCNN(torch.nn.Module):
             if module in self._module_stats:
                 stats = self._module_stats[module]
                 mod.grad_lost = stats.get("grad_lost", Lost(0, 0, 0, 0))
-                mod.output_stride = stats.get("output_stride", torch.tensor([1, 1, 1]))
+                mod.output_stride = stats.get(
+                    "post_upsample_output_stride", stats.get("output_stride", torch.tensor([1, 1, 1]))
+                )
                 mod.pre_upsample_output_stride = stats.get("pre_upsample_output_stride")
                 if mod.pre_upsample_output_stride is None:
                     scale_h, scale_w = stats.get("scale_factor_hw", (mod.scale_factor, mod.scale_factor))
@@ -595,6 +597,17 @@ class StreamingCNN(torch.nn.Module):
                     mod.pre_upsample_output_stride = torch.round(mod.pre_upsample_output_stride).to(torch.long)
                     mod.pre_upsample_output_stride[0] = 1
                     stats["pre_upsample_output_stride"] = mod.pre_upsample_output_stride
+                stats.setdefault("post_upsample_output_stride", mod.output_stride)
+                for key in (
+                    "scale_factor_hw",
+                    "pre_upsample_output_stride",
+                    "post_upsample_output_stride",
+                    "grad_lost",
+                    "side_aware_grad_lost",
+                    "backward_valid_lost",
+                ):
+                    if key in stats and hasattr(mod, key):
+                        setattr(mod, key, stats[key])
                 self._module_stats[mod] = self._module_stats[module]
                 del self._module_stats[module]
         elif isinstance(module, ChannelLayerNorm):
@@ -640,7 +653,12 @@ class StreamingCNN(torch.nn.Module):
                 stats["grad_lost"] = module.grad_lost
                 stats["pre_upsample_output_stride"] = module.pre_upsample_output_stride
                 stats["output_stride"] = module.output_stride
-                stats["pre_upsample_output_stride"] = module.pre_upsample_output_stride
+                stats["post_upsample_output_stride"] = module.output_stride
+                if module.scale_factor is not None:
+                    sf = module.scale_factor
+                    stats["scale_factor_hw"] = (
+                        (float(sf[-2]), float(sf[-1])) if isinstance(sf, tuple) else (float(sf), float(sf))
+                    )
                 self._module_stats[mod] = stats
             else:
                 self._module_stats[mod] = self._module_stats[module]
@@ -1886,6 +1904,14 @@ class StreamingCNN(torch.nn.Module):
             new_grad_in = valid_grad[None].expand(grad_in[0].shape[1], *valid_grad.shape)[None]
             new_grad_in = new_grad_in.type(self.dtype) * 10 - 1
             new_grad_in_lost = self._non_max_border_amount(new_grad_in)
+            self._module_stats[module]["backward_valid_lost"] = new_grad_in_lost
+            self._module_stats[module]["side_aware_grad_lost"] = {
+                "interior": grad_lost,
+                "top": Lost(0, grad_lost.left, grad_lost.bottom, grad_lost.right),
+                "bottom": Lost(grad_lost.top, grad_lost.left, 0, grad_lost.right),
+                "left": Lost(grad_lost.top, 0, grad_lost.bottom, grad_lost.right),
+                "right": Lost(grad_lost.top, grad_lost.left, grad_lost.bottom, 0),
+            }
 
             return (new_grad_in, *grad_in[1:])
 

--- a/lightstream/core/scnn/streamingupsample.py
+++ b/lightstream/core/scnn/streamingupsample.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import math
 from typing import Optional
 
 import torch
@@ -61,18 +62,16 @@ class StreamingUpsample2dF(torch.autograd.Function):
 
         H = grad_output.shape[H_DIM]
         W = grad_output.shape[W_DIM]
-        valid_grad = grad_output[:, :, lost_top : H - lost_bottom, lost_left : W - lost_right]
 
-        output_stride = ctx.output_stride
-        stride_h = int(output_stride[1].item()) if isinstance(output_stride, torch.Tensor) else int(output_stride[1])
-        stride_w = int(output_stride[2].item()) if isinstance(output_stride, torch.Tensor) else int(output_stride[2])
-        # grad_output is in post-upsample coordinates, so locating valid_grad for
-        # _new_value_indices(valid_grad.shape, ...) must use the post-upsample stride.
-        data_loc_y = int(ctx.input_loc.y // stride_h) + lost_top
-        data_loc_x = int(ctx.input_loc.x // stride_w) + lost_left
+        pre_output_stride = ctx.pre_upsample_output_stride
+        stride_h = int(pre_output_stride[1].item()) if isinstance(pre_output_stride, torch.Tensor) else int(pre_output_stride[1])
+        stride_w = int(pre_output_stride[2].item()) if isinstance(pre_output_stride, torch.Tensor) else int(pre_output_stride[2])
+
+        data_loc_y = int(ctx.input_loc.y // stride_h)
+        data_loc_x = int(ctx.input_loc.x // stride_w)
         data_loc = Box(data_loc_y, 0, data_loc_x, 0, ctx.input_loc.sides)
 
-        new_output_box, updated_total_indices = _new_value_indices(valid_grad.shape, data_loc, ctx.seen_indices)
+        owned_lowres_box, updated_total_indices = _new_value_indices(inpt.shape, data_loc, ctx.seen_indices)
 
         ctx.seen_indices.y = updated_total_indices.y
         ctx.seen_indices.height = updated_total_indices.height
@@ -80,18 +79,38 @@ class StreamingUpsample2dF(torch.autograd.Function):
         ctx.seen_indices.width = updated_total_indices.width
         ctx.seen_indices.sides = updated_total_indices.sides
 
+        def _bilinear_backward_support(start: int, length: int, in_size: int, out_size: int) -> tuple[int, int]:
+            if length <= 0:
+                return 0, 0
+            end = start + length
+            if out_size <= 0:
+                return 0, 0
+            scale = float(out_size) / float(max(1, in_size))
+            # For align_corners=False, output coordinate o samples input coordinate
+            # (o + 0.5) / scale - 0.5. An input index i receives gradients from
+            # output locations whose sampling coordinate lies in (i - 1, i + 1).
+            # This conservative integer envelope includes all high-resolution
+            # locations that can contribute to any owned low-resolution index.
+            support_start = math.floor(scale * (float(start) - 0.5) - 0.5) + 1
+            support_end = math.ceil(scale * (float(end) + 0.5) - 0.5)
+            return max(0, support_start), min(out_size, support_end)
+
+        support_top, support_bottom = _bilinear_backward_support(
+            owned_lowres_box.y, owned_lowres_box.height, inpt.shape[H_DIM], H
+        )
+        support_left, support_right = _bilinear_backward_support(
+            owned_lowres_box.x, owned_lowres_box.width, inpt.shape[W_DIM], W
+        )
+
+        support_top = max(support_top, lost_top)
+        support_bottom = min(support_bottom, H - lost_bottom)
+        support_left = max(support_left, lost_left)
+        support_right = min(support_right, W - lost_right)
+
         grad_for_interp = torch.zeros_like(grad_output)
-        if new_output_box.height > 0 and new_output_box.width > 0:
-            grad_for_interp[
-                :,
-                :,
-                lost_top + new_output_box.y : lost_top + new_output_box.y + new_output_box.height,
-                lost_left + new_output_box.x : lost_left + new_output_box.x + new_output_box.width,
-            ] = valid_grad[
-                :,
-                :,
-                new_output_box.y : new_output_box.y + new_output_box.height,
-                new_output_box.x : new_output_box.x + new_output_box.width,
+        if support_bottom > support_top and support_right > support_left:
+            grad_for_interp[:, :, support_top:support_bottom, support_left:support_right] = grad_output[
+                :, :, support_top:support_bottom, support_left:support_right
             ]
 
         if ctx.needs_input_grad[0]:
@@ -108,6 +127,22 @@ class StreamingUpsample2dF(torch.autograd.Function):
                 grad_in = torch.autograd.grad(out, inpt_grad, grad_for_interp, retain_graph=False, allow_unused=False)[0]
         else:
             grad_in = None
+
+        if grad_in is not None:
+            masked_grad_in = torch.zeros_like(grad_in)
+            if owned_lowres_box.height > 0 and owned_lowres_box.width > 0:
+                masked_grad_in[
+                    :,
+                    :,
+                    owned_lowres_box.y : owned_lowres_box.y + owned_lowres_box.height,
+                    owned_lowres_box.x : owned_lowres_box.x + owned_lowres_box.width,
+                ] = grad_in[
+                    :,
+                    :,
+                    owned_lowres_box.y : owned_lowres_box.y + owned_lowres_box.height,
+                    owned_lowres_box.x : owned_lowres_box.x + owned_lowres_box.width,
+                ]
+            grad_in = masked_grad_in
 
         return grad_in, None, None, None, None, None, None, None, None, None, None
 
@@ -144,8 +179,12 @@ class StreamingUpsample2d(nn.Module):
         self.recompute_scale_factor = recompute_scale_factor
 
         self.grad_lost = Lost(0, 0, 0, 0)
+        self.scale_factor_hw = None
         self.pre_upsample_output_stride = torch.tensor([1, 1, 1])
         self.output_stride = torch.tensor([1, 1, 1])
+        self.post_upsample_output_stride = self.output_stride
+        self.side_aware_grad_lost = None
+        self.backward_valid_lost = None
         self.reset()
 
     def reset(self):


### PR DESCRIPTION
### Motivation
- Ensure bilinear `Upsample` layers record the scale and pre/post upsample output-stride metadata so streaming conversion can reason about ownership correctly.
- Compute backward tile ownership in pre‑upsample (low‑res) coordinates so each tile returns only the upstream gradients it owns for bilinear interpolation.
- Preserve and propagate side-aware/backward-validity statistics when available to avoid returning invalid gradient regions.

### Description
- Copy `scale_factor_hw`, `pre_upsample_output_stride`, and `post_upsample_output_stride` into `StreamingUpsample2d` during `_convert_modules_for_streaming` and surface optional `side_aware_grad_lost`/`backward_valid_lost` if present in stats.
- Add attributes to `StreamingUpsample2d` (`scale_factor_hw`, `post_upsample_output_stride`, `side_aware_grad_lost`, `backward_valid_lost`) so conversion can set them when available.
- Rework `StreamingUpsample2dF.backward` to define tile ownership in low‑resolution coordinates using `ctx.input_loc`, `ctx.pre_upsample_output_stride`, `inpt.shape`, and `_new_value_indices(...)` producing `owned_lowres_box`.
- Compute the high‑resolution bilinear interpolation backward support for `owned_lowres_box` (helper `_bilinear_backward_support`), copy only that region from `grad_output` into `grad_for_interp`, run `torch.autograd.grad(...)` through `F.interpolate`, and zero all returned `grad_in` outside `owned_lowres_box`.

### Testing
- Ran `python -m py_compile lightstream/core/scnn/scnn.py lightstream/core/scnn/streamingupsample.py`, which succeeded.
- Executed the project test subset `pytest -q tests/test_scnn.py tests/test_streaminglayernorm.py`, which failed during collection due to missing environment dependency (`numpy` not installed) rather than code errors in the modified files.
- Manual static checks and local imports were validated during development (no runtime exceptions from the modified functions in a type/compile pass).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2f06610a508330aa4f261d25a1f55d)