### PR TITLE
Add debug logging for upsample backward support clipping

### DIFF
--- a/lightstream/core/scnn/streamingupsample.py
+++ b/lightstream/core/scnn/streamingupsample.py
@@ -98,6 +98,22 @@ class StreamingUpsample2dF(torch.autograd.Function):
         valid_left = lost_left
         valid_right = W - lost_right
 
+        owned_support_top, owned_support_bottom = _bilinear_backward_support(
+            owned_lowres_box.y, owned_lowres_box.height, inpt.shape[H_DIM], H
+        )
+        owned_support_left, owned_support_right = _bilinear_backward_support(
+            owned_lowres_box.x, owned_lowres_box.width, inpt.shape[W_DIM], W
+        )
+        clipped_support_edges = []
+        if owned_support_top < valid_top:
+            clipped_support_edges.append("top")
+        if owned_support_bottom > valid_bottom:
+            clipped_support_edges.append("bottom")
+        if owned_support_left < valid_left:
+            clipped_support_edges.append("left")
+        if owned_support_right > valid_right:
+            clipped_support_edges.append("right")
+
         low_y0 = owned_lowres_box.y
         low_y1 = owned_lowres_box.y + owned_lowres_box.height
         low_x0 = owned_lowres_box.x
@@ -134,6 +150,28 @@ class StreamingUpsample2dF(torch.autograd.Function):
             max(0, low_x1 - low_x0),
             owned_lowres_box.sides,
         )
+
+        if clipped_support_edges:
+            logger.debug(
+                "StreamingUpsample2dF.backward found owned low-res cells whose required high-res support "
+                "extends beyond valid grad_output bounds: input_loc=%s sides=%s tile_sides=%s "
+                "owned_lowres_box=%s required_support=(top=%s, bottom=%s, left=%s, right=%s) "
+                "valid_highres=(top=%s, bottom=%s, left=%s, right=%s) complete_lowres_box=%s clipped_edges=%s",
+                ctx.input_loc,
+                sides,
+                owned_lowres_box.sides,
+                owned_lowres_box,
+                owned_support_top,
+                owned_support_bottom,
+                owned_support_left,
+                owned_support_right,
+                valid_top,
+                valid_bottom,
+                valid_left,
+                valid_right,
+                complete_lowres_box,
+                tuple(clipped_support_edges),
+            )
 
         owned_y1 = owned_lowres_box.y + owned_lowres_box.height
         owned_x1 = owned_lowres_box.x + owned_lowres_box.width


### PR DESCRIPTION
### Motivation
- Investigate a failing large-image backward case where owned low-res cells required high-res support that was being clipped by valid gradient bounds. 
- Capture enough context early in `StreamingUpsample2dF.backward` to understand why the later trimming produces a smaller `complete_lowres_box` and triggers existing guards.

### Description
- In `lightstream/core/scnn/streamingupsample.py` inside `StreamingUpsample2dF.backward`, compute the owned low-res box's required high-res support using `_bilinear_backward_support` before trimming incomplete cells. 
- Compare required support to valid high-res bounds (`valid_top`, `valid_bottom`, `valid_left`, `valid_right`) and collect any clipped edges into `clipped_support_edges`.
- Emit a debug log (guarded on `clipped_support_edges`) containing `ctx.input_loc`, tile `sides`, `owned_lowres_box`, the computed `required_support`, `valid_highres` bounds, the resulting `complete_lowres_box`, and `clipped_edges` to aid diagnosis.
- Behavior is otherwise unchanged; the logging is diagnostic and does not alter the clipping/guard logic.

### Testing
- Ran `python -m py_compile lightstream/core/scnn/streamingupsample.py` which succeeded. 
- Executed a small targeted script that constructs a `StreamingUpsample2d` module and calls `.backward()` to reproduce the condition; the new debug log printed the owned box, required support, valid bounds, and resulting `complete_lowres_box`, and then the existing top/left guard raised the expected `RuntimeError`.
- Running `pytest tests/test_streamingupsample.py` was blocked during collection due to a missing `numpy` dependency in the environment, and attempting `pip install numpy` failed due to package index/network restrictions (403), so full test suite could not be completed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2fd8a361048330b6ee66aabee6cdc5)