### PR TITLE
Limit conv weight-gradient regions using activation-validity (handle upsample seams)

### DIFF
--- a/lightstream/core/scnn/scnn.py
+++ b/lightstream/core/scnn/scnn.py
@@ -29,6 +29,24 @@ _triple = _ntuple(3)
 BACKWARD_STREAMING_MODULE_TYPES = (StreamingConv2d, StreamingUpsample2d, StreamingChannelLayerNorm)
 
 
+
+
+def _max_lost(*lost_values):
+    """Return the per-side maximum of any non-None Lost values."""
+    values = [lost for lost in lost_values if lost is not None]
+    if not values:
+        return Lost(0, 0, 0, 0)
+    return Lost(
+        max(int(lost.top) for lost in values),
+        max(int(lost.left) for lost in values),
+        max(int(lost.bottom) for lost in values),
+        max(int(lost.right) for lost in values),
+    )
+
+
+def _ceil_div(a, b):
+    return -(-int(a) // int(b))
+
 def _is_pointwise_channel_norm(module):
     """Return True for channel-only normalization layers that preserve spatial support."""
     return isinstance(module, (ChannelLayerNorm, StreamingChannelLayerNorm))
@@ -573,6 +591,7 @@ class StreamingCNN(torch.nn.Module):
             if module in self._module_stats:
                 mod = StreamingConv2d.from_torch_conv2d(module)
                 mod.grad_lost = self._module_stats[module]["grad_lost"]
+                mod.weight_grad_lost = self._module_stats[module].get("weight_grad_lost", Lost(0, 0, 0, 0))
                 mod.output_stride = self._module_stats[module]["output_stride"]
                 self._module_stats[mod] = self._module_stats[module]
                 del self._module_stats[module]
@@ -1727,6 +1746,42 @@ class StreamingCNN(torch.nn.Module):
         out_stride[0] = 1
         return out_stride
 
+    def _upsample_activation_lost(self, module, input_activation_lost, scale_h, scale_w):
+        """Return output activation loss for upsampling seam-sensitive borders."""
+        mode = getattr(module, "mode", None)
+        if mode not in ("bilinear", "bicubic", "linear", "trilinear"):
+            return input_activation_lost
+
+        seam_h = max(1, int(math.ceil(float(scale_h)))) if scale_h and scale_h > 1 else 1
+        seam_w = max(1, int(math.ceil(float(scale_w)))) if scale_w and scale_w > 1 else 1
+        seam_lost = Lost(seam_h, seam_w, seam_h, seam_w)
+        return _max_lost(input_activation_lost, seam_lost)
+
+    def _conv_weight_grad_lost(self, input_activation_lost, input_shape, output_shape, stride, kernel_size, padding, dilation):
+        """Return conv output border loss whose receptive fields touch invalid input activations."""
+        stride = _triple(stride)
+        kernel_size = _triple(kernel_size)
+        padding = _triple(padding)
+        dilation = _triple(dilation)
+        input_h, input_w = int(input_shape[H_DIM]), int(input_shape[W_DIM])
+        output_h, output_w = int(output_shape[H_DIM]), int(output_shape[W_DIM])
+
+        valid_top = int(input_activation_lost.top)
+        valid_left = int(input_activation_lost.left)
+        valid_bottom = input_h - int(input_activation_lost.bottom)
+        valid_right = input_w - int(input_activation_lost.right)
+        kernel_h = int(dilation[1]) * (int(kernel_size[1]) - 1) + 1
+        kernel_w = int(dilation[2]) * (int(kernel_size[2]) - 1) + 1
+
+        first_y = max(0, _ceil_div(valid_top + int(padding[1]), int(stride[1])))
+        first_x = max(0, _ceil_div(valid_left + int(padding[2]), int(stride[2])))
+        last_y = min(output_h - 1, (valid_bottom - kernel_h + int(padding[1])) // int(stride[1]))
+        last_x = min(output_w - 1, (valid_right - kernel_w + int(padding[2])) // int(stride[2]))
+
+        if last_y < first_y or last_x < first_x:
+            return Lost(output_h, output_w, output_h, output_w)
+        return Lost(first_y, first_x, output_h - last_y - 1, output_w - last_x - 1)
+
     def _forward_gather_statistics_hook(self, module, inpt, output):
         is_upsample = isinstance(module, torch.nn.Upsample)
         is_pointwise_norm = _is_pointwise_channel_norm(module)
@@ -1772,6 +1827,16 @@ class StreamingCNN(torch.nn.Module):
             # make its actual output all zeros, so derive validity from its input.
             lost = self._non_max_border_amount(inpt[0] if is_pointwise_norm else output)
 
+            p_stats = self._prev_stats(output)
+            input_activation_lost = p_stats.get("activation_valid_lost", Lost(0, 0, 0, 0)) if p_stats else Lost(0, 0, 0, 0)
+            if is_pointwise_norm:
+                activation_valid_lost = input_activation_lost
+            elif is_upsample:
+                scale_h, scale_w = self._resolve_upsample_scale(module, inpt, output)
+                activation_valid_lost = self._upsample_activation_lost(module, input_activation_lost, scale_h, scale_w)
+            else:
+                activation_valid_lost = lost
+
             # Make output between 0-1 again, so the values do not explode
             output.fill_(0)
             output[
@@ -1784,6 +1849,7 @@ class StreamingCNN(torch.nn.Module):
                 "kernel_size": kernel_size,
                 "padding": padding,
                 "module": module,
+                "activation_valid_lost": activation_valid_lost,
             }
             self._print_verbose(module, "\n", module_stats["lost"])
 
@@ -1815,8 +1881,25 @@ class StreamingCNN(torch.nn.Module):
             output_stride = output_stride.clone().detach()
             output_stride[0] = 1
             module_stats["output_stride"] = output_stride
-            if is_upsample:
+            input_activation_lost = p_stats.get("activation_valid_lost", Lost(0, 0, 0, 0)) if p_stats else Lost(0, 0, 0, 0)
+            if is_pointwise_norm:
+                activation_valid_lost = input_activation_lost
+            elif is_upsample:
+                activation_valid_lost = self._upsample_activation_lost(module, input_activation_lost, scale_h, scale_w)
                 module_stats["post_upsample_output_stride"] = output_stride
+            else:
+                activation_valid_lost = module_stats.get("lost", Lost(0, 0, 0, 0))
+                if isinstance(module, torch.nn.Conv2d):
+                    module_stats["weight_grad_lost"] = self._conv_weight_grad_lost(
+                        input_activation_lost,
+                        inpt[0].shape,
+                        output.shape,
+                        stride,
+                        kernel_size,
+                        padding,
+                        module.dilation,
+                    )
+            module_stats["activation_valid_lost"] = activation_valid_lost
             self._stats_per_grad_fn[output.grad_fn] = module_stats
             self._module_stats[module] = module_stats
 

--- a/lightstream/core/scnn/streamingconv.py
+++ b/lightstream/core/scnn/streamingconv.py
@@ -15,7 +15,7 @@ class StreamingConv2dF(torch.autograd.Function):
     @staticmethod
     @custom_fwd(device_type="cuda", cast_inputs=torch.bfloat16 if torch.cuda.is_bf16_supported() else torch.float16)
     def forward(
-        ctx, inpt, weight, bias, stride, padding, dilation, groups, grad_lost, seen_indices, output_stride, input_loc
+        ctx, inpt, weight, bias, stride, padding, dilation, groups, grad_lost, weight_grad_lost, seen_indices, output_stride, input_loc
     ):
         ctx.save_for_backward(inpt, weight, bias)
         ctx.stride = stride
@@ -23,6 +23,7 @@ class StreamingConv2dF(torch.autograd.Function):
         ctx.dilation = dilation
         ctx.groups = groups
         ctx.grad_lost = grad_lost
+        ctx.weight_grad_lost = weight_grad_lost
         ctx.seen_indices = seen_indices
         ctx.output_stride = output_stride
         ctx.input_loc = input_loc
@@ -41,6 +42,7 @@ class StreamingConv2dF(torch.autograd.Function):
         sides = ctx.input_loc.sides  # Type: Sides
         seen_indices = ctx.seen_indices
         grad_lost = ctx.grad_lost  # Type: Lost
+        weight_grad_lost = ctx.weight_grad_lost  # Type: Lost
         output_stride = ctx.output_stride
         grad_bias = None
         kernel_size = weight.shape[-1]
@@ -104,66 +106,74 @@ class StreamingConv2dF(torch.autograd.Function):
                 new_output_box.x : new_output_box.x + new_output_box.width,
             ]
 
-            input_y = (new_output_box.y + lost_top) * stride[1]
-            input_x = (new_output_box.x + lost_left) * stride[2]
-
-            # Accounting for padding:
-            # the kernel locations are relative to the padded input, inpt[0] is not padded
-            # this means that the corresponding input of the grad_loc is modules.padding shifted to the left
-            # we account for this:
-            input_y -= padding[1]
-            input_x -= padding[2]
-            input_x = max(0, input_x)
-            input_y = max(0, input_y)
-
-            relevant_input_height = relevant_grad.shape[H_DIM] * stride[1] + (kernel_size[1] - 1)
-            relevant_input_width = relevant_grad.shape[W_DIM] * stride[2] + (kernel_size[2] - 1)
-            relevant_input = inpt[
-                :, :, input_y : input_y + relevant_input_height, input_x : input_x + relevant_input_width
-            ]
-
-            # If layer has padding we need to pad based on if the current tile
-            # is at the sides of the input.
-            if (padding[0] > 0 or padding[1] > 0 or padding[2] > 0) and (
-                sides.top or sides.left or sides.right or sides.bottom
-            ):
-                # The size of the tile should remain equal.
-                crop_bottom = padding[1] if sides.top else 0
-                crop_right = padding[2] if sides.left else 0
-                relevant_input = inpt[
-                    :,
-                    :,
-                    input_y : input_y + relevant_input_height - crop_bottom,
-                    input_x : input_x + relevant_input_width - crop_right,
-                ]
-
-                relevant_input = torch.nn.functional.pad(
-                    relevant_input,
-                    [
-                        padding[2] if sides.left else 0,
-                        padding[2] if sides.right else 0,
-                        padding[1] if sides.top else 0,
-                        padding[1] if sides.bottom else 0,
-                    ],
-                )
-
-            # Calculate the kernel gradients with the new unseen gradient values
-            relevant_grad = relevant_grad.contiguous()
-
-            grad_weight = torch.nn.grad.conv2d_weight(
-                relevant_input.to(weight.dtype),
-                weight.shape,
-                relevant_grad.to(weight.dtype),
-                stride[1:3],
-                (0, 0),  # padding
-                dilation,
-                groups,
-            )
-
+            # Keep bias-gradient accumulation based on the unique grad_output region.
             if bias is not None:
                 grad_bias = relevant_grad[0].sum((1, 2))
 
-            del relevant_input
+            weight_lost_top = 0 if sides.top else int(weight_grad_lost.top)
+            weight_lost_bottom = 0 if sides.bottom else int(weight_grad_lost.bottom)
+            weight_lost_left = 0 if sides.left else int(weight_grad_lost.left)
+            weight_lost_right = 0 if sides.right else int(weight_grad_lost.right)
+            safe_top = max(weight_lost_top - lost_top, 0)
+            safe_left = max(weight_lost_left - lost_left, 0)
+            safe_bottom = valid_grad.shape[H_DIM] - max(weight_lost_bottom - lost_bottom, 0)
+            safe_right = valid_grad.shape[W_DIM] - max(weight_lost_right - lost_right, 0)
+
+            box_top = max(new_output_box.y, safe_top)
+            box_left = max(new_output_box.x, safe_left)
+            box_bottom = min(new_output_box.y + new_output_box.height, safe_bottom)
+            box_right = min(new_output_box.x + new_output_box.width, safe_right)
+
+            if box_bottom > box_top and box_right > box_left:
+                relevant_grad = valid_grad[:, :, box_top:box_bottom, box_left:box_right]
+
+                input_y = (box_top + lost_top) * stride[1] - padding[1]
+                input_x = (box_left + lost_left) * stride[2] - padding[2]
+                input_x = max(0, input_x)
+                input_y = max(0, input_y)
+
+                relevant_input_height = relevant_grad.shape[H_DIM] * stride[1] + (kernel_size[1] - 1)
+                relevant_input_width = relevant_grad.shape[W_DIM] * stride[2] + (kernel_size[2] - 1)
+                relevant_input = inpt[
+                    :, :, input_y : input_y + relevant_input_height, input_x : input_x + relevant_input_width
+                ]
+
+                if (padding[0] > 0 or padding[1] > 0 or padding[2] > 0) and (
+                    sides.top or sides.left or sides.right or sides.bottom
+                ):
+                    crop_bottom = padding[1] if sides.top else 0
+                    crop_right = padding[2] if sides.left else 0
+                    relevant_input = inpt[
+                        :,
+                        :,
+                        input_y : input_y + relevant_input_height - crop_bottom,
+                        input_x : input_x + relevant_input_width - crop_right,
+                    ]
+
+                    relevant_input = torch.nn.functional.pad(
+                        relevant_input,
+                        [
+                            padding[2] if sides.left else 0,
+                            padding[2] if sides.right else 0,
+                            padding[1] if sides.top else 0,
+                            padding[1] if sides.bottom else 0,
+                        ],
+                    )
+
+                relevant_grad = relevant_grad.contiguous()
+                grad_weight = torch.nn.grad.conv2d_weight(
+                    relevant_input.to(weight.dtype),
+                    weight.shape,
+                    relevant_grad.to(weight.dtype),
+                    stride[1:3],
+                    (0, 0),
+                    dilation,
+                    groups,
+                )
+                del relevant_input
+            else:
+                grad_weight = torch.zeros_like(weight)
+
             del relevant_grad
         else:
             # if self.verbose and not hasattr(self, '_inefficient_tile_shape_warning'):
@@ -176,9 +186,9 @@ class StreamingConv2dF(torch.autograd.Function):
                 grad_bias = torch.zeros_like(bias)
 
         if bias is not None:
-            return (grad_in, grad_weight, grad_bias, None, None, None, None, None, None, None, None)
+            return (grad_in, grad_weight, grad_bias, None, None, None, None, None, None, None, None, None)
         else:
-            return (grad_in, grad_weight, None, None, None, None, None, None, None, None, None)
+            return (grad_in, grad_weight, None, None, None, None, None, None, None, None, None, None)
 
 
 conv2d = StreamingConv2dF.apply  # type:ignore
@@ -215,6 +225,7 @@ class StreamingConv2d(_ConvNd):
             padding_mode,
         )
         self.grad_lost = Lost(0, 0, 0, 0)
+        self.weight_grad_lost = Lost(0, 0, 0, 0)
         self.reset()
 
     @classmethod
@@ -273,6 +284,7 @@ class StreamingConv2d(_ConvNd):
             self.dilation,
             self.groups,
             self.grad_lost,
+            self.weight_grad_lost,
             self.seen_indices,
             self.output_stride,
             self.input_loc,


### PR DESCRIPTION
### Motivation
- Reduce false-positive conv weight gradients when input activations improve but post-upsampling weight gradients remain above baseline by marking seam-sensitive upsample outputs and propagating activation-validity to conv weight-gradient selection.

### Description
- Add utility helpers `_max_lost` and `_ceil_div` and new methods `_upsample_activation_lost` and `_conv_weight_grad_lost` to `StreamingCNN` in `lightstream/core/scnn/scnn.py` to compute activation-validity and derive conv `weight_grad_lost` from input activation validity, kernel/dilation/padding and strides.
- Propagate `activation_valid_lost` through pointwise layers and make bilinear-type `Upsample` mark seam-sensitive borders invalid in the forward statistics gathering; store `weight_grad_lost` in per-module stats for convs.
- Copy `weight_grad_lost` into `StreamingConv2d` instances during streaming conversion so streaming convs carry both `grad_lost` and `weight_grad_lost` metadata.
- Extend `StreamingConv2dF.forward`/`backward` signatures to accept `weight_grad_lost` and, in `backward`, intersect the unique `grad_output` region with the weight-gradient-safe region before calling `torch.nn.grad.conv2d_weight`, while keeping bias-gradient accumulation unchanged.

### Testing
- Ran `python -m py_compile lightstream/core/scnn/scnn.py lightstream/core/scnn/streamingconv.py`, which succeeded.
- Performed a small runtime smoke test invoking a `StreamingConv2d` forward+backward to verify `weight`/`bias` gradients and the new backward path; the smoke test succeeded.
- Ran `pytest tests/test_streamingupsample.py tests/test_scnn.py -q`, which failed during collection due to `numpy` not being installed in the environment (test collection error), so full test suite could not be validated here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2fdd77d100833087e45b151d29ec7e)