### PR TITLE
Use backward-valid tile stats for StreamingConv2d input gradients

### DIFF
--- a/lightstream/core/scnn/scnn.py
+++ b/lightstream/core/scnn/scnn.py
@@ -592,6 +592,7 @@ class StreamingCNN(torch.nn.Module):
                 mod = StreamingConv2d.from_torch_conv2d(module)
                 mod.grad_lost = self._module_stats[module]["grad_lost"]
                 mod.weight_grad_lost = self._module_stats[module].get("weight_grad_lost", Lost(0, 0, 0, 0))
+                mod.backward_valid_lost = self._module_stats[module].get("backward_valid_lost", Lost(0, 0, 0, 0))
                 mod.output_stride = self._module_stats[module]["output_stride"]
                 self._module_stats[mod] = self._module_stats[module]
                 del self._module_stats[module]

--- a/lightstream/core/scnn/streamingconv.py
+++ b/lightstream/core/scnn/streamingconv.py
@@ -15,7 +15,20 @@ class StreamingConv2dF(torch.autograd.Function):
     @staticmethod
     @custom_fwd(device_type="cuda", cast_inputs=torch.bfloat16 if torch.cuda.is_bf16_supported() else torch.float16)
     def forward(
-        ctx, inpt, weight, bias, stride, padding, dilation, groups, grad_lost, weight_grad_lost, seen_indices, output_stride, input_loc
+        ctx,
+        inpt,
+        weight,
+        bias,
+        stride,
+        padding,
+        dilation,
+        groups,
+        grad_lost,
+        weight_grad_lost,
+        backward_valid_lost,
+        seen_indices,
+        output_stride,
+        input_loc,
     ):
         ctx.save_for_backward(inpt, weight, bias)
         ctx.stride = stride
@@ -24,6 +37,7 @@ class StreamingConv2dF(torch.autograd.Function):
         ctx.groups = groups
         ctx.grad_lost = grad_lost
         ctx.weight_grad_lost = weight_grad_lost
+        ctx.backward_valid_lost = backward_valid_lost
         ctx.seen_indices = seen_indices
         ctx.output_stride = output_stride
         ctx.input_loc = input_loc
@@ -43,6 +57,7 @@ class StreamingConv2dF(torch.autograd.Function):
         seen_indices = ctx.seen_indices
         grad_lost = ctx.grad_lost  # Type: Lost
         weight_grad_lost = ctx.weight_grad_lost  # Type: Lost
+        backward_valid_lost = ctx.backward_valid_lost  # Type: Lost
         output_stride = ctx.output_stride
         grad_bias = None
         kernel_size = weight.shape[-1]
@@ -60,6 +75,23 @@ class StreamingConv2dF(torch.autograd.Function):
                 dilation,
                 groups,
             )
+            lost_top = backward_valid_lost.top if not sides.top else 0
+            lost_bottom = backward_valid_lost.bottom if not sides.bottom else 0
+            lost_left = backward_valid_lost.left if not sides.left else 0
+            lost_right = backward_valid_lost.right if not sides.right else 0
+            masked_grad_in = torch.zeros_like(grad_in)
+            masked_grad_in[
+                :,
+                :,
+                lost_top : grad_in.shape[H_DIM] - lost_bottom,
+                lost_left : grad_in.shape[W_DIM] - lost_right,
+            ] = grad_in[
+                :,
+                :,
+                lost_top : grad_in.shape[H_DIM] - lost_bottom,
+                lost_left : grad_in.shape[W_DIM] - lost_right,
+            ]
+            grad_in = masked_grad_in
         else:
             grad_in = None
 
@@ -186,9 +218,9 @@ class StreamingConv2dF(torch.autograd.Function):
                 grad_bias = torch.zeros_like(bias)
 
         if bias is not None:
-            return (grad_in, grad_weight, grad_bias, None, None, None, None, None, None, None, None, None)
+            return (grad_in, grad_weight, grad_bias, None, None, None, None, None, None, None, None, None, None)
         else:
-            return (grad_in, grad_weight, None, None, None, None, None, None, None, None, None, None)
+            return (grad_in, grad_weight, None, None, None, None, None, None, None, None, None, None, None)
 
 
 conv2d = StreamingConv2dF.apply  # type:ignore
@@ -226,6 +258,7 @@ class StreamingConv2d(_ConvNd):
         )
         self.grad_lost = Lost(0, 0, 0, 0)
         self.weight_grad_lost = Lost(0, 0, 0, 0)
+        self.backward_valid_lost = Lost(0, 0, 0, 0)
         self.reset()
 
     @classmethod
@@ -285,6 +318,7 @@ class StreamingConv2d(_ConvNd):
             self.groups,
             self.grad_lost,
             self.weight_grad_lost,
+            self.backward_valid_lost,
             self.seen_indices,
             self.output_stride,
             self.input_loc,


### PR DESCRIPTION
### Motivation
- Ensure conv backward propagation respects per-tile "backward valid" statistics so invalid border regions do not propagate gradients upstream, improving bias and input-gradient accuracy while keeping later layers behavior unchanged.

### Description
- Confirmed `backward_valid_lost` is produced by the backward statistics hook and propagated into converted modules via `_convert_modules_for_streaming` by copying `mod.backward_valid_lost = _module_stats[module].get("backward_valid_lost", Lost(0,0,0,0))`.
- Added `self.backward_valid_lost = Lost(0, 0, 0, 0)` to `StreamingConv2d.__init__` and passed it through `StreamingConv2d.forward` into `StreamingConv2dF.apply`.
- Stored `backward_valid_lost` on the autograd context in `StreamingConv2dF.forward` and read it in `StreamingConv2dF.backward` as `ctx.backward_valid_lost`.
- In `StreamingConv2dF.backward` applied side-aware masking (using `ctx.input_loc.sides`) to `grad_in` after computing it via `conv2d_input`, by copying only the valid center region into a zero tensor and returning the masked `grad_in`, while leaving `grad_weight`/`grad_bias` ownership logic unchanged.

### Testing
- Ran `python -m py_compile lightstream/core/scnn/streamingconv.py lightstream/core/scnn/scnn.py`, which succeeded without syntax errors.
- Attempted `pytest tests/test_scnn.py tests/test_streamingupsample.py tests/test_streaminglayernorm.py`, but collection failed due to missing dependency `numpy` (two import errors during collection).
- Attempted `python -m pip install numpy` to satisfy test dependencies, but package install was blocked by package-index access (HTTP 403), so full test run could not complete.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2fe3e082e08330b3d4c1746eeb8c58)