### PR TITLE
Revert experimental StreamingConv2d grad masking

### DIFF
--- a/lightstream/core/scnn/scnn.py
+++ b/lightstream/core/scnn/scnn.py
@@ -575,7 +575,6 @@ class StreamingCNN(torch.nn.Module):
             if module in self._module_stats:
                 mod = StreamingConv2d.from_torch_conv2d(module)
                 mod.grad_lost = self._module_stats[module]["grad_lost"]
-                mod.backward_valid_lost = self._module_stats[module].get("backward_valid_lost", Lost(0, 0, 0, 0))
                 mod.output_stride = self._module_stats[module]["output_stride"]
                 self._module_stats[mod] = self._module_stats[module]
                 del self._module_stats[module]

--- a/lightstream/core/scnn/streamingconv.py
+++ b/lightstream/core/scnn/streamingconv.py
@@ -24,7 +24,6 @@ class StreamingConv2dF(torch.autograd.Function):
         dilation,
         groups,
         grad_lost,
-        backward_valid_lost,
         seen_indices,
         output_stride,
         input_loc,
@@ -35,7 +34,6 @@ class StreamingConv2dF(torch.autograd.Function):
         ctx.dilation = dilation
         ctx.groups = groups
         ctx.grad_lost = grad_lost
-        ctx.backward_valid_lost = backward_valid_lost
         ctx.seen_indices = seen_indices
         ctx.output_stride = output_stride
         ctx.input_loc = input_loc
@@ -54,7 +52,6 @@ class StreamingConv2dF(torch.autograd.Function):
         sides = ctx.input_loc.sides  # Type: Sides
         seen_indices = ctx.seen_indices
         grad_lost = ctx.grad_lost  # Type: Lost
-        backward_valid_lost = ctx.backward_valid_lost  # Type: Lost
         output_stride = ctx.output_stride
         grad_bias = None
         kernel_size = weight.shape[-1]
@@ -72,23 +69,6 @@ class StreamingConv2dF(torch.autograd.Function):
                 dilation,
                 groups,
             )
-            lost_top = backward_valid_lost.top if not sides.top else 0
-            lost_bottom = backward_valid_lost.bottom if not sides.bottom else 0
-            lost_left = backward_valid_lost.left if not sides.left else 0
-            lost_right = backward_valid_lost.right if not sides.right else 0
-            masked_grad_in = torch.zeros_like(grad_in)
-            masked_grad_in[
-                :,
-                :,
-                lost_top : grad_in.shape[H_DIM] - lost_bottom,
-                lost_left : grad_in.shape[W_DIM] - lost_right,
-            ] = grad_in[
-                :,
-                :,
-                lost_top : grad_in.shape[H_DIM] - lost_bottom,
-                lost_left : grad_in.shape[W_DIM] - lost_right,
-            ]
-            grad_in = masked_grad_in
         else:
             grad_in = None
 
@@ -207,9 +187,9 @@ class StreamingConv2dF(torch.autograd.Function):
                 grad_bias = torch.zeros_like(bias)
 
         if bias is not None:
-            return (grad_in, grad_weight, grad_bias, None, None, None, None, None, None, None, None, None)
+            return (grad_in, grad_weight, grad_bias, None, None, None, None, None, None, None, None)
         else:
-            return (grad_in, grad_weight, None, None, None, None, None, None, None, None, None, None)
+            return (grad_in, grad_weight, None, None, None, None, None, None, None, None, None)
 
 
 conv2d = StreamingConv2dF.apply  # type:ignore
@@ -246,7 +226,6 @@ class StreamingConv2d(_ConvNd):
             padding_mode,
         )
         self.grad_lost = Lost(0, 0, 0, 0)
-        self.backward_valid_lost = Lost(0, 0, 0, 0)
         self.reset()
 
     @classmethod
@@ -305,7 +284,6 @@ class StreamingConv2d(_ConvNd):
             self.dilation,
             self.groups,
             self.grad_lost,
-            self.backward_valid_lost,
             self.seen_indices,
             self.output_stride,
             self.input_loc,


### PR DESCRIPTION
### Motivation

- Remove experimental backward-validity masking introduced while debugging upsample backward and restore the stable `StreamingConv2d` autograd behavior. 
- Ensure `grad_in` is produced by the canonical convolution input gradient path and stop carrying experimental runtime fields into streaming conversion. 
- Keep existing forward alignment and upsample metadata handling that are known-good.

### Description

- Removed the experimental `backward_valid_lost` parameter from `StreamingConv2dF.forward` and stopped storing it on the autograd `ctx`. (file: `lightstream/core/scnn/streamingconv.py`).
- Restored backward behavior to compute `grad_in` via `torch.nn.grad.conv2d_input(...)` and removed the experimental masking/cropping of the returned `grad_in`. (file: `lightstream/core/scnn/streamingconv.py`).
- Adjusted the backward return tuple to remove the extra experimental `None` slots added for the removed argument. (file: `lightstream/core/scnn/streamingconv.py`).
- Removed the `self.backward_valid_lost` runtime attribute from `StreamingConv2d.__init__` and stopped passing it from `StreamingConv2d.forward` into `conv2d(...)`. (file: `lightstream/core/scnn/streamingconv.py`).
- Stopped copying `backward_valid_lost` into `StreamingConv2d` during conversion in `_convert_modules_for_streaming`, while leaving upsample-related metadata handling intact. (file: `lightstream/core/scnn/scnn.py`).

### Testing

- Ran `python -m py_compile lightstream/core/scnn/streamingconv.py` which succeeded. 
- Executed a small runtime smoke test that instantiates a `StreamingConv2d`, performs a forward and `backward`, and verified `x.grad.shape` and `weight.grad.shape` are as expected, which succeeded. 
- Attempted targeted `pytest` runs but they were blocked by a missing environment dependency (`ModuleNotFoundError: No module named 'numpy'`) so the full test-suite parity check could not complete. 
- Attempted to install `numpy` via `pip` to unblock tests but the environment blocked package index access (network restriction), so `pytest` remains unrun in this session.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2fed47679c83308541d4f8726b2e72)