### PR TITLE
Account for upsample lost regions in tile-step planning

### DIFF
--- a/lightstream/core/scnn/scnn.py
+++ b/lightstream/core/scnn/scnn.py
@@ -471,7 +471,14 @@ class StreamingCNN(torch.nn.Module):
         raise TypeError(f"Unsupported output spec kind: {kind}")
 
     def _compute_internal_safe_input_step(self):
-        """Compute conservative input-step bounds from per-layer backward stats."""
+        """Compute conservative input-step bounds from per-layer lost-region stats.
+
+        Upsampling layers report two different losses in layer-local coordinates:
+        forward loss is measured on the high-resolution upsample output, while
+        backward input loss is measured on the low-resolution gradient input.
+        Convert both to input-image coordinates before comparing them to the
+        input tile size so tile overlap covers the largest lost border.
+        """
         candidates_h = []
         candidates_w = []
 
@@ -487,15 +494,63 @@ class StreamingCNN(torch.nn.Module):
                     candidates_h.append(step_h)
                     candidates_w.append(step_w)
             elif isinstance(mod, StreamingUpsample2d):
-                input_lost = getattr(mod, "upsample_backward_input_lost", None)
-                if input_lost is None:
-                    continue
-                output_stride = getattr(mod, "pre_upsample_output_stride", torch.tensor([1, 1, 1]))
-                step_h = self.tile_shape[H_DIM] - int(input_lost.top + input_lost.bottom) * int(output_stride[1])
-                step_w = self.tile_shape[W_DIM] - int(input_lost.left + input_lost.right) * int(output_stride[2])
-                if step_h > 0 and step_w > 0:
-                    candidates_h.append(step_h)
-                    candidates_w.append(step_w)
+                stats = self._module_stats.get(mod, {})
+                forward_lost = stats.get("lost")
+                backward_input_lost = stats.get(
+                    "upsample_backward_input_lost",
+                    getattr(mod, "upsample_backward_input_lost", None),
+                )
+                pre_upsample_output_stride = torch.as_tensor(
+                    getattr(mod, "pre_upsample_output_stride", torch.tensor([1, 1, 1])),
+                    dtype=torch.long,
+                )
+                post_upsample_output_stride = torch.as_tensor(
+                    getattr(
+                        mod,
+                        "post_upsample_output_stride",
+                        getattr(mod, "output_stride", torch.tensor([1, 1, 1])),
+                    ),
+                    dtype=torch.long,
+                )
+
+                upsample_candidates_h = []
+                upsample_candidates_w = []
+                if forward_lost is not None:
+                    step_h = self.tile_shape[H_DIM] - int(forward_lost.top + forward_lost.bottom) * int(
+                        post_upsample_output_stride[1]
+                    )
+                    step_w = self.tile_shape[W_DIM] - int(forward_lost.left + forward_lost.right) * int(
+                        post_upsample_output_stride[2]
+                    )
+                    if step_h > 0 and step_w > 0:
+                        candidates_h.append(step_h)
+                        candidates_w.append(step_w)
+                        upsample_candidates_h.append(step_h)
+                        upsample_candidates_w.append(step_w)
+                if backward_input_lost is not None:
+                    step_h = self.tile_shape[H_DIM] - int(
+                        backward_input_lost.top + backward_input_lost.bottom
+                    ) * int(pre_upsample_output_stride[1])
+                    step_w = self.tile_shape[W_DIM] - int(
+                        backward_input_lost.left + backward_input_lost.right
+                    ) * int(pre_upsample_output_stride[2])
+                    if step_h > 0 and step_w > 0:
+                        candidates_h.append(step_h)
+                        candidates_w.append(step_w)
+                        upsample_candidates_h.append(step_h)
+                        upsample_candidates_w.append(step_w)
+                if upsample_candidates_h and upsample_candidates_w:
+                    self._print_verbose(
+                        "Upsample safe tile step",
+                        {
+                            "module": mod,
+                            "forward_lost": forward_lost,
+                            "backward_input_lost": backward_input_lost,
+                            "pre_upsample_output_stride": pre_upsample_output_stride,
+                            "post_upsample_output_stride": post_upsample_output_stride,
+                            "safe_tile_step": (min(upsample_candidates_h), min(upsample_candidates_w)),
+                        },
+                    )
 
         # Fallback to global backward-safe span if per-layer stats are unavailable
         grad_safe_h = self.tile_shape[H_DIM] - self.tile_gradient_lost.top - self.tile_gradient_lost.bottom
@@ -853,6 +908,9 @@ class StreamingCNN(torch.nn.Module):
             1,
             valid_output_widths[0] * int(self._output_stride_per_output[0][2]),
         )
+        grad_safe_h, grad_safe_w = self._compute_internal_safe_input_step()
+        valid_input_height = min(valid_input_height, int(grad_safe_h))
+        valid_input_width = min(valid_input_width, int(grad_safe_w))
 
         internal_align_h, internal_align_w = self._compute_internal_alignment()
         align_h = math.lcm(int(self._output_stride_per_output[0][1]), internal_align_h)

--- a/tests/test_streamingupsample.py
+++ b/tests/test_streamingupsample.py
@@ -204,3 +204,51 @@ def test_upsample_backward_statistics_store_backward_valid_lost():
     scnn._backward_gather_statistics_hook(module, (inpt.grad,), (torch.ones_like(output),))
 
     assert scnn._module_stats[module]["backward_valid_lost"] == Lost(0, 0, 0, 0)
+
+
+def test_safe_input_step_accounts_for_upsample_forward_and_backward_lost_regions():
+    scnn = StreamingCNN.__new__(StreamingCNN)
+    scnn.tile_shape = (1, 1, 64, 64)
+    scnn.tile_gradient_lost = Lost(0, 0, 0, 0)
+    scnn._print_verbose = lambda *args, **kwargs: None
+
+    module = StreamingUpsample2d(scale_factor=2, mode="bilinear", align_corners=False)
+    module.grad_lost = Lost(top=3, left=5, bottom=7, right=11)
+    module.upsample_backward_input_lost = Lost(top=2, left=4, bottom=6, right=8)
+    module.pre_upsample_output_stride = torch.tensor([1, 4, 4])
+    module.output_stride = torch.tensor([1, 2, 2])
+    module.post_upsample_output_stride = module.output_stride
+    scnn.stream_module = torch.nn.Sequential(module)
+    scnn._module_stats = {module: {"lost": Lost(top=3, left=5, bottom=7, right=11)}}
+
+    safe_h, safe_w = scnn._compute_internal_safe_input_step()
+
+    # Forward loss is in post-upsample output coordinates:
+    #   H: 64 - (3 + 7) * 2 = 44
+    #   W: 64 - (5 + 11) * 2 = 32
+    # Backward input loss is in pre-upsample low-resolution coordinates:
+    #   H: 64 - (2 + 6) * 4 = 32
+    #   W: 64 - (4 + 8) * 4 = 16
+    assert (safe_h, safe_w) == (32, 16)
+
+
+def test_single_output_valid_input_step_is_reduced_by_upsample_safe_step_without_losing_alignment():
+    scnn = StreamingCNN.__new__(StreamingCNN)
+    scnn.tile_shape = (1, 1, 64, 64)
+    scnn.tile_gradient_lost = Lost(0, 0, 0, 0)
+    scnn._tile_output_shapes = [(1, 1, 32, 32)]
+    scnn._output_stride_per_output = [torch.tensor([1, 2, 2])]
+    scnn._print_verbose = lambda *args, **kwargs: None
+
+    module = StreamingUpsample2d(scale_factor=2, mode="bilinear", align_corners=False)
+    module.grad_lost = Lost(top=0, left=0, bottom=0, right=0)
+    module.upsample_backward_input_lost = Lost(top=3, left=3, bottom=3, right=3)
+    module.pre_upsample_output_stride = torch.tensor([1, 4, 4])
+    module.output_stride = torch.tensor([1, 2, 2])
+    module.post_upsample_output_stride = module.output_stride
+    scnn.stream_module = torch.nn.Sequential(module)
+    scnn._module_stats = {module: {"lost": Lost(top=0, left=0, bottom=0, right=0)}}
+
+    step_h, step_w = scnn._compute_valid_input_step([32], [32])
+
+    assert (step_h, step_w) == (40, 40)


### PR DESCRIPTION
### Motivation
- Upsampling layers report lost regions in two coordinate spaces (high-res forward output and low-res backward input) which were not being converted into input-image coordinates when computing safe tile steps, causing overlaps that might be too small to cover upsample border losses.
- The single-output tiling path did not apply the conservative per-layer safe-step reduction computed from backward stats, allowing gaps for upsample losses.
- Additional per-upsample diagnostics are useful to debug how forward/backward lost and pre/post upsample strides affect the safe tile step.

### Description
- Include `StreamingUpsample2d` modules in `_compute_internal_safe_input_step` and convert both forward lost (high-resolution) and backward low-resolution grad-input lost into input-image coordinates using `post_upsample_output_stride` and `pre_upsample_output_stride`, respectively. 
- When both forward and backward lost are present, compute candidate safe tile steps from both and log per-upsample diagnostics including `forward_lost`, `backward_input_lost`, `pre_upsample_output_stride`, `post_upsample_output_stride`, and the computed `safe_tile_step` via `self._print_verbose`.
- Use stored module stats (when available) for upsample forward lost (`lost`) and fallback to module attributes where needed.
- Apply the computed internal safe input step to the single-output code-path in `_compute_valid_input_step` by reducing the valid input height/width to the conservative safe values, while preserving the existing internal alignment rounding from `_compute_internal_alignment`.
- Added unit tests in `tests/test_streamingupsample.py` that validate conversion of forward/backward upsample lost into safe tile steps and that single-output valid input step is reduced by the upsample-safe step without losing alignment.

### Testing
- `python -m py_compile lightstream/core/scnn/scnn.py tests/test_streamingupsample.py` was run and succeeded.
- `pytest tests/test_streamingupsample.py -q` was attempted but collection failed because the environment is missing `numpy`, so the tests could not be executed end-to-end in this environment.
- An attempt to install `numpy` via `python -m pip install numpy` was blocked by the environment (package index/proxy returned `403 Forbidden`), preventing running the full pytest suite here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a301126a35c8330a5c42e1acd68bd47)