### PR TITLE
Use low-resolution lost region for upsample backward

### DIFF
--- a/lightstream/core/scnn/scnn.py
+++ b/lightstream/core/scnn/scnn.py
@@ -673,6 +673,7 @@ class StreamingCNN(torch.nn.Module):
                     "side_aware_grad_lost",
                     "backward_valid_lost",
                     "upsample_backward_input_lost",
+                    "upsample_forward_output_lost",
                 ):
                     if key in stats and hasattr(mod, key):
                         setattr(mod, key, stats[key])
@@ -724,6 +725,7 @@ class StreamingCNN(torch.nn.Module):
                 stats["post_upsample_output_stride"] = module.output_stride
                 stats["backward_valid_lost"] = module.backward_valid_lost
                 stats["upsample_backward_input_lost"] = module.upsample_backward_input_lost
+                stats["upsample_forward_output_lost"] = module.upsample_forward_output_lost
                 if module.scale_factor is not None:
                     sf = module.scale_factor
                     stats["scale_factor_hw"] = (
@@ -1861,6 +1863,7 @@ class StreamingCNN(torch.nn.Module):
             }
             if is_upsample:
                 module_stats["backward_valid_lost"] = Lost(0, 0, 0, 0)
+                module_stats["upsample_forward_output_lost"] = module_stats["lost"]
 
             self._print_verbose(module, "\n", module_stats["lost"])
 

--- a/lightstream/core/scnn/streamingupsample.py
+++ b/lightstream/core/scnn/streamingupsample.py
@@ -1,7 +1,5 @@
 from __future__ import annotations
 
-import logging
-import math
 from typing import Optional
 
 import torch
@@ -9,10 +7,8 @@ import torch.nn as nn
 import torch.nn.functional as F
 from torch.amp import custom_bwd, custom_fwd
 
-from lightstream.core.scnn.utils import Box, Lost, _new_value_indices, H_DIM, W_DIM
+from lightstream.core.scnn.utils import Box, Lost, H_DIM, W_DIM
 
-
-logger = logging.getLogger(__name__)
 
 
 class StreamingUpsample2dF(torch.autograd.Function):
@@ -61,196 +57,11 @@ class StreamingUpsample2dF(torch.autograd.Function):
     def backward(ctx, grad_output):
         (inpt,) = ctx.saved_tensors
         sides = ctx.input_loc.sides
-        grad_lost = ctx.grad_lost
         upsample_backward_input_lost = (
             ctx.upsample_backward_input_lost
             if ctx.upsample_backward_input_lost is not None
             else ctx.backward_valid_lost or Lost(0, 0, 0, 0)
         )
-
-        lost_top = grad_lost.top if not sides.top else 0
-        lost_bottom = grad_lost.bottom if not sides.bottom else 0
-        lost_left = grad_lost.left if not sides.left else 0
-        lost_right = grad_lost.right if not sides.right else 0
-
-        H = grad_output.shape[H_DIM]
-        W = grad_output.shape[W_DIM]
-
-        pre_output_stride = ctx.pre_upsample_output_stride
-        stride_h = int(pre_output_stride[1].item()) if isinstance(pre_output_stride, torch.Tensor) else int(pre_output_stride[1])
-        stride_w = int(pre_output_stride[2].item()) if isinstance(pre_output_stride, torch.Tensor) else int(pre_output_stride[2])
-
-        data_loc_y = int(ctx.input_loc.y // stride_h)
-        data_loc_x = int(ctx.input_loc.x // stride_w)
-        data_loc = Box(data_loc_y, 0, data_loc_x, 0, ctx.input_loc.sides)
-
-        owned_lowres_box, updated_total_indices = _new_value_indices(inpt.shape, data_loc, ctx.seen_indices)
-
-        def _bilinear_backward_support(start: int, length: int, in_size: int, out_size: int) -> tuple[int, int]:
-            if length <= 0:
-                return 0, 0
-            end = start + length
-            if out_size <= 0:
-                return 0, 0
-            scale = float(out_size) / float(max(1, in_size))
-            # For align_corners=False, output coordinate o samples input coordinate
-            # (o + 0.5) / scale - 0.5. An input index i receives gradients from
-            # output locations whose sampling coordinate lies in (i - 1, i + 1).
-            # This conservative integer envelope includes all high-resolution
-            # locations that can contribute to any owned low-resolution index.
-            support_start = math.floor(scale * (float(start) - 0.5) - 0.5) + 1
-            support_end = math.ceil(scale * (float(end) + 0.5) - 0.5)
-            return max(0, support_start), min(out_size, support_end)
-
-        valid_top = lost_top
-        valid_bottom = H - lost_bottom
-        valid_left = lost_left
-        valid_right = W - lost_right
-
-        owned_support_top, owned_support_bottom = _bilinear_backward_support(
-            owned_lowres_box.y, owned_lowres_box.height, inpt.shape[H_DIM], H
-        )
-        owned_support_left, owned_support_right = _bilinear_backward_support(
-            owned_lowres_box.x, owned_lowres_box.width, inpt.shape[W_DIM], W
-        )
-        clipped_support_edges = []
-        if owned_support_top < valid_top:
-            clipped_support_edges.append("top")
-        if owned_support_bottom > valid_bottom:
-            clipped_support_edges.append("bottom")
-        if owned_support_left < valid_left:
-            clipped_support_edges.append("left")
-        if owned_support_right > valid_right:
-            clipped_support_edges.append("right")
-
-        low_y0 = owned_lowres_box.y
-        low_y1 = owned_lowres_box.y + owned_lowres_box.height
-        low_x0 = owned_lowres_box.x
-        low_x1 = owned_lowres_box.x + owned_lowres_box.width
-
-        while low_y0 < low_y1:
-            support_top, _ = _bilinear_backward_support(low_y0, 1, inpt.shape[H_DIM], H)
-            if support_top >= valid_top:
-                break
-            low_y0 += 1
-
-        while low_y0 < low_y1:
-            _, support_bottom = _bilinear_backward_support(low_y1 - 1, 1, inpt.shape[H_DIM], H)
-            if support_bottom <= valid_bottom:
-                break
-            low_y1 -= 1
-
-        while low_x0 < low_x1:
-            support_left, _ = _bilinear_backward_support(low_x0, 1, inpt.shape[W_DIM], W)
-            if support_left >= valid_left:
-                break
-            low_x0 += 1
-
-        while low_x0 < low_x1:
-            _, support_right = _bilinear_backward_support(low_x1 - 1, 1, inpt.shape[W_DIM], W)
-            if support_right <= valid_right:
-                break
-            low_x1 -= 1
-
-        complete_lowres_box = Box(
-            low_y0,
-            max(0, low_y1 - low_y0),
-            low_x0,
-            max(0, low_x1 - low_x0),
-            owned_lowres_box.sides,
-        )
-
-        if clipped_support_edges:
-            logger.debug(
-                "StreamingUpsample2dF.backward found owned low-res cells whose required high-res support "
-                "extends beyond valid grad_output bounds: input_loc=%s sides=%s tile_sides=%s "
-                "owned_lowres_box=%s required_support=(top=%s, bottom=%s, left=%s, right=%s) "
-                "valid_highres=(top=%s, bottom=%s, left=%s, right=%s) complete_lowres_box=%s clipped_edges=%s",
-                ctx.input_loc,
-                sides,
-                owned_lowres_box.sides,
-                owned_lowres_box,
-                owned_support_top,
-                owned_support_bottom,
-                owned_support_left,
-                owned_support_right,
-                valid_top,
-                valid_bottom,
-                valid_left,
-                valid_right,
-                complete_lowres_box,
-                tuple(clipped_support_edges),
-            )
-
-        owned_y1 = owned_lowres_box.y + owned_lowres_box.height
-        owned_x1 = owned_lowres_box.x + owned_lowres_box.width
-        skipped_top = complete_lowres_box.y - owned_lowres_box.y
-        skipped_left = complete_lowres_box.x - owned_lowres_box.x
-        skipped_bottom = owned_y1 - (complete_lowres_box.y + complete_lowres_box.height)
-        skipped_right = owned_x1 - (complete_lowres_box.x + complete_lowres_box.width)
-
-        dropped_cells = (
-            skipped_top * owned_lowres_box.width
-            + skipped_bottom * owned_lowres_box.width
-            + skipped_left * complete_lowres_box.height
-            + skipped_right * complete_lowres_box.height
-        )
-        if dropped_cells > 0:
-            logger.debug(
-                "StreamingUpsample2dF.backward dropped candidate low-res cells with incomplete high-res support: "
-                "dropped_cells=%s skipped=(top=%s, bottom=%s, left=%s, right=%s) "
-                "owned_lowres_box=%s complete_lowres_box=%s data_loc=%s "
-                "valid_highres=(top=%s, bottom=%s, left=%s, right=%s)",
-                dropped_cells,
-                skipped_top,
-                skipped_bottom,
-                skipped_left,
-                skipped_right,
-                owned_lowres_box,
-                complete_lowres_box,
-                data_loc,
-                valid_top,
-                valid_bottom,
-                valid_left,
-                valid_right,
-            )
-
-        if complete_lowres_box.height > 0 and complete_lowres_box.width > 0:
-            # seen_indices is a scan-order frontier and can represent only a contiguous
-            # prefix of emitted low-resolution cells. Advance it only over cells that
-            # were actually emitted; if the complete box does not start at the owned
-            # box origin, leave the frontier unchanged rather than marking a gap seen.
-            if complete_lowres_box.y == owned_lowres_box.y and complete_lowres_box.x == owned_lowres_box.x:
-                emitted_rel_bottom = complete_lowres_box.y + complete_lowres_box.height
-                emitted_rel_right = complete_lowres_box.x + complete_lowres_box.width
-                emitted_abs_bottom = data_loc.y + emitted_rel_bottom
-                emitted_abs_right = data_loc.x + emitted_rel_right
-
-                ctx.seen_indices.y = updated_total_indices.y
-                ctx.seen_indices.height = emitted_abs_bottom if data_loc.x == 0 else updated_total_indices.height
-                ctx.seen_indices.x = emitted_abs_right
-                ctx.seen_indices.width = updated_total_indices.width
-                ctx.seen_indices.sides = updated_total_indices.sides
-            else:
-                logger.debug(
-                    "StreamingUpsample2dF.backward did not advance seen_indices because emitted low-res cells "
-                    "do not form a contiguous scan-order prefix: owned_lowres_box=%s complete_lowres_box=%s",
-                    owned_lowres_box,
-                    complete_lowres_box,
-                )
-
-        support_top, support_bottom = _bilinear_backward_support(
-            complete_lowres_box.y, complete_lowres_box.height, inpt.shape[H_DIM], H
-        )
-        support_left, support_right = _bilinear_backward_support(
-            complete_lowres_box.x, complete_lowres_box.width, inpt.shape[W_DIM], W
-        )
-
-        grad_for_interp = torch.zeros_like(grad_output)
-        if valid_bottom > valid_top and valid_right > valid_left:
-            grad_for_interp[:, :, valid_top:valid_bottom, valid_left:valid_right] = grad_output[
-                :, :, valid_top:valid_bottom, valid_left:valid_right
-            ]
 
         if ctx.needs_input_grad[0]:
             with torch.enable_grad():
@@ -263,27 +74,28 @@ class StreamingUpsample2dF(torch.autograd.Function):
                     align_corners=ctx.align_corners,
                     recompute_scale_factor=ctx.recompute_scale_factor,
                 )
-                grad_in = torch.autograd.grad(out, inpt_grad, grad_for_interp, retain_graph=False, allow_unused=False)[0]
+                grad_in = torch.autograd.grad(out, inpt_grad, grad_output, retain_graph=False, allow_unused=False)[0]
         else:
             grad_in = None
 
         if grad_in is not None:
+            # Upsample backward maps a high-resolution gradient tile onto the
+            # low-resolution input lattice.  Statistics gathering computes how
+            # much of that low-resolution lattice lacks complete support for
+            # each border, so crop/zero in low-resolution coordinates here.
+            # Do not reuse the high-resolution grad_output loss directly: its
+            # units differ from grad_in after interpolation backward.
             input_lost_top = upsample_backward_input_lost.top if not sides.top else 0
             input_lost_bottom = upsample_backward_input_lost.bottom if not sides.bottom else 0
             input_lost_left = upsample_backward_input_lost.left if not sides.left else 0
             input_lost_right = upsample_backward_input_lost.right if not sides.right else 0
+
+            h_end = grad_in.shape[H_DIM] - input_lost_bottom
+            w_end = grad_in.shape[W_DIM] - input_lost_right
             masked_grad_in = torch.zeros_like(grad_in)
-            if grad_in.shape[H_DIM] > input_lost_top + input_lost_bottom and grad_in.shape[W_DIM] > input_lost_left + input_lost_right:
-                masked_grad_in[
-                    :,
-                    :,
-                    input_lost_top : grad_in.shape[H_DIM] - input_lost_bottom,
-                    input_lost_left : grad_in.shape[W_DIM] - input_lost_right,
-                ] = grad_in[
-                    :,
-                    :,
-                    input_lost_top : grad_in.shape[H_DIM] - input_lost_bottom,
-                    input_lost_left : grad_in.shape[W_DIM] - input_lost_right,
+            if h_end > input_lost_top and w_end > input_lost_left:
+                masked_grad_in[:, :, input_lost_top:h_end, input_lost_left:w_end] = grad_in[
+                    :, :, input_lost_top:h_end, input_lost_left:w_end
                 ]
             grad_in = masked_grad_in
 
@@ -329,6 +141,7 @@ class StreamingUpsample2d(nn.Module):
         self.side_aware_grad_lost = None
         self.backward_valid_lost = Lost(0, 0, 0, 0)
         self.upsample_backward_input_lost = None
+        self.upsample_forward_output_lost = None
         self.reset()
 
     def reset(self):

--- a/tests/test_streamingupsample.py
+++ b/tests/test_streamingupsample.py
@@ -146,20 +146,23 @@ def test_streaming_upsample_backward_valid_lost_does_not_depend_on_seen_indices_
     torch.testing.assert_close(x.grad[:, :, 1:3, 1:3], torch.full((1, 1, 2, 2), 4.0))
 
 
-def test_bilinear_upsample_backward_drops_incomplete_support_cells(caplog):
+def test_bilinear_upsample_backward_uses_stat_derived_lowres_lost_region():
     module = StreamingUpsample2d(scale_factor=2, mode="bilinear", align_corners=False)
-    module.grad_lost = Lost(top=0, left=0, bottom=1, right=1)
+    # This high-resolution grad-output loss is intentionally different from the
+    # low-resolution backward-input loss. The backward pass must not use it to
+    # crop grad_in directly.
+    module.grad_lost = Lost(top=0, left=0, bottom=99, right=99)
+    module.upsample_backward_input_lost = Lost(top=1, left=1, bottom=1, right=1)
     module.input_loc = Box(0, 0, 0, 0, Sides(left=0, top=0, right=0, bottom=0))
 
-    x = torch.ones(1, 1, 3, 3, requires_grad=True)
+    x = torch.ones(1, 1, 4, 4, requires_grad=True)
+    module(x).sum().backward()
 
-    with caplog.at_level("DEBUG", logger="lightstream.core.scnn.streamingupsample"):
-        module(x).sum().backward()
-
-    expected = torch.tensor([[[[4.0, 4.0, 2.0], [4.0, 4.0, 2.0], [2.0, 2.0, 1.0]]]])
+    expected = torch.tensor(
+        [[[[0.0, 0.0, 0.0, 0.0], [0.0, 4.0, 4.0, 0.0], [0.0, 4.0, 4.0, 0.0], [0.0, 0.0, 0.0, 0.0]]]]
+    )
     torch.testing.assert_close(x.grad, expected)
-    assert module.seen_indices == Box(0, 2, 2, 0, None)
-    assert "dropped candidate low-res cells with incomplete high-res support" in caplog.text
+    assert module.seen_indices == Box(0, 0, 0, 0, None)
 
 
 def test_upsample_statistics_store_pre_upsample_output_stride():


### PR DESCRIPTION
### Motivation
- Ensure the upsample backward pass uses the statistic-derived low-resolution lost region when cropping low-res gradients instead of reusing high-resolution grad-output lost metrics.

### Description
- Compute the interpolation backward from the full `grad_output` and then mask/zero the low-resolution `grad_in` using `upsample_backward_input_lost` in `StreamingUpsample2dF.backward` (replace previous high-res-based cropping logic). 
- Add `upsample_forward_output_lost` storage on `StreamingUpsample2d` and propagate both forward/backward upsample stats during module conversion in `_convert_modules_for_streaming` and reverse conversion. 
- Update the streaming upsample test to assert the backward uses the stat-derived low-res lost region (new regression test). 

### Testing
- Ran `python -m py_compile lightstream/core/scnn/streamingupsample.py lightstream/core/scnn/scnn.py tests/test_streamingupsample.py` and it succeeded. 
- Performed upsample-only and pool->upsample backward smoke tests via small Python scripts and both succeeded. 
- Ran `python -m pytest tests/test_streamingupsample.py -q` but collection failed because `numpy` is not available in the environment. 
- Ran a full-segment model smoke test which failed to run in this environment due to missing `lightning` dependency; the failure is environmental and unrelated to the change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a301661d5148330834a1ecec625af5a)