### PR TITLE
Align single-head backward tile iteration

### DIFF
--- a/lightstream/core/scnn/scnn.py
+++ b/lightstream/core/scnn/scnn.py
@@ -1264,6 +1264,24 @@ class StreamingCNN(torch.nn.Module):
         valid_grad_width = (tile_width - grad_lost.left - grad_lost.right) // int(self.output_stride[2])
         valid_grad_width *= int(self.output_stride[2])
 
+        internal_align_h, internal_align_w = self._compute_internal_alignment()
+        valid_grad_height = max(
+            internal_align_h,
+            (valid_grad_height // internal_align_h) * internal_align_h,
+        )
+        valid_grad_width = max(
+            internal_align_w,
+            (valid_grad_width // internal_align_w) * internal_align_w,
+        )
+
+        logger.debug(
+            "Backward single-head tiling step: valid_grad_height=%s, valid_grad_width=%s, internal_alignment=(%s, %s)",
+            valid_grad_height,
+            valid_grad_width,
+            internal_align_h,
+            internal_align_w,
+        )
+
         n_rows = math.ceil(float(image.shape[H_DIM] - grad_lost.top - grad_lost.bottom) / float(valid_grad_height))
         n_cols = math.ceil(float(image.shape[W_DIM] - grad_lost.left - grad_lost.right) / float(valid_grad_width))
 
@@ -1289,9 +1307,25 @@ class StreamingCNN(torch.nn.Module):
                 if sides_right:
                     output_x = max(base_grad.shape[W_DIM] - output_width, 0)
 
-                input_y = output_y * int(self.output_stride[1])
-                input_x = output_x * int(self.output_stride[2])
-                tile_iter.append((int(input_y), int(input_x), Sides(sides_left, sides_top, sides_right, sides_bottom)))
+                input_y = int(output_y * int(self.output_stride[1]))
+                input_x = int(output_x * int(self.output_stride[2]))
+                logger.debug(
+                    "Backward single-head tile start: y=%s, x=%s, sides=%s, internal_alignment=(%s, %s)",
+                    input_y,
+                    input_x,
+                    Sides(sides_left, sides_top, sides_right, sides_bottom),
+                    internal_align_h,
+                    internal_align_w,
+                )
+                assert input_y % internal_align_h == 0, (
+                    f"Backward single-head tile y-start {input_y} is not a multiple of "
+                    f"internal alignment {internal_align_h}"
+                )
+                assert input_x % internal_align_w == 0, (
+                    f"Backward single-head tile x-start {input_x} is not a multiple of "
+                    f"internal alignment {internal_align_w}"
+                )
+                tile_iter.append((input_y, input_x, Sides(sides_left, sides_top, sides_right, sides_bottom)))
 
         return tile_iter
 

--- a/tests/test_scnn.py
+++ b/tests/test_scnn.py
@@ -4,6 +4,7 @@ import pytest
 
 from lightstream.core.constructor import StreamingConstructor
 from lightstream.core.scnn.scnn import StreamingCNN
+from lightstream.core.scnn.utils import Lost
 from lightstream.models.testnet.segment import StreamingTestNet
 
 from lightstream.core.reducer import (
@@ -975,3 +976,26 @@ def test_internal_alignment_keeps_resnet_encoder_upsampling_decoder_tile_phase()
     image = torch.rand(1, 3, 224, 224)
     scnn.forward(image)
     _assert_non_edge_starts_match_alignment(scnn)
+
+
+def test_single_head_backward_tile_step_rounds_down_to_internal_alignment():
+    scnn = StreamingCNN.__new__(StreamingCNN)
+    scnn.tile_gradient_lost = Lost(left=78, top=78, right=78, bottom=78)
+    scnn.output_stride = torch.tensor([1, 1, 1])
+    scnn._tile_output_shape = (1, 1, 1920, 1920)
+    scnn._compute_internal_alignment = lambda: (8, 8)
+
+    image = torch.empty(1, 3, 4000, 1920)
+    grad_tensors = [torch.empty(1, 1, 4000, 1920)]
+
+    tile_iter = scnn._prepare_backward_tile_iter_single_head(
+        image=image,
+        grad_tensors=grad_tensors,
+        tile_height=1920,
+        tile_width=1920,
+    )
+
+    y_starts = [input_y for input_y, _input_x, _sides in tile_iter]
+    assert y_starts[:2] == [0, 1760]
+    assert 1764 not in y_starts
+    assert all(input_y % 8 == 0 and input_x % 8 == 0 for input_y, input_x, _sides in tile_iter)


### PR DESCRIPTION
### Motivation
- Single-head backward tiling could produce input-starts that violate internal sampling phase constraints (e.g. `1920 - 78 - 78 = 1764`), causing non-aligned tile starts; the backward step must respect internal alignment computed from strided layers.

### Description
- Compute internal alignment via `internal_align_h, internal_align_w = self._compute_internal_alignment()` in `_prepare_backward_tile_iter_single_head` and round the backward valid-gradient step down to a multiple of that alignment using `max(internal_align, (valid // internal_align) * internal_align)` for both height and width.
- Add a debug `logger.debug(...)` message reporting the backward single-head tiling step and internal alignment.
- Validate per-tile starts by logging each backward tile start and asserting `input_y % internal_align_h == 0` and `input_x % internal_align_w == 0` before appending to `tile_iter`.
- Add a regression unit test `test_single_head_backward_tile_step_rounds_down_to_internal_alignment` in `tests/test_scnn.py` that reproduces the `1920` tile / `78`-pixel lost margins case and asserts the starts advance by `1760` (not `1764`) and remain aligned to `8` pixels.

### Testing
- `python -m py_compile lightstream/core/scnn/scnn.py tests/test_scnn.py` succeeded.
- Running the new unit test with `pytest -q tests/test_scnn.py::test_single_head_backward_tile_step_rounds_down_to_internal_alignment` was attempted but blocked by the test environment missing `numpy` (ImportError during test collection).
- Attempt to install `numpy` (`python -m pip install numpy`) failed due to package index access restrictions, so full `pytest` validation could not be completed in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a30217955d883309bc7438f858db6ff)