### PR TITLE
Reuse forward tile starts for single-head backward replay

### DIFF
--- a/lightstream/core/scnn/scnn.py
+++ b/lightstream/core/scnn/scnn.py
@@ -976,6 +976,28 @@ class StreamingCNN(torch.nn.Module):
                 f"internal alignment {align_w}"
             )
 
+    def _tile_start_list(self, tile_iter):
+        """Return input-space tile starts for compact forward/backward diagnostics."""
+        return [(int(input_y), int(input_x)) for input_y, input_x, _ in tile_iter]
+
+    def _log_forward_tile_starts(self):
+        logger.debug("forward tile starts: %s", self._tile_start_list(self._last_forward_tiles))
+
+    def _log_backward_tile_starts(self, tile_iter):
+        logger.debug("backward tile starts: %s", self._tile_start_list(tile_iter))
+
+    def _validate_backward_tile_iter_matches_forward(self, tile_iter):
+        """Assert in debug mode that backward replays the exact forward tile starts."""
+        if not __debug__ or not self._last_forward_tiles:
+            return
+
+        forward_starts = self._tile_start_list(self._last_forward_tiles)
+        backward_starts = self._tile_start_list(tile_iter)
+        assert backward_starts == forward_starts, (
+            "Backward tile starts differ from forward tile starts: "
+            f"forward={forward_starts}, backward={backward_starts}"
+        )
+
     def _prepare_forward_outputs(self, image, output_heights, output_widths, result_device):
         outputs = [None] * len(self._tile_output_shapes)
 
@@ -1504,6 +1526,7 @@ class StreamingCNN(torch.nn.Module):
         assert last_sides is not None and last_sides.bottom and last_sides.right, (
             "It seems like we could not reconstruct all output"
         )
+        self._log_forward_tile_starts()
 
         self._validate_reducer_head_map_resolved()
 
@@ -1564,7 +1587,9 @@ class StreamingCNN(torch.nn.Module):
         for public_grad, internal_idx in zip(grad_tensors, public_indices):
             internal_grad_tensors[internal_idx] = public_grad
 
-        if len(self._tile_output_shapes) == 1:
+        if len(self._tile_output_shapes) == 1 and self._last_forward_tiles:
+            tile_iter = list(self._last_forward_tiles)
+        elif len(self._tile_output_shapes) == 1:
             tile_iter = self._prepare_backward_tile_iter_single_head(image, internal_grad_tensors, tile_height, tile_width)
         else:
             tile_iter = self._prepare_backward_tile_iter_multi_head(
@@ -1576,6 +1601,9 @@ class StreamingCNN(torch.nn.Module):
                 tile_height=tile_height,
                 tile_width=tile_width,
             )
+
+        self._log_backward_tile_starts(tile_iter)
+        self._validate_backward_tile_iter_matches_forward(tile_iter)
 
         self._validate_reducer_lifecycle_for_backward()
 


### PR DESCRIPTION
### Motivation
- Ensure single-head backward replay uses the exact aligned tile starts computed during forward so backward replay preserves internal sampling phase and reducer expectations.
- Avoid divergence between forward and backward tile traversal when forward already computed alignment-safe steps via internal safe-step and alignment logic.

### Description
- When available, `backward()` now reuses the recorded forward tiles stored in `self._last_forward_tiles` for the single-head case instead of recomputing a potentially different tiling step by `_prepare_backward_tile_iter_single_head()`.
- Added compact helpers ` _tile_start_list`, `_log_forward_tile_starts`, and `_log_backward_tile_starts` to emit debug logs `forward tile starts` and `backward tile starts`.
- Added `_validate_backward_tile_iter_matches_forward` which asserts (in debug mode) that backward tile starts equal the forward tile starts; the forward tiles continue to be produced by `_compute_valid_input_step`, `_compute_internal_safe_input_step`, `_compute_internal_alignment`, and `_iter_input_tiles`.
- Hooked forward logging after tiling and backward logging+validation before backward replay to surface mismatches early.

### Testing
- Ran `python -m py_compile lightstream/core/scnn/scnn.py` which succeeded.
- Ran `git diff --check` (no style/errors reported) as part of verification.
- Ran `python -m pytest tests/test_scnn.py tests/test_streamingupsample.py` which failed during collection due to the environment missing `numpy`, so test execution could not complete.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a302fec611483309d245621c9b4fbe0)