### PR TITLE
Add test: convert nearest Upsample to StreamingUpsample2d

### DIFF
--- a/tests/test_streamingupsample.py
+++ b/tests/test_streamingupsample.py
@@ -29,6 +29,30 @@ def test_constructor_keeps_upsample_modules():
     assert torch.nn.Upsample in constructor.keep_modules
 
 
+def test_constructor_converts_nearest_upsample_to_streaming_upsample():
+    upsample = torch.nn.Upsample(scale_factor=2, mode="nearest")
+    model = torch.nn.Sequential(torch.nn.Conv2d(3, 3, 1), upsample).eval()
+    constructor = StreamingConstructor(
+        model,
+        tile_size=8,
+        verbose=False,
+        deterministic=True,
+        copy_to_gpu=False,
+        statistics_on_cpu=False,
+        normalize_on_gpu=False,
+    )
+
+    scnn = constructor.prepare_streaming_model()
+    converted = scnn.stream_module[1]
+
+    assert isinstance(converted, StreamingUpsample2d)
+    assert converted.mode == "nearest"
+    assert converted.scale_factor == upsample.scale_factor
+    assert converted.size == upsample.size
+    assert converted.recompute_scale_factor == upsample.recompute_scale_factor
+    assert converted.align_corners is None
+
+
 def test_bilinear_upsample_statistics_add_explicit_border_loss():
     scnn = StreamingCNN.__new__(StreamingCNN)
     scnn.eps = 1e-5


### PR DESCRIPTION
### Motivation
- Ensure the streaming conversion preserves nearest-neighbor `Upsample` semantics by verifying `StreamingConstructor` converts a `torch.nn.Upsample(scale_factor=2, mode="nearest")` into `StreamingUpsample2d` while keeping its configuration.

### Description
- Add `test_constructor_converts_nearest_upsample_to_streaming_upsample` to `tests/test_streamingupsample.py` which builds a `torch.nn.Sequential` containing `torch.nn.Conv2d` and `torch.nn.Upsample(scale_factor=2, mode="nearest")`, runs `StreamingConstructor(...).prepare_streaming_model()`, and asserts the converted layer is `lightstream.core.scnn.streamingupsample.StreamingUpsample2d` and preserves `mode`, `scale_factor`, `size`, `recompute_scale_factor`, and an `align_corners` value compatible with nearest behavior (`None`).

### Testing
- Ran `pytest tests/test_streamingupsample.py -q`, which failed during collection in this environment due to `ModuleNotFoundError: No module named 'numpy'`, preventing full automated test execution.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a31cac1b0e08330aaa84d276a6474f4)