### PR TITLE
Fix nearest StreamingUpsample2d align_corners handling and add tests

### DIFF
--- a/lightstream/core/scnn/streamingupsample.py
+++ b/lightstream/core/scnn/streamingupsample.py
@@ -124,6 +124,8 @@ class StreamingUpsample2d(nn.Module):
             raise ValueError(
                 f"Unsupported upsample mode `{mode}` for StreamingUpsample2d. Supported modes: {sorted(self._SUPPORTED_MODES)}"
             )
+        if mode == "nearest" and align_corners is not None:
+            raise ValueError("StreamingUpsample2d requires align_corners=None for nearest mode.")
         if mode == "bilinear" and align_corners not in (None, False):
             raise ValueError("StreamingUpsample2d currently supports bilinear mode only with align_corners=False.")
 

--- a/tests/test_streamingupsample.py
+++ b/tests/test_streamingupsample.py
@@ -18,6 +18,45 @@ def test_streaming_upsample_from_torch_matches_interpolate():
     torch.testing.assert_close(out, expected)
 
 
+def test_streaming_upsample_nearest_matches_interpolate():
+    module = StreamingUpsample2d(scale_factor=2, mode="nearest")
+
+    x = torch.rand(1, 3, 9, 11)
+    expected = torch.nn.functional.interpolate(x, scale_factor=2, mode="nearest")
+    out = module(x)
+
+    torch.testing.assert_close(out, expected)
+
+
+def test_streaming_upsample_from_torch_nearest_matches_interpolate():
+    upsample = torch.nn.Upsample(scale_factor=2, mode="nearest")
+    module = StreamingUpsample2d.from_torch_upsample(upsample)
+
+    x = torch.rand(1, 3, 9, 11)
+    expected = torch.nn.functional.interpolate(x, scale_factor=2, mode="nearest")
+    out = module(x)
+
+    assert module.align_corners is None
+    torch.testing.assert_close(out, expected)
+
+
+def test_streaming_upsample_to_torch_nearest_emits_valid_upsample():
+    module = StreamingUpsample2d(scale_factor=2, mode="nearest")
+    upsample = module.to_torch_upsample()
+
+    x = torch.rand(1, 3, 9, 11)
+    expected = torch.nn.functional.interpolate(x, scale_factor=2, mode="nearest")
+    out = upsample(x)
+
+    assert upsample.align_corners is None
+    torch.testing.assert_close(out, expected)
+
+
+def test_streaming_upsample_rejects_align_corners_for_nearest():
+    with pytest.raises(ValueError, match="align_corners=None"):
+        StreamingUpsample2d(scale_factor=2, mode="nearest", align_corners=True)
+
+
 def test_streaming_upsample_rejects_align_corners_true_for_bilinear():
     with pytest.raises(ValueError):
         StreamingUpsample2d(scale_factor=2.0, mode="bilinear", align_corners=True)


### PR DESCRIPTION
### Motivation
- Prevent passing an invalid `align_corners` value to `torch.nn.functional.interpolate` when using nearest-neighbor upsampling by enforcing a valid contract for nearest mode.
- Add unit tests to ensure parity with `F.interpolate` and correct conversions to/from `torch.nn.Upsample` for nearest mode.

### Description
- Enforce that `StreamingUpsample2d` in nearest mode requires `align_corners is None` by raising a `ValueError` when a non-`None` value is provided in `__init__`.
- Add tests in `tests/test_streamingupsample.py` that verify `StreamingUpsample2d(scale_factor=2, mode="nearest")` matches `F.interpolate(..., mode="nearest")`, that `from_torch_upsample()` preserves a valid nearest `nn.Upsample` configuration, that `to_torch_upsample()` emits an `Upsample` with `align_corners is None`, and that invalid `align_corners=True` for nearest is rejected.

### Testing
- Ran `python -m py_compile lightstream/core/scnn/streamingupsample.py tests/test_streamingupsample.py`, which succeeded.
- Executed a small validation script exercising nearest-mode parity and `to_torch_upsample()` which passed locally in the environment used for development.
- Ran `pytest -q tests/test_streamingupsample.py` which failed during collection due to an environment dependency error (`ModuleNotFoundError: No module named 'numpy'`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a31cca9b1fc833088a002bb70de4bc1)