### PR TITLE
Test nearest upsample preserves validity and reports zero border loss

### DIFF
--- a/tests/test_streamingupsample.py
+++ b/tests/test_streamingupsample.py
@@ -117,6 +117,28 @@ def test_bilinear_upsample_statistics_add_explicit_border_loss():
     assert torch.all(output[:, :, 1:-1, 1:-1] == 1)
 
 
+def test_nearest_upsample_statistics_do_not_add_explicit_border_loss():
+    scnn = StreamingCNN.__new__(StreamingCNN)
+    scnn.eps = 1e-5
+    scnn.dtype = torch.float32
+    scnn.device = torch.device("cpu")
+    scnn._saved_tensors = {}
+    scnn._module_stats = {}
+    scnn._print_verbose = lambda *args, **kwargs: None
+
+    module = torch.nn.Upsample(scale_factor=2, mode="nearest")
+    inpt = torch.ones(1, 3, 5, 7)
+
+    with torch.no_grad():
+        output = module(inpt)
+        scnn._forward_gather_statistics_hook(module, (inpt,), output)
+
+    lost = scnn._module_stats[module]["lost"]
+    assert lost == Lost(0, 0, 0, 0)
+    assert output.shape[-2:] == (10, 14)
+    assert torch.all(output == 1)
+
+
 @pytest.mark.parametrize(
     ("scale_factor", "expected_loss"),
     [


### PR DESCRIPTION
### Motivation
- Add a regression test to ensure `StreamingCNN._forward_gather_statistics_hook` does not add border loss for nearest-neighbor upsampling, since only bilinear interpolation should produce edge-loss behavior.

### Description
- Add `test_nearest_upsample_statistics_do_not_add_explicit_border_loss` to `tests/test_streamingupsample.py` which builds a `StreamingCNN` stub, applies `torch.nn.Upsample(scale_factor=2, mode="nearest")` to an all-ones input, calls `_forward_gather_statistics_hook`, and asserts `lost == Lost(0, 0, 0, 0)` and that the upsampled output validity mask covers the full spatial extent (checks output shape and that all values are `1`).

### Testing
- Ran `python -m py_compile tests/test_streamingupsample.py`, which succeeded; running `pytest -q tests/test_streamingupsample.py` failed during collection because `numpy` is not installed in the test environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a31d0816f4483308334519c0e86c8f6)