### PR TITLE
Exclude nearest Upsample from bilinear-derived backward-input loss and add tests

### DIFF
--- a/lightstream/core/scnn/scnn.py
+++ b/lightstream/core/scnn/scnn.py
@@ -693,11 +693,14 @@ class StreamingCNN(torch.nn.Module):
                     "grad_lost",
                     "side_aware_grad_lost",
                     "backward_valid_lost",
-                    "upsample_backward_input_lost",
                     "upsample_forward_output_lost",
                 ):
                     if key in stats and hasattr(mod, key):
                         setattr(mod, key, stats[key])
+                if mod.mode == "bilinear" and "upsample_backward_input_lost" in stats:
+                    mod.upsample_backward_input_lost = stats["upsample_backward_input_lost"]
+                else:
+                    mod.upsample_backward_input_lost = None
                 self._module_stats[mod] = self._module_stats[module]
                 del self._module_stats[module]
         elif isinstance(module, ChannelLayerNorm):

--- a/lightstream/core/scnn/streamingupsample.py
+++ b/lightstream/core/scnn/streamingupsample.py
@@ -59,7 +59,7 @@ class StreamingUpsample2dF(torch.autograd.Function):
         sides = ctx.input_loc.sides
         upsample_backward_input_lost = (
             ctx.upsample_backward_input_lost
-            if ctx.upsample_backward_input_lost is not None
+            if ctx.mode == "bilinear" and ctx.upsample_backward_input_lost is not None
             else ctx.backward_valid_lost or Lost(0, 0, 0, 0)
         )
 

--- a/tests/test_streamingupsample.py
+++ b/tests/test_streamingupsample.py
@@ -116,7 +116,6 @@ def test_bilinear_upsample_statistics_add_explicit_border_loss():
     assert torch.all(output[:, :, :, -1:] == 0)
     assert torch.all(output[:, :, 1:-1, 1:-1] == 1)
 
-
 def test_nearest_upsample_statistics_do_not_add_explicit_border_loss():
     scnn = StreamingCNN.__new__(StreamingCNN)
     scnn.eps = 1e-5
@@ -292,6 +291,59 @@ def test_upsample_backward_statistics_store_backward_valid_lost():
     scnn._backward_gather_statistics_hook(module, (inpt.grad,), (torch.ones_like(output),))
 
     assert scnn._module_stats[module]["backward_valid_lost"] == Lost(0, 0, 0, 0)
+
+
+def test_nearest_upsample_backward_statistics_do_not_store_bilinear_input_lost():
+    scnn = StreamingCNN.__new__(StreamingCNN)
+    scnn.eps = 1e-5
+    scnn.dtype = torch.float32
+    scnn.device = torch.device("cpu")
+    scnn._saved_tensors = {}
+    scnn._module_stats = {}
+    scnn._print_verbose = lambda *args, **kwargs: None
+
+    module = torch.nn.Upsample(scale_factor=2, mode="nearest")
+    inpt = torch.ones(1, 1, 4, 4, requires_grad=True)
+    output = module(inpt)
+    scnn._module_stats[module] = {}
+
+    output.sum().backward()
+    scnn._backward_gather_statistics_hook(module, (inpt.grad,), (torch.ones_like(output),))
+
+    stats = scnn._module_stats[module]
+    assert stats["backward_valid_lost"] == Lost(0, 0, 0, 0)
+    assert stats.get("upsample_backward_input_lost") is None
+
+
+def test_converted_nearest_upsample_uses_backward_valid_lost_without_bilinear_input_lost():
+    scnn = StreamingCNN.__new__(StreamingCNN)
+    scnn._streaming_reducers = []
+    torch_upsample = torch.nn.Upsample(scale_factor=2, mode="nearest")
+    scnn._module_stats = {
+        torch_upsample: {
+            "grad_lost": Lost(top=0, left=0, bottom=99, right=99),
+            "backward_valid_lost": Lost(top=1, left=1, bottom=1, right=1),
+            "upsample_backward_input_lost": Lost(top=0, left=0, bottom=0, right=0),
+            "output_stride": torch.tensor([1, 1, 1]),
+            "pre_upsample_output_stride": torch.tensor([1, 2, 2]),
+        }
+    }
+
+    module = scnn._convert_modules_for_streaming(torch_upsample)
+    module.input_loc = Box(0, 0, 0, 0, Sides(left=0, top=0, right=0, bottom=0))
+
+    assert isinstance(module, StreamingUpsample2d)
+    assert module.mode == "nearest"
+    assert module.backward_valid_lost == Lost(top=1, left=1, bottom=1, right=1)
+    assert module.upsample_backward_input_lost is None
+
+    x = torch.ones(1, 1, 4, 4, requires_grad=True)
+    module(x).sum().backward()
+
+    expected = torch.tensor(
+        [[[[0.0, 0.0, 0.0, 0.0], [0.0, 4.0, 4.0, 0.0], [0.0, 4.0, 4.0, 0.0], [0.0, 0.0, 0.0, 0.0]]]]
+    )
+    torch.testing.assert_close(x.grad, expected)
 
 
 def test_safe_input_step_accounts_for_upsample_forward_and_backward_lost_regions():


### PR DESCRIPTION
### Motivation
- Nearest-neighbor upsampling should not reuse bilinear-derived low-resolution loss statistics when computing backward masking. 
- Converting `torch.nn.Upsample(mode="nearest")` to `StreamingUpsample2d` must not carry bilinear-specific `upsample_backward_input_lost` state. 
- Add tests to ensure nearest upsample uses `backward_valid_lost` for gradient masking and does not require bilinear input-loss stats. 

### Description
- Change `StreamingUpsample2dF.backward` to prefer `upsample_backward_input_lost` only when `ctx.mode == "bilinear"` and the value is present, otherwise fall back to `ctx.backward_valid_lost` (file: `lightstream/core/scnn/streamingupsample.py`).
- Update `_convert_modules_for_streaming` to set `mod.upsample_backward_input_lost` only for bilinear upsample conversions and explicitly clear it (`None`) for non-bilinear modes (file: `lightstream/core/scnn/scnn.py`).
- Add two tests to `tests/test_streamingupsample.py`: `test_nearest_upsample_backward_statistics_do_not_store_bilinear_input_lost` and `test_converted_nearest_upsample_uses_backward_valid_lost_without_bilinear_input_lost` which validate `backward_valid_lost == Lost(0,0,0,0)`, absence of `upsample_backward_input_lost`, and correct gradient masking for converted nearest upsample modules.

### Testing
- Performed syntax checks via `python -m py_compile` on the modified files and the test file which succeeded. 
- Ran `pytest -q tests/test_streamingupsample.py` but test collection failed due to missing runtime dependency `numpy` (`ModuleNotFoundError: No module named 'numpy'`).
- The new tests were added and compiled, but full automated test execution is blocked until `numpy` is available in the environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a31d40bc93c833095b0d9df089b6a99)