### PR TITLE
Allow maskless backward replay for GeM reducers

### DIFF
--- a/lightstream/core/reducer/attention_gem.py
+++ b/lightstream/core/reducer/attention_gem.py
@@ -284,9 +284,9 @@ class StreamingAttentionGeMReducer(BaseStreamingGlobalReducer):
         }
 
     def reduce_tile_for_backward(self, trimmed_output, valid_mask: torch.Tensor | None, global_context):
-        if valid_mask is None:
-            raise ValueError("StreamingAttentionGeMReducer backward replay requires a valid_mask.")
         x_tile, logits_tile = self._parse_multi_input_payload(trimmed_output)
+        if valid_mask is None:
+            valid_mask = torch.ones(x_tile.shape[-2:], device=x_tile.device, dtype=torch.bool)
         acc_dtype = resolve_accumulator_dtype(self.accumulator_dtype, x_tile.dtype)
         x = x_tile.to(dtype=acc_dtype).clamp_min(self.eps)
         logits = _normalize_logits(logits_tile, x_tile).to(dtype=acc_dtype)

--- a/lightstream/core/reducer/fused_attention_gem.py
+++ b/lightstream/core/reducer/fused_attention_gem.py
@@ -381,12 +381,12 @@ class StreamingFusedAttentionGeMReducer(BaseStreamingGlobalReducer):
         }
 
     def reduce_tile_for_backward(self, trimmed_output, valid_mask: torch.Tensor | None, global_context):
-        if valid_mask is None:
-            raise ValueError("StreamingFusedAttentionGeMReducer backward replay requires a valid_mask.")
         payload = self._parse_multi_input_payload(trimmed_output)
         if len(payload) != 2:
             raise ValueError(f"StreamingFusedAttentionGeMReducer expects payload arity=2, got {len(payload)}")
         fused_y, logits_stacked = payload
+        if valid_mask is None:
+            valid_mask = torch.ones(fused_y.shape[-2:], device=fused_y.device, dtype=torch.bool)
         if fused_y.ndim != 4:
             raise ValueError(f"fused_y must be an NCHW tensor, got shape={tuple(fused_y.shape)}")
         _validate_stacked_logits(logits_stacked, fused_y)

--- a/lightstream/core/reducer/gem.py
+++ b/lightstream/core/reducer/gem.py
@@ -177,7 +177,7 @@ class StreamingGeMReducer(BaseStreamingGlobalReducer):
 
     def reduce_tile_for_backward(self, trimmed_output: torch.Tensor, valid_mask: torch.Tensor | None, global_context: dict[str, torch.Tensor | int | float | None]) -> torch.Tensor:
         if valid_mask is None:
-            raise ValueError("StreamingGeMReducer backward replay requires a valid_mask.")
+            valid_mask = torch.ones(trimmed_output.shape[-2:], device=trimmed_output.device, dtype=torch.bool)
 
         acc_dtype = resolve_accumulator_dtype(self.accumulator_dtype, trimmed_output.dtype)
         x = trimmed_output.to(dtype=acc_dtype)


### PR DESCRIPTION
### Motivation
- Backward replay code raised hard errors when `valid_mask` was not provided, making no-mask replay fragile for tiled streaming scenarios.
- Provide parity across GeM, attention-GeM, and fused-attention-GeM streaming reducers so replay can proceed with a synthetic all-true mask when needed.

### Description
- In `StreamingGeMReducer.reduce_tile_for_backward()` synthesize `valid_mask = torch.ones(trimmed_output.shape[-2:], device=..., dtype=torch.bool)` when `valid_mask is None` so downstream `streaming_reduce_tile(...)` calls use a full-valid tile.
- In `StreamingAttentionGeMReducer.reduce_tile_for_backward()` synthesize `valid_mask = torch.ones(x_tile.shape[-2:], device=..., dtype=torch.bool)` when missing and continue to build `valid4d = valid_mask[None, None]` and other reductions unchanged.
- In `StreamingFusedAttentionGeMReducer.reduce_tile_for_backward()` apply the same pattern by synthesizing an all-true mask from `fused_y.shape[-2:]` when `valid_mask is None` so the existing `valid5d` and `streaming_reduce_tile(...)` calls work without change.
- Existing behavior is unchanged when a real `valid_mask` is supplied.

### Testing
- Ran `python -m py_compile lightstream/core/reducer/gem.py lightstream/core/reducer/attention_gem.py lightstream/core/reducer/fused_attention_gem.py` which succeeded.
- Ran `pytest -q tests/test_scnn.py` but collection failed due to a missing test environment dependency (`ModuleNotFoundError: No module named 'numpy'`), so unit tests could not complete in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a589aee2efc83308091848ab38d3cc3)