### PR TITLE
Add optional spatial mask resizing for reducers

### DIFF
--- a/lightstream/core/reducer/attention_gem.py
+++ b/lightstream/core/reducer/attention_gem.py
@@ -8,7 +8,7 @@ import torch
 
 from .base import BaseStreamingGlobalReducer, streaming_reduce_tile
 from .reducer_base import BaseReducer
-from .utils import normalize_spatial_mask, resolve_accumulator_dtype
+from .utils import prepare_spatial_mask, resolve_accumulator_dtype
 
 
 def _validate_uniform_attention_eps(uniform_attention_eps: float) -> float:
@@ -44,11 +44,21 @@ def _normalize_logits(logits: torch.Tensor, x: torch.Tensor) -> torch.Tensor:
 class AttentionGeMReducer(BaseReducer):
     """Apply attention-weighted global GeM reduction on NCHW tensors."""
 
-    def __init__(self, r_init: float = 4.0, eps: float = 1e-6, accumulator_dtype: torch.dtype | None = None, uniform_attention_eps: float = 0.0):
+    def __init__(
+        self,
+        r_init: float = 4.0,
+        eps: float = 1e-6,
+        accumulator_dtype: torch.dtype | None = None,
+        uniform_attention_eps: float = 0.0,
+        mask_resize: bool = False,
+        mask_resize_mode: str = "nearest",
+    ):
         super().__init__()
         self.eps = float(eps)
         self.accumulator_dtype = accumulator_dtype
         self.uniform_attention_eps = _validate_uniform_attention_eps(uniform_attention_eps)
+        self.mask_resize = bool(mask_resize)
+        self.mask_resize_mode = mask_resize_mode
         self.register_buffer("r", torch.tensor(float(r_init), dtype=torch.float32))
 
     @property
@@ -74,7 +84,7 @@ class AttentionGeMReducer(BaseReducer):
         logits_acc = logits.to(dtype=acc_dtype)
 
         if mask is not None:
-            mask_nchw = normalize_spatial_mask(mask, x).to(device=x.device)
+            mask_nchw = prepare_spatial_mask(mask, x, mask_resize=self.mask_resize, mask_resize_mode=self.mask_resize_mode).to(device=x.device)
             neg_inf = torch.finfo(acc_dtype).min
             logits_acc = torch.where(mask_nchw, logits_acc, torch.full_like(logits_acc, neg_inf))
             any_valid = mask_nchw.flatten(2).any(dim=-1, keepdim=True).unsqueeze(-1)

--- a/lightstream/core/reducer/fused_attention_gem.py
+++ b/lightstream/core/reducer/fused_attention_gem.py
@@ -7,7 +7,7 @@ import torch
 from .attention_gem import _normalize_logits, _validate_uniform_attention_eps
 from .base import BaseStreamingGlobalReducer, streaming_reduce_tile
 from .reducer_base import BaseReducer
-from .utils import normalize_spatial_mask, resolve_accumulator_dtype
+from .utils import prepare_spatial_mask, resolve_accumulator_dtype
 
 
 _WEIGHT_LEN = 3
@@ -73,11 +73,15 @@ class FusedAttentionGeMReducer(BaseReducer):
         attention_weights: tuple[float, float, float] = (0.3, 0.4, 0.3),
         accumulator_dtype: torch.dtype | None = None,
         uniform_attention_eps: float = 0.0,
+        mask_resize: bool = False,
+        mask_resize_mode: str = "nearest",
     ):
         super().__init__()
         self.eps = float(eps)
         self.accumulator_dtype = accumulator_dtype
         self.uniform_attention_eps = _validate_uniform_attention_eps(uniform_attention_eps)
+        self.mask_resize = bool(mask_resize)
+        self.mask_resize_mode = mask_resize_mode
         self.register_buffer("r", torch.tensor(float(r_init), dtype=torch.float32))
         self.register_buffer("value_weights", _weights_tensor("value_weights", value_weights))
         self.register_buffer("attention_weights", _weights_tensor("attention_weights", attention_weights))
@@ -118,7 +122,7 @@ class FusedAttentionGeMReducer(BaseReducer):
 
         logits_acc = tuple(logit.to(device=y1.device, dtype=acc_dtype) for logit in logits)
         if mask is not None:
-            mask_nchw = normalize_spatial_mask(mask, y1).to(device=y1.device)
+            mask_nchw = prepare_spatial_mask(mask, y1, mask_resize=self.mask_resize, mask_resize_mode=self.mask_resize_mode).to(device=y1.device)
             neg_inf = torch.finfo(acc_dtype).min
             logits_acc = tuple(torch.where(mask_nchw, logit, torch.full_like(logit, neg_inf)) for logit in logits_acc)
             any_valid = mask_nchw.flatten(2).any(dim=-1, keepdim=True).unsqueeze(-1)

--- a/lightstream/core/reducer/gem.py
+++ b/lightstream/core/reducer/gem.py
@@ -4,7 +4,7 @@ import torch
 
 from .base import BaseStreamingGlobalReducer, streaming_reduce_tile
 from .reducer_base import BaseReducer
-from .utils import normalize_spatial_mask, resolve_accumulator_dtype
+from .utils import prepare_spatial_mask, resolve_accumulator_dtype
 
 
 class GeMReducer(BaseReducer):
@@ -16,12 +16,16 @@ class GeMReducer(BaseReducer):
         eps: float = 1e-6,
         accumulator_dtype: torch.dtype | None = None,
         learnable_r: bool = False,
+        mask_resize: bool = False,
+        mask_resize_mode: str = "nearest",
         r: float | None = None,
         r_parameter: torch.nn.Parameter | None = None,
     ):
         super().__init__()
         self.eps = float(eps)
         self.accumulator_dtype = accumulator_dtype
+        self.mask_resize = bool(mask_resize)
+        self.mask_resize_mode = mask_resize_mode
 
         if r is not None:
             r_init = r
@@ -57,7 +61,7 @@ class GeMReducer(BaseReducer):
         x_pow = x_clamped.pow(r)
 
         if mask is not None:
-            mask_nchw = normalize_spatial_mask(mask, x)
+            mask_nchw = prepare_spatial_mask(mask, x, mask_resize=self.mask_resize, mask_resize_mode=self.mask_resize_mode)
             mask_acc = mask_nchw.to(dtype=acc_dtype)
             denom = mask_acc.sum(dim=(-2, -1), keepdim=True, dtype=acc_dtype).clamp_min(1)
             mean_pow = (x_pow * mask_acc).sum(dim=(-2, -1), keepdim=True, dtype=acc_dtype) / denom

--- a/lightstream/core/reducer/mean.py
+++ b/lightstream/core/reducer/mean.py
@@ -5,15 +5,22 @@ import torch
 from .base import BaseStreamingGlobalReducer, streaming_reduce_tile
 from .reducer_base import BaseReducer
 from .sum import StreamingSumReducer
-from .utils import normalize_spatial_mask, resolve_accumulator_dtype
+from .utils import prepare_spatial_mask, resolve_accumulator_dtype
 
 
 class MeanReducer(BaseReducer):
     """Apply global spatial mean reduction on NCHW tensors."""
 
-    def __init__(self, accumulator_dtype: torch.dtype | None = None):
+    def __init__(
+        self,
+        accumulator_dtype: torch.dtype | None = None,
+        mask_resize: bool = False,
+        mask_resize_mode: str = "nearest",
+    ):
         super().__init__()
         self.accumulator_dtype = accumulator_dtype
+        self.mask_resize = bool(mask_resize)
+        self.mask_resize_mode = mask_resize_mode
 
     def forward(self, *inputs: torch.Tensor, mask: torch.Tensor | None = None) -> torch.Tensor:
         if len(inputs) != 1:
@@ -25,7 +32,7 @@ class MeanReducer(BaseReducer):
             return x
         acc_dtype = resolve_accumulator_dtype(self.accumulator_dtype, x.dtype)
         if mask is not None:
-            mask_nchw = normalize_spatial_mask(mask, x)
+            mask_nchw = prepare_spatial_mask(mask, x, mask_resize=self.mask_resize, mask_resize_mode=self.mask_resize_mode)
             masked = x * mask_nchw.to(dtype=x.dtype)
             denom = mask_nchw.sum(dim=(-2, -1), keepdim=True, dtype=acc_dtype).clamp_min(1)
             mean = masked.sum(dim=(-2, -1), keepdim=True, dtype=acc_dtype) / denom

--- a/lightstream/core/reducer/sum.py
+++ b/lightstream/core/reducer/sum.py
@@ -4,15 +4,22 @@ import torch
 
 from .base import BaseStreamingGlobalReducer, streaming_reduce_tile
 from .reducer_base import BaseReducer
-from .utils import normalize_spatial_mask, resolve_accumulator_dtype
+from .utils import prepare_spatial_mask, resolve_accumulator_dtype
 
 
 class SumReducer(BaseReducer):
     """Apply global spatial sum reduction on NCHW tensors."""
 
-    def __init__(self, accumulator_dtype: torch.dtype | None = None):
+    def __init__(
+        self,
+        accumulator_dtype: torch.dtype | None = None,
+        mask_resize: bool = False,
+        mask_resize_mode: str = "nearest",
+    ):
         super().__init__()
         self.accumulator_dtype = accumulator_dtype
+        self.mask_resize = bool(mask_resize)
+        self.mask_resize_mode = mask_resize_mode
 
     def forward(self, *inputs: torch.Tensor, mask: torch.Tensor | None = None) -> torch.Tensor:
         if len(inputs) != 1:
@@ -24,7 +31,7 @@ class SumReducer(BaseReducer):
             return x
         acc_dtype = resolve_accumulator_dtype(self.accumulator_dtype, x.dtype)
         if mask is not None:
-            mask_nchw = normalize_spatial_mask(mask, x)
+            mask_nchw = prepare_spatial_mask(mask, x, mask_resize=self.mask_resize, mask_resize_mode=self.mask_resize_mode)
             masked = x * mask_nchw.to(dtype=x.dtype)
             return masked.sum(dim=(-2, -1), keepdim=True, dtype=acc_dtype).to(dtype=x.dtype)
         return x.sum(dim=(-2, -1), keepdim=True, dtype=acc_dtype).to(dtype=x.dtype)

--- a/lightstream/core/reducer/utils.py
+++ b/lightstream/core/reducer/utils.py
@@ -1,6 +1,7 @@
 """Shared reducer helper utilities for mask and dtype handling."""
 
 import torch
+import torch.nn.functional as F
 
 
 def normalize_spatial_mask(mask: torch.Tensor, x: torch.Tensor) -> torch.Tensor:
@@ -45,6 +46,64 @@ def normalize_spatial_mask(mask: torch.Tensor, x: torch.Tensor) -> torch.Tensor:
         return mask_bool
 
     raise ValueError(f"mask must be 2D/3D/4D spatial mask, got shape={tuple(mask.shape)}")
+
+
+def prepare_spatial_mask(
+    mask: torch.Tensor,
+    x: torch.Tensor,
+    *,
+    mask_resize: bool = False,
+    mask_resize_mode: str = "nearest",
+) -> torch.Tensor:
+    """Prepare a spatial mask for reduction against ``x``.
+
+    Masks with spatial dimensions matching ``x`` are normalized directly. When
+    spatial dimensions differ, optionally resize with nearest-neighbor
+    interpolation before normalizing to ``[N, 1, H, W]`` boolean format on
+    ``x.device``.
+    """
+    if mask_resize_mode != "nearest":
+        raise ValueError(f"Unsupported mask_resize_mode '{mask_resize_mode}'. Only 'nearest' is supported.")
+
+    if mask.ndim not in (2, 3, 4):
+        raise ValueError(f"mask must be 2D/3D/4D spatial mask, got shape={tuple(mask.shape)}")
+
+    target_spatial = tuple(x.shape[-2:])
+    mask_spatial = tuple(mask.shape[-2:])
+    if mask_spatial == target_spatial:
+        return normalize_spatial_mask(mask, x)
+
+    if not mask_resize:
+        raise ValueError(
+            f"mask spatial shape {mask_spatial} must match input spatial shape {target_spatial}; "
+            "set mask_resize=True to resize masks with nearest-neighbor interpolation"
+        )
+
+    if mask.ndim == 2:
+        mask_nchw = mask[None, None]
+    elif mask.ndim == 3:
+        if mask.shape[0] != x.shape[0]:
+            raise ValueError(
+                f"3D mask shape {tuple(mask.shape)} must be [N,H,W] with N={x.shape[0]} before resizing"
+            )
+        mask_nchw = mask[:, None]
+    else:
+        if mask.shape[0] != x.shape[0]:
+            raise ValueError(
+                f"4D mask shape {tuple(mask.shape)} must have N={x.shape[0]} before resizing"
+            )
+        if mask.shape[1] not in (1, x.shape[1]):
+            raise ValueError(
+                f"4D mask channel dim must be 1 or C={x.shape[1]}, got {mask.shape[1]}"
+            )
+        mask_nchw = mask
+
+    resized = F.interpolate(
+        mask_nchw.to(device=x.device, dtype=torch.float32),
+        size=target_spatial,
+        mode=mask_resize_mode,
+    ).to(dtype=torch.bool)
+    return normalize_spatial_mask(resized, x)
 
 
 def resolve_accumulator_dtype(accumulator_dtype: torch.dtype | None, reference_dtype: torch.dtype) -> torch.dtype:

--- a/tests/test_spatial_mask_resize.py
+++ b/tests/test_spatial_mask_resize.py
@@ -1,0 +1,76 @@
+import pytest
+import torch
+
+from lightstream.core.reducer import AttentionGeMReducer, FusedAttentionGeMReducer, GeMReducer, MeanReducer, SumReducer
+from lightstream.core.reducer.utils import prepare_spatial_mask
+
+
+def test_prepare_spatial_mask_rejects_mismatch_without_resize():
+    x = torch.zeros(2, 3, 4, 6)
+    mask = torch.ones(2, 2, 3, dtype=torch.bool)
+
+    with pytest.raises(ValueError, match="mask spatial shape .* set mask_resize=True"):
+        prepare_spatial_mask(mask, x)
+
+
+def test_prepare_spatial_mask_resizes_to_bool_n1hw_on_input_device():
+    x = torch.zeros(2, 3, 4, 6)
+    mask = torch.tensor(
+        [
+            [[True, False, True], [False, True, False]],
+            [[False, True, False], [True, False, True]],
+        ]
+    )
+
+    prepared = prepare_spatial_mask(mask, x, mask_resize=True)
+
+    assert prepared.shape == (2, 1, 4, 6)
+    assert prepared.dtype == torch.bool
+    assert prepared.device == x.device
+    assert torch.equal(prepared[..., 0:2, 0:2], mask[:, None, 0:1, 0:1].expand(-1, -1, 2, 2))
+
+
+def test_prepare_spatial_mask_rejects_non_nearest_resize_mode():
+    x = torch.zeros(1, 1, 4, 4)
+    mask = torch.ones(2, 2, dtype=torch.bool)
+
+    with pytest.raises(ValueError, match="Only 'nearest' is supported"):
+        prepare_spatial_mask(mask, x, mask_resize=True, mask_resize_mode="bilinear")
+
+
+@pytest.mark.parametrize("reducer_cls", [MeanReducer, SumReducer, GeMReducer])
+def test_single_input_reducers_resize_masks_when_enabled(reducer_cls):
+    x = torch.arange(16, dtype=torch.float32).reshape(1, 1, 4, 4) + 1
+    mask = torch.tensor([[True, False], [False, True]])
+    expected_mask = prepare_spatial_mask(mask, x, mask_resize=True)
+    expected = reducer_cls()(x, mask=expected_mask)
+
+    assert torch.allclose(reducer_cls(mask_resize=True)(x, mask=mask), expected)
+
+
+def test_attention_gem_resizes_mask_when_enabled():
+    x = torch.arange(16, dtype=torch.float32).reshape(1, 1, 4, 4) + 1
+    logits = torch.zeros(1, 1, 4, 4)
+    mask = torch.tensor([[True, False], [False, True]])
+    expected_mask = prepare_spatial_mask(mask, x, mask_resize=True)
+    reducer = AttentionGeMReducer(r_init=1.0)
+
+    assert torch.allclose(
+        AttentionGeMReducer(r_init=1.0, mask_resize=True)(x, logits, mask=mask),
+        reducer(x, logits, mask=expected_mask),
+    )
+
+
+def test_fused_attention_gem_resizes_mask_against_y1_domain():
+    y1 = torch.arange(16, dtype=torch.float32).reshape(1, 1, 4, 4) + 1
+    y2 = y1 + 1
+    y3 = y1 + 2
+    logits = tuple(torch.zeros(1, 1, 4, 4) for _ in range(3))
+    mask = torch.tensor([[True, False], [False, True]])
+    expected_mask = prepare_spatial_mask(mask, y1, mask_resize=True)
+    reducer = FusedAttentionGeMReducer(r_init=1.0)
+
+    assert torch.allclose(
+        FusedAttentionGeMReducer(r_init=1.0, mask_resize=True)(y1, y2, y3, *logits, mask=mask),
+        reducer(y1, y2, y3, *logits, mask=expected_mask),
+    )


### PR DESCRIPTION
### Motivation
- Provide a helper that accepts masks at different spatial sizes and either validates or resizes them to match reducer inputs so downstream reducers can accept user masks that don't already match the spatial domain. 
- Ensure mask resizing is explicit and controlled by reducer options to avoid silently changing user intent. 
- Keep existing behavior unchanged by default (no resizing) while enabling nearest-neighbor resizing when requested.

### Description
- Add `prepare_spatial_mask(mask, x, *, mask_resize: bool = False, mask_resize_mode: str = "nearest")` which delegates to `normalize_spatial_mask(...)` when spatial sizes match, otherwise optionally resizes with `torch.nn.functional.interpolate(..., mode="nearest")`, rejects non-`"nearest"` modes, converts to float for interpolation then back to boolean, and returns a boolean mask in `[N,1,H,W]` on `x.device`.
- Wire `prepare_spatial_mask(...)` into masked forward paths for `GeMReducer`, `AttentionGeMReducer`, and `FusedAttentionGeMReducer`, and optionally for `MeanReducer` and `SumReducer`, replacing prior `normalize_spatial_mask(...)` calls; `FusedAttentionGeMReducer` uses `y1` as the reference spatial domain.
- Add constructor options `mask_resize: bool = False` and `mask_resize_mode: str = "nearest"` to the updated reducers and store them as instance attributes, preserving the default behavior (`mask_resize=False`).

### Testing
- Compiled reducer package with `python -m compileall lightstream/core/reducer` with no errors.
- Ran the new unit tests with `pytest tests/test_spatial_mask_resize.py`, which passed (8 passed).
- Ran `pytest tests/test_spatial_mask_resize.py tests/test_attention_gem_reducers.py`, which passed (16 passed total for those suites).
- Attempted running the broader test set including `tests/test_scnn.py` but collection failed due to `numpy` not being installed in the environment, which is an external dependency issue and not related to the changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a58b4804968833099abdb9da5c9ebf1)