### PR TITLE
Propagate reducer mask resize settings to streaming reducers and prepare full-domain reducer masks in StreamingCNN

### DIFF
--- a/lightstream/core/reducer/attention_gem.py
+++ b/lightstream/core/reducer/attention_gem.py
@@ -121,6 +121,8 @@ class AttentionGeMReducer(BaseReducer):
             eps=self.eps,
             accumulator_dtype=self.accumulator_dtype,
             uniform_attention_eps=self.uniform_attention_eps,
+            mask_resize=self.mask_resize,
+            mask_resize_mode=self.mask_resize_mode,
         )
         reducer.r.data.copy_(self.current_r.detach().to(device=reducer.r.device, dtype=reducer.r.dtype))
         return reducer
@@ -129,10 +131,20 @@ class AttentionGeMReducer(BaseReducer):
 class StreamingAttentionGeMReducer(BaseStreamingGlobalReducer):
     """Streaming attention-weighted global GeM reducer with stable softmax accumulation."""
 
-    def __init__(self, r_init: float = 4.0, eps: float = 1e-6, accumulator_dtype: torch.dtype | None = None, uniform_attention_eps: float = 0.0):
+    def __init__(
+        self,
+        r_init: float = 4.0,
+        eps: float = 1e-6,
+        accumulator_dtype: torch.dtype | None = None,
+        uniform_attention_eps: float = 0.0,
+        mask_resize: bool = False,
+        mask_resize_mode: str = "nearest",
+    ):
         super().__init__(mode="mean", accumulator_dtype=accumulator_dtype)
         self.eps = float(eps)
         self.uniform_attention_eps = _validate_uniform_attention_eps(uniform_attention_eps)
+        self.mask_resize = bool(mask_resize)
+        self.mask_resize_mode = mask_resize_mode
         self.register_buffer("r", torch.tensor(float(r_init), dtype=torch.float32))
         self.register_buffer("running_m", torch.zeros(0), persistent=False)
         self.register_buffer("running_zhat", torch.zeros(0), persistent=False)
@@ -339,6 +351,8 @@ class StreamingAttentionGeMReducer(BaseStreamingGlobalReducer):
             eps=self.eps,
             accumulator_dtype=self.accumulator_dtype,
             uniform_attention_eps=self.uniform_attention_eps,
+            mask_resize=self.mask_resize,
+            mask_resize_mode=self.mask_resize_mode,
         )
         reducer.r.data.copy_(self.current_r.detach().to(device=reducer.r.device, dtype=reducer.r.dtype))
         return reducer

--- a/lightstream/core/reducer/fused_attention_gem.py
+++ b/lightstream/core/reducer/fused_attention_gem.py
@@ -163,6 +163,8 @@ class FusedAttentionGeMReducer(BaseReducer):
             attention_weights=tuple(float(x) for x in self.attention_weights.detach().cpu()),
             accumulator_dtype=self.accumulator_dtype,
             uniform_attention_eps=self.uniform_attention_eps,
+            mask_resize=self.mask_resize,
+            mask_resize_mode=self.mask_resize_mode,
         )
         reducer.r.data.copy_(self.current_r.detach().to(device=reducer.r.device, dtype=reducer.r.dtype))
         reducer.value_weights.data.copy_(self.value_weights.detach().to(device=reducer.value_weights.device, dtype=reducer.value_weights.dtype))
@@ -181,10 +183,14 @@ class StreamingFusedAttentionGeMReducer(BaseStreamingGlobalReducer):
         attention_weights: tuple[float, float, float] = (0.3, 0.4, 0.3),
         accumulator_dtype: torch.dtype | None = None,
         uniform_attention_eps: float = 0.0,
+        mask_resize: bool = False,
+        mask_resize_mode: str = "nearest",
     ):
         super().__init__(mode="mean", accumulator_dtype=accumulator_dtype)
         self.eps = float(eps)
         self.uniform_attention_eps = _validate_uniform_attention_eps(uniform_attention_eps)
+        self.mask_resize = bool(mask_resize)
+        self.mask_resize_mode = mask_resize_mode
         self.register_buffer("r", torch.tensor(float(r_init), dtype=torch.float32))
         self.register_buffer("value_weights", _weights_tensor("value_weights", value_weights))
         self.register_buffer("attention_weights", _weights_tensor("attention_weights", attention_weights))
@@ -446,6 +452,8 @@ class StreamingFusedAttentionGeMReducer(BaseStreamingGlobalReducer):
             attention_weights=tuple(float(x) for x in self.attention_weights.detach().cpu()),
             accumulator_dtype=self.accumulator_dtype,
             uniform_attention_eps=self.uniform_attention_eps,
+            mask_resize=self.mask_resize,
+            mask_resize_mode=self.mask_resize_mode,
         )
         reducer.r.data.copy_(self.current_r.detach().to(device=reducer.r.device, dtype=reducer.r.dtype))
         reducer.value_weights.data.copy_(self.value_weights.detach().to(device=reducer.value_weights.device, dtype=reducer.value_weights.dtype))

--- a/lightstream/core/reducer/gem.py
+++ b/lightstream/core/reducer/gem.py
@@ -76,6 +76,8 @@ class GeMReducer(BaseReducer):
             return StreamingGeMReducer(
                 eps=self.eps,
                 accumulator_dtype=self.accumulator_dtype,
+                mask_resize=self.mask_resize,
+                mask_resize_mode=self.mask_resize_mode,
                 r_parameter=self.r,
             )
 
@@ -84,6 +86,8 @@ class GeMReducer(BaseReducer):
             eps=self.eps,
             accumulator_dtype=self.accumulator_dtype,
             learnable_r=False,
+            mask_resize=self.mask_resize,
+            mask_resize_mode=self.mask_resize_mode,
         )
         with torch.no_grad():
             reducer.r.copy_(self.current_r.detach().to(device=reducer.r.device, dtype=reducer.r.dtype))
@@ -99,11 +103,15 @@ class StreamingGeMReducer(BaseStreamingGlobalReducer):
         eps: float = 1e-6,
         accumulator_dtype: torch.dtype | None = None,
         learnable_r: bool = False,
+        mask_resize: bool = False,
+        mask_resize_mode: str = "nearest",
         r: float | None = None,
         r_parameter: torch.nn.Parameter | None = None,
     ):
         super().__init__(mode="mean", accumulator_dtype=accumulator_dtype)
         self.eps = float(eps)
+        self.mask_resize = bool(mask_resize)
+        self.mask_resize_mode = mask_resize_mode
 
         if r is not None:
             r_init = r
@@ -219,6 +227,8 @@ class StreamingGeMReducer(BaseStreamingGlobalReducer):
             return GeMReducer(
                 eps=self.eps,
                 accumulator_dtype=self.accumulator_dtype,
+                mask_resize=self.mask_resize,
+                mask_resize_mode=self.mask_resize_mode,
                 r_parameter=self.r,
             )
 
@@ -227,6 +237,8 @@ class StreamingGeMReducer(BaseStreamingGlobalReducer):
             eps=self.eps,
             accumulator_dtype=self.accumulator_dtype,
             learnable_r=False,
+            mask_resize=self.mask_resize,
+            mask_resize_mode=self.mask_resize_mode,
         )
         with torch.no_grad():
             reducer.r.copy_(self.current_r.detach().to(device=reducer.r.device, dtype=reducer.r.dtype))

--- a/lightstream/core/scnn/scnn.py
+++ b/lightstream/core/scnn/scnn.py
@@ -181,6 +181,10 @@ class StreamingCNN(torch.nn.Module):
         self._reducer_head_map = {}
         self._reducer_input_indices = {}
         self._active_reducer_mask = None
+        self._active_reducer_mask_image = None
+        self._prepared_reducer_domain_masks = {}
+        self._current_output_heights = None
+        self._current_output_widths = None
 
         if state_dict is None:
             self._configure()
@@ -221,6 +225,62 @@ class StreamingCNN(torch.nn.Module):
                 )
             return torch.any(mask.to(device=self.device, dtype=torch.bool), dim=(0, 1))
         raise ValueError(f"mask must be 2D [H,W], 3D [N,H,W], or 4D [N,C,H,W], got shape={tuple(mask.shape)}")
+
+    def _prepare_reducer_domain_mask(
+        self,
+        mask: torch.Tensor | None,
+        head_idx: int,
+        reducer: BaseStreamingGlobalReducer,
+        output_height: int,
+        output_width: int,
+    ) -> torch.Tensor | None:
+        """Normalize and optionally resize a full user mask to one reducer output domain."""
+        if mask is None:
+            return None
+        if self._active_reducer_mask_image is None:
+            raise RuntimeError("Reducer mask preparation requires the active forward/backward image context.")
+
+        normalized = self._normalize_reducer_mask(mask, self._active_reducer_mask_image)
+        if normalized is None:
+            return None
+
+        expected_shape = (int(output_height), int(output_width))
+        actual_shape = (int(normalized.shape[-2]), int(normalized.shape[-1]))
+        if actual_shape == expected_shape:
+            return normalized
+
+        if not getattr(reducer, "mask_resize", False):
+            raise ValueError(
+                f"Reducer mask for head_idx={head_idx} has spatial size {actual_shape}, "
+                f"expected {expected_shape}. Enable mask_resize=True on the reducer to resize "
+                "the full user mask into the reducer output domain before tile slicing."
+            )
+        mask_resize_mode = getattr(reducer, "mask_resize_mode", "nearest")
+        if mask_resize_mode != "nearest":
+            raise ValueError(
+                f"Unsupported reducer mask_resize_mode '{mask_resize_mode}' for head_idx={head_idx}. "
+                "Only 'nearest' is supported for streaming reducer mask resizing."
+            )
+
+        resized = torch.nn.functional.interpolate(
+            normalized[None, None].to(dtype=torch.float32),
+            size=expected_shape,
+            mode=mask_resize_mode,
+        )[0, 0]
+        return resized.to(device=self.device, dtype=torch.bool)
+
+    def _get_prepared_reducer_domain_mask(self, head_idx: int) -> torch.Tensor | None:
+        reducer = self._reducer_head_map[head_idx]
+        cache_key = (id(reducer), int(head_idx))
+        if cache_key not in self._prepared_reducer_domain_masks:
+            self._prepared_reducer_domain_masks[cache_key] = self._prepare_reducer_domain_mask(
+                self._active_reducer_mask,
+                head_idx,
+                reducer,
+                self._current_output_heights[head_idx],
+                self._current_output_widths[head_idx],
+            )
+        return self._prepared_reducer_domain_masks[cache_key]
 
     def _slice_reducer_mask(
         self,
@@ -1285,8 +1345,9 @@ class StreamingCNN(torch.nn.Module):
                 )
         dst_y0, dst_y1, dst_x0, dst_x1 = (int(v) for v in dst_box)
         payload = trimmed_payload[0] if len(trimmed_payload) == 1 else tuple(trimmed_payload)
+        reducer_domain_mask = self._get_prepared_reducer_domain_mask(head_idx)
         tile_mask = self._slice_reducer_mask(
-            user_mask,
+            reducer_domain_mask,
             dst_y0,
             dst_y1,
             dst_x0,
@@ -1509,13 +1570,17 @@ class StreamingCNN(torch.nn.Module):
         """Perform forward pass with lightstream."""
         if self.copy_to_gpu:
             image = image.to(self.device, non_blocking=True)
-        self._active_reducer_mask = self._normalize_reducer_mask(mask, image)
+        self._active_reducer_mask = mask
+        self._active_reducer_mask_image = image
+        self._prepared_reducer_domain_masks = {}
 
         tile_height = self.tile_shape[H_DIM]
         tile_width = self.tile_shape[W_DIM]
 
         valid_output_heights, valid_output_widths = self._compute_valid_output_sizes()
         output_heights, output_widths = self._compute_full_output_sizes(image)
+        self._current_output_heights = output_heights
+        self._current_output_widths = output_widths
         valid_input_height, valid_input_width = self._compute_valid_input_step(
             valid_output_heights, valid_output_widths
         )
@@ -1649,13 +1714,19 @@ class StreamingCNN(torch.nn.Module):
         if self.copy_to_gpu:
             image = image.to(self.device, non_blocking=True)
         if mask is not None:
-            self._active_reducer_mask = self._normalize_reducer_mask(mask, image)
+            self._active_reducer_mask = mask
+            self._active_reducer_mask_image = image
+            self._prepared_reducer_domain_masks = {}
+        elif self._active_reducer_mask_image is None:
+            self._active_reducer_mask_image = image
 
         tile_height = self.tile_shape[H_DIM]
         tile_width = self.tile_shape[W_DIM]
 
         valid_output_heights, valid_output_widths = self._compute_valid_output_sizes()
         output_heights, output_widths = self._compute_full_output_sizes(image)
+        self._current_output_heights = output_heights
+        self._current_output_widths = output_widths
         valid_input_height, valid_input_width = self._compute_valid_input_step(
             valid_output_heights, valid_output_widths
         )
@@ -1857,8 +1928,9 @@ class StreamingCNN(torch.nn.Module):
 
         dst_y0, dst_y1, dst_x0, dst_x1 = common_dst_box
         ref = payload[0] if isinstance(payload, (tuple, list)) else payload
+        reducer_domain_mask = self._get_prepared_reducer_domain_mask(head_idx)
         valid_mask = self._slice_reducer_mask(
-            self._active_reducer_mask,
+            reducer_domain_mask,
             dst_y0,
             dst_y1,
             dst_x0,


### PR DESCRIPTION
### Motivation
- Ensure streaming reducers honor their parent reducer mask settings so streaming behavior matches offline reducers when masks must be resized. 
- Avoid per-tile independent resizing by preparing a single full-domain reducer mask for each reducer/head and slicing tiles from that prepared mask. 

### Description
- Propagate `mask_resize` and `mask_resize_mode` into streaming constructors for `GeMReducer`, `AttentionGeMReducer`, and `FusedAttentionGeMReducer`, and store them on streaming counterparts (`StreamingGeMReducer`, `StreamingAttentionGeMReducer`, `StreamingFusedAttentionGeMReducer`).
- Add `_prepare_reducer_domain_mask(mask, head_idx, reducer, output_height, output_width)` and `_get_prepared_reducer_domain_mask(head_idx)` helpers to `StreamingCNN` to normalize, (optionally) nearest-resize the full user mask into each reducer/head full output domain, and cache the result per reducer/head.
- Change forward/backward streaming flows to record the user mask and its image context, compute and cache per-head full-domain masks once per forward/backward, slice tile-local masks from that prepared full-domain mask, and pass tile masks into streaming reducer APIs.
- Enforce clear errors when shapes mismatch and `mask_resize=False`, and validate `mask_resize_mode` (only `'nearest'` supported for streaming); retain existing `prepare_spatial_mask` usage for non-streaming paths.

### Testing
- Compiled modified modules with `python -m py_compile lightstream/core/scnn/scnn.py lightstream/core/reducer/gem.py lightstream/core/reducer/attention_gem.py lightstream/core/reducer/fused_attention_gem.py` (succeeded). 
- Ran `pytest tests/test_spatial_mask_resize.py` and all tests passed (`8 passed`).
- Attempted to run `pytest tests/test_scnn.py tests/test_spatial_mask_resize.py`, but collection was blocked due to missing `numpy` in the environment, and `pip install numpy` failed due to package index access restrictions, so full test run could not be completed in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a58be6897bc8330937bbafd7e72ea79)