### PR TITLE
Add nGWP and SizeFocal reducer families (offline + streaming)

### DIFF
--- a/lightstream/core/reducer/README.md
+++ b/lightstream/core/reducer/README.md
@@ -37,6 +37,8 @@ For SCNN streaming support, reducers must preserve non-streaming semantics:
 - `MeanReducer` / `GeMReducer`: `inputs == (x,)`, where `x` is `[N, C, H, W]`.
 - `AttentionGeMReducer`: `inputs == (x, att_logits)`, where `att_logits` is `[N, H, W]`, `[N, 1, H, W]`, or `[N, C, H, W]`.
 - `FusedAttentionGeMReducer`: `inputs == (y1, y2, y3, att_logits1, att_logits2, att_logits3)`, where all value maps are spatially aligned `[N, C, H, W]` tensors and each attention-logit map follows the `AttentionGeMReducer` logit shape contract.
+- `NGWPReducer`: `inputs == (scores, activation_masks)`, with both tensors aligned as `[N, C, H, W]`. It returns `sum(scores * activation_masks) / (eps + sum(activation_masks))` per batch/channel.
+- `SizeFocalReducer`: `inputs == (m,)`, where `m` is an activation/probability tensor `[N, C, H, W]`. It returns `(1 - mean_m)^p * log(lambda_ + mean_m)` per batch/channel.
 - Custom reducers: explicitly document ordering (for example `(x, weights)` or `(x, guidance, confidence)`) and enforce with runtime checks.
 
 ## Package structure
@@ -95,6 +97,28 @@ This passthrough keeps your model code stable while switching execution strategy
 4. **Backward behavior**
    - Tile-level backward expands `[N, C, 1, 1]` gradients back to tile shape and reapplies masks.
    - Mean mode uses normalization from stream counts.
+
+## nGWP and size-focal reducers
+
+Both families accept `mask=` as a tissue mask. Only tissue pixels are included in
+their sums and denominators/counts. Masks follow the package's 2D/3D/4D spatial
+mask contract. By default they must already align with the reducer output; set
+`mask_resize=True` to resize a reduced-resolution tissue mask using nearest-neighbor
+interpolation. Empty tissue masks return zero for every affected output channel.
+
+`StreamingNGWPReducer` retains separate weighted-score and activation-mask sums,
+then divides only during `finalize_from_state`. `StreamingSizeFocalReducer` retains
+only activation sums and valid-pixel counts, then applies its nonlinear expression
+only during finalization. Their backward replay uses those finalized global values,
+so tiled gradients equal the corresponding full-frame gradients.
+
+These reducers are independent terminal outputs in a streamed model; do not compose
+them in the streaming graph. Once `StreamingCNN.forward()` has completed, combine
+their finalized `[N, C, 1, 1]` outputs in the caller/training module:
+
+```python
+final_prediction = ngwp_prediction + size_focal_prediction
+```
 
 ## Example: global mean pooling
 

--- a/lightstream/core/reducer/__init__.py
+++ b/lightstream/core/reducer/__init__.py
@@ -3,7 +3,9 @@ from .attention_gem import AttentionGeMReducer, StreamingAttentionGeMReducer
 from .fused_attention_gem import FusedAttentionGeMReducer, StreamingFusedAttentionGeMReducer
 from .gem import GeMReducer, StreamingGeMReducer
 from .mean import MeanReducer, StreamingMeanReducer
+from .ngwp import NGWPReducer, StreamingNGWPReducer
 from .reducer_base import BaseReducer
+from .size_focal import SizeFocalReducer, StreamingSizeFocalReducer
 from .sum import StreamingSumReducer, SumReducer
 
 __all__ = [
@@ -20,4 +22,8 @@ __all__ = [
     "StreamingAttentionGeMReducer",
     "FusedAttentionGeMReducer",
     "StreamingFusedAttentionGeMReducer",
+    "NGWPReducer",
+    "StreamingNGWPReducer",
+    "SizeFocalReducer",
+    "StreamingSizeFocalReducer",
 ]

--- a/lightstream/core/reducer/ngwp.py
+++ b/lightstream/core/reducer/ngwp.py
@@ -1,0 +1,135 @@
+"""Normalized global weighted pooling reducers."""
+
+from __future__ import annotations
+
+import math
+
+import torch
+
+from .base import BaseStreamingGlobalReducer
+from .reducer_base import BaseReducer
+from .utils import prepare_spatial_mask, resolve_accumulator_dtype
+
+
+def _validate_inputs(scores: torch.Tensor, activation_masks: torch.Tensor) -> None:
+    if not isinstance(scores, torch.Tensor) or not isinstance(activation_masks, torch.Tensor):
+        raise TypeError("NGWPReducer scores and activation_masks must both be tensors.")
+    if scores.ndim != 4 or activation_masks.ndim != 4:
+        raise ValueError("NGWPReducer inputs must both be NCHW [N, C, H, W] tensors.")
+    if scores.shape != activation_masks.shape:
+        raise ValueError(
+            "NGWPReducer scores and activation_masks must have identical NCHW shapes; "
+            f"got {tuple(scores.shape)} and {tuple(activation_masks.shape)}."
+        )
+
+
+class NGWPReducer(BaseReducer):
+    """Reduce ``(scores, activation_masks)`` by normalized global weighting."""
+
+    def __init__(self, eps: float = 1e-6, accumulator_dtype: torch.dtype | None = None,
+                 mask_resize: bool = False, mask_resize_mode: str = "nearest"):
+        super().__init__()
+        if not math.isfinite(eps) or eps < 0:
+            raise ValueError("eps must be finite and non-negative.")
+        self.eps = float(eps)
+        self.accumulator_dtype = accumulator_dtype
+        self.mask_resize = bool(mask_resize)
+        self.mask_resize_mode = mask_resize_mode
+
+    def forward(self, *inputs: torch.Tensor, mask: torch.Tensor | None = None) -> torch.Tensor:
+        if len(inputs) != 2:
+            raise ValueError(f"NGWPReducer expects (scores, activation_masks), got {len(inputs)} inputs.")
+        scores, activation_masks = inputs
+        _validate_inputs(scores, activation_masks)
+        if self._streaming_passthrough:
+            return scores
+        acc_dtype = resolve_accumulator_dtype(self.accumulator_dtype, scores.dtype)
+        scores_acc, activations_acc = scores.to(acc_dtype), activation_masks.to(acc_dtype)
+        if mask is not None:
+            tissue = prepare_spatial_mask(mask, scores, mask_resize=self.mask_resize, mask_resize_mode=self.mask_resize_mode).to(acc_dtype)
+            scores_acc, activations_acc = scores_acc * tissue, activations_acc * tissue
+        numerator = (activations_acc * scores_acc).sum(dim=(-2, -1), keepdim=True, dtype=acc_dtype)
+        denominator = activations_acc.sum(dim=(-2, -1), keepdim=True, dtype=acc_dtype)
+        return (numerator / (denominator + self.eps)).to(dtype=scores.dtype)
+
+    def to_streaming(self) -> BaseStreamingGlobalReducer:
+        return StreamingNGWPReducer(self.eps, self.accumulator_dtype, self.mask_resize, self.mask_resize_mode)
+
+
+class StreamingNGWPReducer(BaseStreamingGlobalReducer):
+    """Streaming nGWP, accumulating global numerator and denominator separately."""
+
+    def __init__(self, eps: float = 1e-6, accumulator_dtype: torch.dtype | None = None,
+                 mask_resize: bool = False, mask_resize_mode: str = "nearest"):
+        super().__init__(mode="sum", accumulator_dtype=accumulator_dtype)
+        if not math.isfinite(eps) or eps < 0:
+            raise ValueError("eps must be finite and non-negative.")
+        self.eps, self.mask_resize, self.mask_resize_mode = float(eps), bool(mask_resize), mask_resize_mode
+        self.register_buffer("running_activation_sum", torch.zeros(0), persistent=False)
+
+    def forward(self, *inputs: torch.Tensor, mask: torch.Tensor | None = None):
+        if len(inputs) != 2:
+            raise ValueError(f"StreamingNGWPReducer expects (scores_tile, activation_masks_tile), got {len(inputs)} inputs.")
+        _validate_inputs(*inputs)
+        self._last_output = inputs[0]
+        return tuple(inputs)
+
+    def _payload(self, payload):
+        values = self._parse_multi_input_payload(payload)
+        if len(values) != 2:
+            raise ValueError(f"StreamingNGWPReducer expects payload arity=2, got {len(values)}.")
+        _validate_inputs(*values)
+        return values
+
+    def accumulate_stream_tile(self, trimmed_output, tile_y, tile_x, sides, dst_box, user_mask=None):
+        payload = self._payload(trimmed_output)
+        return self._accumulate_payload(payload, tile_y, tile_x, sides, dst_box, user_mask)
+
+    def _accumulate_payload(self, payload, tile_y, tile_x, sides, dst_box, user_mask):
+        scores, _ = payload
+        y0, y1, x0, x1 = dst_box
+        seen = self._stream_seen_mask[y0:y1, x0:x1]
+        new, effective = ~seen, ~seen if user_mask is None else (~seen & user_mask.to(device=seen.device, dtype=torch.bool))
+        if self._debug_replay_enabled:
+            self._replay_assignments.append((int(tile_y), int(tile_x), bool(sides.top), bool(sides.left), bool(sides.right), bool(sides.bottom), scores.shape[-2], scores.shape[-1], y0, y1, x0, x1, 2))
+        if torch.any(effective): self.accumulate_valid_tile(payload, effective)
+        seen |= new
+
+    def build_backward_pair(self, trimmed_output, gradient, *, input_y, input_x, sides, valid_mask=None):
+        payload = self._payload(trimmed_output)
+        if self._debug_replay_enabled:
+            self._replay_cursor = self._validate_replay_assignment(assignments=self._replay_assignments, cursor=self._replay_cursor, input_y=input_y, input_x=input_x, sides=sides, expected_h=payload[0].shape[-2], expected_w=payload[0].shape[-1], expected_arity=2)
+        return self.reduce_tile_for_backward(payload, valid_mask, self.extra_state_for_backward()), gradient
+
+    def init_reduction_state(self, *, batch_size, channels, device, dtype, accumulator_dtype):
+        self._output_dtype = dtype
+        self.running_sum = torch.zeros((batch_size, channels, 1, 1), device=device, dtype=accumulator_dtype)
+        self.running_activation_sum = torch.zeros((batch_size, channels, 1, 1), device=device, dtype=accumulator_dtype)
+
+    def accumulate_valid_tile(self, tile, valid_mask):
+        scores, activations = self._payload(tile)
+        if self.running_sum.numel() == 0: self.reset_stream_state(scores.shape[0], scores.shape[1], scores.device, scores.dtype)
+        dtype = resolve_accumulator_dtype(self.accumulator_dtype, scores.dtype)
+        valid = valid_mask[None, None].to(device=scores.device, dtype=dtype)
+        self.running_sum = self.running_sum + (scores.to(dtype) * activations.to(dtype) * valid).sum((-2, -1), keepdim=True, dtype=dtype)
+        self.running_activation_sum = self.running_activation_sum + (activations.to(dtype) * valid).sum((-2, -1), keepdim=True, dtype=dtype)
+
+    def finalize_from_state(self):
+        if self.running_sum.numel() == 0: raise RuntimeError("StreamingNGWPReducer state is empty, accumulate_stream_tile() was not called.")
+        return (self.running_sum / (self.running_activation_sum.to(self.running_sum.dtype) + self.eps)).to(self._output_dtype)
+
+    def extra_state_for_backward(self):
+        return {"weighted_sum": self.running_sum, "denominator": self.running_activation_sum + self.eps}
+
+    def reduce_tile_for_backward(self, trimmed_output, valid_mask, global_context):
+        scores, activations = self._payload(trimmed_output)
+        dtype = resolve_accumulator_dtype(self.accumulator_dtype, scores.dtype)
+        valid = 1 if valid_mask is None else valid_mask[None, None].to(device=scores.device, dtype=dtype)
+        weighted = (scores.to(dtype) * activations.to(dtype) * valid).sum((-2, -1), keepdim=True, dtype=dtype)
+        activation_sum = (activations.to(dtype) * valid).sum((-2, -1), keepdim=True, dtype=dtype)
+        denom = global_context["denominator"].to(device=scores.device, dtype=dtype)
+        total = global_context["weighted_sum"].to(device=scores.device, dtype=dtype)
+        return (weighted / denom - activation_sum * total / denom.square()).to(scores.dtype)
+
+    def to_reducer(self):
+        return NGWPReducer(self.eps, self.accumulator_dtype, self.mask_resize, self.mask_resize_mode)

--- a/lightstream/core/reducer/size_focal.py
+++ b/lightstream/core/reducer/size_focal.py
@@ -1,0 +1,109 @@
+"""Size-focal pooling reducers."""
+
+from __future__ import annotations
+
+import math
+import torch
+
+from .base import BaseStreamingGlobalReducer
+from .reducer_base import BaseReducer
+from .utils import prepare_spatial_mask, resolve_accumulator_dtype
+
+
+def _validate_m(m: torch.Tensor) -> None:
+    if not isinstance(m, torch.Tensor):
+        raise TypeError("SizeFocalReducer input m must be a tensor.")
+    if m.ndim != 4:
+        raise ValueError(f"SizeFocalReducer expects an NCHW [N, C, H, W] tensor, got {tuple(m.shape)}.")
+
+
+def _validate_parameters(p: float, lambda_: float) -> tuple[float, float]:
+    if not math.isfinite(p):
+        raise ValueError("p must be finite.")
+    if not math.isfinite(lambda_) or lambda_ <= 0:
+        raise ValueError("lambda_ must be positive and finite.")
+    return float(p), float(lambda_)
+
+
+class SizeFocalReducer(BaseReducer):
+    """Compute size-focal scores from one activation/probability map."""
+
+    def __init__(self, p: float = 1.0, lambda_: float = 1e-6, accumulator_dtype: torch.dtype | None = None,
+                 mask_resize: bool = False, mask_resize_mode: str = "nearest"):
+        super().__init__()
+        self.p, self.lambda_ = _validate_parameters(p, lambda_)
+        self.accumulator_dtype, self.mask_resize, self.mask_resize_mode = accumulator_dtype, bool(mask_resize), mask_resize_mode
+
+    def forward(self, *inputs: torch.Tensor, mask: torch.Tensor | None = None) -> torch.Tensor:
+        if len(inputs) != 1: raise ValueError(f"SizeFocalReducer expects exactly one input, got {len(inputs)}.")
+        m = inputs[0]; _validate_m(m)
+        if self._streaming_passthrough: return m
+        dtype = resolve_accumulator_dtype(self.accumulator_dtype, m.dtype)
+        value = m.to(dtype)
+        if mask is None:
+            count = torch.full((m.shape[0], 1, 1, 1), m.shape[-2] * m.shape[-1], device=m.device, dtype=dtype)
+        else:
+            tissue = prepare_spatial_mask(mask, m, mask_resize=self.mask_resize, mask_resize_mode=self.mask_resize_mode).to(dtype)
+            value = value * tissue
+            count = tissue.sum((-2, -1), keepdim=True, dtype=dtype)
+        mean = value.sum((-2, -1), keepdim=True, dtype=dtype) / count.clamp_min(1)
+        result = (1 - mean).pow(self.p) * torch.log(mean + self.lambda_)
+        return torch.where(count > 0, result, torch.zeros_like(result)).to(m.dtype)
+
+    def to_streaming(self):
+        return StreamingSizeFocalReducer(self.p, self.lambda_, self.accumulator_dtype, self.mask_resize, self.mask_resize_mode)
+
+
+class StreamingSizeFocalReducer(BaseStreamingGlobalReducer):
+    """Streaming size-focal reducer; nonlinear finalization happens once globally."""
+
+    def __init__(self, p: float = 1.0, lambda_: float = 1e-6, accumulator_dtype: torch.dtype | None = None,
+                 mask_resize: bool = False, mask_resize_mode: str = "nearest"):
+        super().__init__(mode="mean", accumulator_dtype=accumulator_dtype)
+        self.p, self.lambda_ = _validate_parameters(p, lambda_)
+        self.mask_resize, self.mask_resize_mode = bool(mask_resize), mask_resize_mode
+
+    def forward(self, *inputs: torch.Tensor, mask: torch.Tensor | None = None):
+        if len(inputs) != 1:
+            raise ValueError(f"StreamingSizeFocalReducer expects exactly one input, got {len(inputs)}.")
+        _validate_m(inputs[0])
+        self._last_output = inputs[0]
+        return inputs[0]
+
+    def init_reduction_state(self, *, batch_size, channels, device, dtype, accumulator_dtype):
+        self._output_dtype = dtype
+        self.running_sum = torch.zeros((batch_size, channels, 1, 1), device=device, dtype=accumulator_dtype)
+
+    def accumulate_valid_tile(self, tile, valid_mask):
+        _validate_m(tile)
+        if self.running_sum.numel() == 0: self.reset_stream_state(tile.shape[0], tile.shape[1], tile.device, tile.dtype)
+        dtype = resolve_accumulator_dtype(self.accumulator_dtype, tile.dtype)
+        valid = valid_mask[None, None].to(device=tile.device, dtype=dtype)
+        self.running_sum = self.running_sum + (tile.to(dtype) * valid).sum((-2, -1), keepdim=True, dtype=dtype)
+        self.running_count = self.running_count + valid.sum((-2, -1), keepdim=True, dtype=dtype)
+
+    def finalize_from_state(self):
+        if self.running_sum.numel() == 0: raise RuntimeError("StreamingSizeFocalReducer state is empty, accumulate_stream_tile() was not called.")
+        count = self.running_count.to(self.running_sum.dtype)
+        mean = self.running_sum / count.clamp_min(1)
+        result = (1 - mean).pow(self.p) * torch.log(mean + self.lambda_)
+        return torch.where(count > 0, result, torch.zeros_like(result)).to(self._output_dtype)
+
+    def extra_state_for_backward(self):
+        count = self.running_count
+        mean = self.running_sum / count.to(self.running_sum.dtype).clamp_min(1)
+        # d/dmean [(1-mean)^p log(lambda + mean)]
+        derivative = (-self.p * (1 - mean).pow(self.p - 1) * torch.log(mean + self.lambda_)
+                      + (1 - mean).pow(self.p) / (mean + self.lambda_))
+        return {"count": count, "derivative": torch.where(count > 0, derivative, torch.zeros_like(derivative))}
+
+    def reduce_tile_for_backward(self, trimmed_output, valid_mask, global_context):
+        _validate_m(trimmed_output)
+        dtype = resolve_accumulator_dtype(self.accumulator_dtype, trimmed_output.dtype)
+        valid = 1 if valid_mask is None else valid_mask[None, None].to(device=trimmed_output.device, dtype=dtype)
+        local_sum = (trimmed_output.to(dtype) * valid).sum((-2, -1), keepdim=True, dtype=dtype)
+        return (local_sum * global_context["derivative"].to(device=trimmed_output.device, dtype=dtype)
+                / global_context["count"].to(device=trimmed_output.device, dtype=dtype).clamp_min(1)).to(trimmed_output.dtype)
+
+    def to_reducer(self):
+        return SizeFocalReducer(self.p, self.lambda_, self.accumulator_dtype, self.mask_resize, self.mask_resize_mode)

--- a/tests/test_ngwp_size_focal_reducers.py
+++ b/tests/test_ngwp_size_focal_reducers.py
@@ -1,0 +1,65 @@
+"""Contract and streaming-equivalence checks for nGWP and size-focal reducers."""
+
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+from lightstream.core.reducer import NGWPReducer, SizeFocalReducer, StreamingNGWPReducer, StreamingSizeFocalReducer
+
+
+def _stream(reducer, inputs, mask=None):
+    x = inputs[0]
+    stream = reducer.to_streaming()
+    stream.start_stream(x.shape[-2], x.shape[-1], x.shape[0], x.shape[1], x.device, x.dtype)
+    sides = SimpleNamespace(top=False, left=False, right=False, bottom=False)
+    for y0, y1 in ((0, 2), (2, x.shape[-2])):
+        for x0, x1 in ((0, 2), (2, x.shape[-1])):
+            payload = tuple(v[..., y0:y1, x0:x1] for v in inputs)
+            stream.accumulate_stream_tile(payload if len(payload) > 1 else payload[0], y0, x0, sides, (y0, y1, x0, x1), None if mask is None else mask[y0:y1, x0:x1])
+    return stream.finish_stream()
+
+
+def test_offline_formulas_masks_empty_masks_and_resize():
+    scores = torch.tensor([[[[1., 3.], [5., 7.]]]])
+    activation = torch.tensor([[[[.2, .4], [.6, .8]]]])
+    mask = torch.tensor([[True, False], [True, False]])
+    ngwp = NGWPReducer(eps=.5)
+    expected = (scores * activation * mask).sum((-2, -1), keepdim=True) / (.5 + (activation * mask).sum((-2, -1), keepdim=True))
+    assert torch.allclose(ngwp(scores, activation, mask=mask), expected)
+    assert torch.equal(ngwp(scores, activation, mask=torch.zeros_like(mask)), torch.zeros(1, 1, 1, 1))
+
+    m = torch.tensor([[[[.2, .4], [.6, .8]]]])
+    focal = SizeFocalReducer(p=2, lambda_=1.)
+    mean = (m * mask).sum() / mask.sum()
+    assert torch.allclose(focal(m, mask=mask), (1 - mean).pow(2) * torch.log(1 + mean))
+    assert torch.equal(focal(m, mask=torch.zeros_like(mask)), torch.zeros(1, 1, 1, 1))
+    small = torch.ones(1, 1, 2, 2)
+    with pytest.raises(ValueError): focal(torch.ones(1, 1, 4, 4), mask=small)
+    assert SizeFocalReducer(lambda_=1, mask_resize=True)(torch.ones(1, 1, 4, 4), mask=small).shape == (1, 1, 1, 1)
+    assert NGWPReducer(mask_resize=True)(torch.ones(1, 1, 4, 4), torch.ones(1, 1, 4, 4), mask=small).shape == (1, 1, 1, 1)
+
+
+def test_validation_conversion_tiled_forward_and_backward_equivalence():
+    with pytest.raises(ValueError): NGWPReducer()(torch.ones(1, 1, 2, 2))
+    with pytest.raises(ValueError): NGWPReducer()(torch.ones(1, 1, 2, 2), torch.ones(1, 2, 2, 2))
+    with pytest.raises(ValueError): SizeFocalReducer(p=float("nan"))
+    with pytest.raises(ValueError): SizeFocalReducer(lambda_=0)
+    assert isinstance(NGWPReducer().to_streaming(), StreamingNGWPReducer)
+    assert isinstance(SizeFocalReducer().to_streaming(), StreamingSizeFocalReducer)
+
+    torch.manual_seed(9)
+    mask = torch.rand(4, 5) > .3
+    cases = [(NGWPReducer(eps=.1), (torch.rand(2, 3, 4, 5, dtype=torch.float64), torch.rand(2, 3, 4, 5, dtype=torch.float64))),
+             (SizeFocalReducer(p=2, lambda_=1), (torch.rand(2, 3, 4, 5, dtype=torch.float64),))]
+    for reducer, values in cases:
+        assert torch.allclose(_stream(reducer, values, mask), reducer(*values, mask=mask), atol=1e-10)
+        inputs = [v.detach().requires_grad_() for v in values]
+        upstream = torch.randn(2, 3, 1, 1, dtype=torch.float64)
+        reducer(*inputs, mask=mask).backward(upstream)
+        expected = [v.grad.clone() for v in inputs]
+        stream = reducer.to_streaming(); stream.accumulate_valid_tile(tuple(v.detach() for v in inputs) if len(inputs) > 1 else inputs[0].detach(), mask)
+        replay = [v.detach().requires_grad_() for v in inputs]
+        tile = tuple(replay) if len(replay) > 1 else replay[0]
+        stream.reduce_tile_for_backward(tile, mask, stream.extra_state_for_backward()).backward(upstream)
+        for actual, wanted in zip(replay, expected): assert torch.allclose(actual.grad, wanted, atol=1e-10)


### PR DESCRIPTION
### Motivation
- Provide two new global pooling reducers: normalized global weighted pooling (nGWP) and size-focal pooling to support per-channel aggregation useful for downstream prediction composition.
- Ensure both reducers work in the tiled/streaming execution path with overlap-safe accumulation and numerically stable accumulator dtype policies.
- Preserve exact non-streaming semantics in streaming mode by deferring nonlinear finalization until `finalize_from_state` and implementing gradient-equivalent backward replay.

### Description
- Added `lightstream/core/reducer/ngwp.py` which implements `NGWPReducer(BaseReducer)` and `StreamingNGWPReducer(BaseStreamingGlobalReducer)` with inputs `(scores, activation_masks)` as NCHW `[N,C,H,W]`, optional `mask=` tissue semantics, `mask_resize` support, streaming accumulation of weighted sums and activation counts, and backward-replay using finalized denominators.
- Added `lightstream/core/reducer/size_focal.py` which implements `SizeFocalReducer(BaseReducer)` and `StreamingSizeFocalReducer(BaseStreamingGlobalReducer)` consuming one NCHW tensor `m`, validating finite `p` and positive finite `lambda_`, supporting tissue masks and optional nearest-neighbor mask-resize, accumulating activation sums/pixel counts in streaming mode, applying the nonlinear expression at finalization, and providing gradient-equivalent replay logic.
- Exported the four public classes in `lightstream/core/reducer/__init__.py` and updated `lightstream/core/reducer/README.md` to document input contracts, tissue-mask semantics, `mask_resize` behavior, empty-mask semantics (channels with no valid tissue pixels return zero), and streaming lifecycle notes including the integration guidance to sum the two finalized outputs outside the streaming graph.
- Added comprehensive automated tests in `tests/test_ngwp_size_focal_reducers.py` covering offline formulas, tensor/parameter validation, tissue masks, resized masks for reduced-resolution inputs, empty-mask behavior, `to_streaming()` conversion, tiled forward equivalence, and tiled backward-equivalence checks.

### Testing
- Ran `pytest -q tests/test_ngwp_size_focal_reducers.py` and the new tests passed (`2 passed`) with one unrelated NumPy init warning from the environment.
- Ran `pytest -q tests/test_attention_gem_reducers.py` to ensure existing reducer behavior was unaffected and the suite passed (`8 passed`) in this environment.
- Ran `python -m compileall -q lightstream/core/reducer` which completed successfully and validated module compilation.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a63977f25ec8330932254fc85ac6658)