### PR TITLE
Fix nGWP multi-input streaming passthrough

### DIFF
--- a/lightstream/core/reducer/ngwp.py
+++ b/lightstream/core/reducer/ngwp.py
@@ -36,13 +36,19 @@ class NGWPReducer(BaseReducer):
         self.mask_resize = bool(mask_resize)
         self.mask_resize_mode = mask_resize_mode
 
-    def forward(self, *inputs: torch.Tensor, mask: torch.Tensor | None = None) -> torch.Tensor:
+    def forward(self, *inputs: torch.Tensor, mask: torch.Tensor | None = None) -> torch.Tensor | tuple[torch.Tensor, torch.Tensor]:
         if len(inputs) != 2:
             raise ValueError(f"NGWPReducer expects (scores, activation_masks), got {len(inputs)} inputs.")
         scores, activation_masks = inputs
         _validate_inputs(scores, activation_masks)
         if self._streaming_passthrough:
-            return scores
+            passthrough = (
+                scores.view_as(scores),
+                activation_masks.view_as(activation_masks),
+            )
+            self._last_inputs = passthrough
+            self._last_output = passthrough[0]
+            return passthrough
         acc_dtype = resolve_accumulator_dtype(self.accumulator_dtype, scores.dtype)
         scores_acc, activations_acc = scores.to(acc_dtype), activation_masks.to(acc_dtype)
         if mask is not None:
@@ -70,9 +76,15 @@ class StreamingNGWPReducer(BaseStreamingGlobalReducer):
     def forward(self, *inputs: torch.Tensor, mask: torch.Tensor | None = None):
         if len(inputs) != 2:
             raise ValueError(f"StreamingNGWPReducer expects (scores_tile, activation_masks_tile), got {len(inputs)} inputs.")
-        _validate_inputs(*inputs)
-        self._last_output = inputs[0]
-        return tuple(inputs)
+        scores_tile, activation_masks_tile = inputs
+        _validate_inputs(scores_tile, activation_masks_tile)
+        passthrough = (
+            scores_tile.view_as(scores_tile),
+            activation_masks_tile.view_as(activation_masks_tile),
+        )
+        self._last_inputs = passthrough
+        self._last_output = passthrough[0]
+        return passthrough
 
     def _payload(self, payload):
         values = self._parse_multi_input_payload(payload)

--- a/tests/test_scnn.py
+++ b/tests/test_scnn.py
@@ -16,10 +16,12 @@ from lightstream.core.reducer import (
     FusedAttentionGeMReducer,
     GeMReducer,
     MeanReducer,
+    NGWPReducer,
     StreamingAttentionGeMReducer,
     StreamingFusedAttentionGeMReducer,
     StreamingGeMReducer,
     StreamingMeanReducer,
+    StreamingNGWPReducer,
     StreamingSumReducer,
     SumReducer,
 )
@@ -240,6 +242,27 @@ class AttentionGeMHeadNet(nn.Module):
         logits = self.att_logits(feat)
         reduced = self.reducer(value, logits, mask=mask)
         return reduced, value, logits
+
+
+class NGWPMultiHeadNet(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.backbone = nn.Sequential(
+            nn.Conv2d(3, 5, kernel_size=3, padding=1, bias=False),
+            nn.Softplus(),
+        )
+        self.score_heads = nn.ModuleList([nn.Conv2d(5, 2, kernel_size=1) for _ in range(4)])
+        self.activation_heads = nn.ModuleList([nn.Conv2d(5, 2, kernel_size=1) for _ in range(4)])
+        self.reducers = nn.ModuleList([NGWPReducer(eps=1e-6) for _ in range(4)])
+
+    def forward(self, x, mask: torch.Tensor | None = None):
+        feat = self.backbone(x)
+        scores = [head(feat) for head in self.score_heads]
+        activation_masks = [torch.sigmoid(head(feat)) for head in self.activation_heads]
+        return tuple(
+            reducer(score, activation_mask, mask=mask)
+            for reducer, score, activation_mask in zip(self.reducers, scores, activation_masks)
+        )
 
 
 
@@ -745,6 +768,85 @@ def test_attention_gem_streaming_passthrough_logit_bias_gradient_uniform_shift_p
     assert torch.allclose(stream_bias_grad, ref_bias_grad, atol=1e-5, rtol=1e-4)
     assert torch.allclose(ref_bias_grad, torch.zeros_like(ref_bias_grad), atol=1e-6, rtol=0)
     assert torch.allclose(stream_bias_grad, torch.zeros_like(stream_bias_grad), atol=1e-6, rtol=0)
+
+
+def test_ngwp_passthrough_preserves_two_input_payload_order():
+    scores = torch.randn(1, 2, 4, 5)
+    activation_masks = torch.rand(1, 2, 4, 5)
+    reducer = NGWPReducer()
+    reducer._streaming_passthrough = True
+
+    offline_payload = reducer(scores, activation_masks)
+    streaming = reducer.to_streaming()
+    streaming_payload = streaming(scores, activation_masks)
+
+    for owner, payload in ((reducer, offline_payload), (streaming, streaming_payload)):
+        assert len(payload) == 2
+        assert torch.equal(payload[0], scores)
+        assert torch.equal(payload[1], activation_masks)
+        assert payload[0].data_ptr() == scores.data_ptr()
+        assert payload[1].data_ptr() == activation_masks.data_ptr()
+        assert owner._last_inputs is payload
+        assert owner._last_output is payload[0]
+
+
+def test_scnn_four_ngwp_heads_regenerate_eight_tensor_tile_payload_and_forward_parity():
+    torch.manual_seed(137)
+    model = NGWPMultiHeadNet().eval()
+    image = torch.randn(1, 3, 9, 11)
+    mask = torch.rand(9, 11) > 0.2
+
+    with torch.no_grad():
+        expected = model(image, mask=mask)
+
+    scnn = _make_streaming(model, tile_size=4)
+
+    assert all(isinstance(reducer, StreamingNGWPReducer) for reducer in scnn.stream_module.reducers)
+    assert len(scnn._tile_output_shapes) == 8
+
+    with torch.no_grad():
+        streamed = scnn.forward(image, mask=mask)
+
+    assert len(streamed) == 4
+    for actual, wanted in zip(streamed, expected):
+        assert torch.allclose(actual, wanted, atol=1e-5, rtol=1e-4)
+
+
+def test_scnn_four_ngwp_heads_backward_replay_gradient_parity_for_both_inputs():
+    torch.manual_seed(139)
+    model = NGWPMultiHeadNet().eval()
+    reference = NGWPMultiHeadNet().eval()
+    reference.load_state_dict(model.state_dict())
+    image = torch.randn(1, 3, 11, 9)
+    mask = torch.rand(11, 9) > 0.25
+
+    reference_outputs = reference(image.clone().requires_grad_(True), mask=mask)
+    output_gradients = tuple(
+        torch.full_like(output, 0.11 + 0.07 * index)
+        for index, output in enumerate(reference_outputs)
+    )
+    torch.autograd.backward(reference_outputs, output_gradients)
+
+    scnn = _make_streaming(model, tile_size=5)
+    streamed_outputs = scnn.forward(image.clone(), mask=mask)
+    for actual, wanted in zip(streamed_outputs, reference_outputs):
+        assert torch.allclose(actual, wanted.detach(), atol=1e-5, rtol=1e-4)
+    scnn.backward(image.clone(), output_gradients, mask=mask)
+
+    reference_parameters = dict(reference.named_parameters())
+    streaming_parameters = dict(scnn.stream_module.named_parameters())
+    for family in ("score_heads", "activation_heads"):
+        family_names = [name for name in reference_parameters if name.startswith(family)]
+        assert family_names
+        for name in family_names:
+            assert reference_parameters[name].grad is not None
+            assert streaming_parameters[name].grad is not None
+            assert torch.allclose(
+                streaming_parameters[name].grad,
+                reference_parameters[name].grad,
+                atol=1e-5,
+                rtol=1e-4,
+            ), name
 
 
 def test_scnn_single_input_reducers_compatibility_unchanged():


### PR DESCRIPTION
### Motivation
- Ensure `NGWPReducer` obeys the multi-input passthrough contract used by `AttentionGeMReducer` so offline passthrough, streaming forward, accumulation, and backward replay all expose a consistent two-tensor payload `(scores, activation_masks)`.
- Prevent downstream SCNN tile-cache invalidation and backward-replay mismatches caused by the previous passthrough returning only a single tensor.

### Description
- Update `NGWPReducer.forward` to return the two-tensor passthrough `(scores, activation_masks)`, set `self._last_inputs` to that tuple, and set `self._last_output` to the first element (`scores`). (`lightstream/core/reducer/ngwp.py`)
- Update `StreamingNGWPReducer.forward` to construct the same ordered two-tensor payload `(scores_tile, activation_masks_tile)`, assign it to `self._last_inputs`, set `self._last_output` to its first element, and return the tuple. (`lightstream/core/reducer/ngwp.py`)
- Add SCNN regression coverage by introducing `NGWPMultiHeadNet` and tests that verify passthrough arity and identity ordering, that four nGWP heads produce eight internal tile tensors and four final outputs, tiled forward parity, and gradient parity for both score and activation-mask inputs. (`tests/test_scnn.py`)
- Keep the payload order `(scores, activation_masks)` consistent across offline passthrough, streaming forward, accumulation, and backward replay; leave a note that existing segment tile caches must be regenerated because older caches recorded only four internal outputs.

### Testing
- Ran `pytest -q tests/test_ngwp_size_focal_reducers.py`, which passed (`2 passed`) and produced a single warning about missing NumPy initialization in the environment. 
- Performed static/byte-compile checks via `python -m compileall -q lightstream/core/reducer/ngwp.py tests/test_scnn.py`, which succeeded. 
- Ran `git diff --check` and fixed whitespace/format issues as part of the patch (no problems reported). 
- Attempted `pytest -q tests/test_scnn.py -k 'ngwp' tests/test_ngwp_size_focal_reducers.py` but collection of the SCNN tests was blocked because `numpy` is not available in the execution environment; an attempt to install `numpy` failed due to the environment package-index proxy (HTTP 403).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a653b039fdc8330b7e419126eee7804)