### PR TITLE
Defer streaming preparation until Lightning distributed setup

### DIFF
--- a/lightstream/modules/lightningstreaming.py
+++ b/lightstream/modules/lightningstreaming.py
@@ -15,9 +15,19 @@ class LightningStreamingModule(L.LightningModule):
         stream_network: StreamingModule,
     ):
         super().__init__()
+        self._streaming_wrapper = stream_network
+        self._tile_size = stream_network.tile_size
 
-        self.stream_network = stream_network.stream_network
-        self._tile_size = self.stream_network.tile_shape[2]
+    @property
+    def stream_network(self):
+        """The converted network, available after :meth:`setup`."""
+        if not self._streaming_wrapper._is_prepared:
+            raise RuntimeError("The streaming network has not been prepared; Lightning setup must run first")
+        return self._streaming_wrapper.stream_network
+
+    def setup(self, stage: str | None = None) -> None:
+        """Prepare after Lightning has initialized its distributed strategy."""
+        self._streaming_wrapper.prepare_streaming_model()
 
     @property
     def tile_size(self):

--- a/lightstream/modules/streaming.py
+++ b/lightstream/modules/streaming.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 import copy
 import fcntl
+import os
+import tempfile
 from contextlib import contextmanager
 from pathlib import Path
 
@@ -32,6 +34,10 @@ class StreamingModule(nn.Module):
     tile_cache_path : str or pathlib.Path, optional
         File path used to load and save tile cache data. If omitted, a default
         cache file is created in the current working directory.
+    defer_prepare : bool, default=False
+        Delay metadata probing, cache I/O, and conversion until
+        :meth:`prepare_streaming_model` is called. This is useful when a
+        framework initializes distributed state after constructing modules.
     **kwargs
         Additional keyword arguments forwarded to
         :class:`lightstream.core.constructor.StreamingConstructor`.
@@ -51,7 +57,14 @@ class StreamingModule(nn.Module):
     TILE_CACHE_METADATA_KEY = "tile_cache_metadata"
     TILE_CACHE_METADATA_VERSION = 1
 
-    def __init__(self, stream_network: torch.nn.Module, tile_size, tile_cache_path: str | Path = None, **kwargs):
+    def __init__(
+        self,
+        stream_network: torch.nn.Module,
+        tile_size,
+        tile_cache_path: str | Path = None,
+        defer_prepare: bool = False,
+        **kwargs,
+    ):
         """Initialize the streaming wrapper and prepare tile-cache state.
 
         Parameters
@@ -62,6 +75,8 @@ class StreamingModule(nn.Module):
             Spatial height and width of square NCHW tiles.
         tile_cache_path : str or pathlib.Path, optional
             File path used to load and save tile cache data.
+        defer_prepare : bool, default=False
+            Defer all cache and streaming-network preparation.
         **kwargs
             Additional keyword arguments forwarded to
             :class:`lightstream.core.constructor.StreamingConstructor`.
@@ -72,41 +87,80 @@ class StreamingModule(nn.Module):
         self.tile_cache_path = Path(tile_cache_path) if tile_cache_path else None
         self.tile_cache_dir = Path.cwd() if tile_cache_path is None else self.tile_cache_path.parent
         self.tile_cache_fname = None if tile_cache_path is None else self.tile_cache_path.stem
-        self.tile_cache_metadata = self.build_tile_cache_metadata(stream_network)
+        # Keep the original model and constructor arguments intact until the
+        # distributed runtime (and, in particular, the process rank) is known.
+        self._source_stream_network = stream_network
+        self._constructor_kwargs = dict(kwargs)
+        self._defer_prepare_requested = defer_prepare
+        self._is_prepared = False
+        self.tile_cache_metadata = None
         self._tile_cache_was_ignored = False
-        tile_cache = self.load_tile_cache_if_needed()  # Load tile cache if present
+        if not defer_prepare:
+            self.prepare_streaming_model()
 
-        # Initialize the streaming network. When a distributed job starts with no
-        # compatible cache, rank zero computes and saves it while the remaining
-        # ranks wait and then reload the freshly written cache.
-        if tile_cache is not None:
-            self._prepare_streaming_model(stream_network, tile_cache, **kwargs)
+    def prepare_streaming_model(self) -> None:
+        """Prepare the streaming network once, after distributed initialization.
+
+        In a distributed run only global rank zero is allowed to calculate tile
+        statistics.  A status object is broadcast before the barrier so a rank
+        zero exception cannot leave its peers blocked indefinitely.
+        """
+        if self._is_prepared:
+            return
+
+        source = self._source_stream_network
+        self.tile_cache_metadata = self.build_tile_cache_metadata(source)
+        distributed = self._distributed_is_initialized() and self._distributed_world_size() > 1
+        # Deferred distributed preparation goes straight to the coordinated
+        # path: rank zero rechecks under the lock and every peer performs only
+        # the single post-barrier load.
+        tile_cache = (
+            None
+            if distributed and self._defer_prepare_requested
+            else self.load_tile_cache_if_needed()
+        )
+
+        if not distributed:
+            self._prepare_streaming_model(source, tile_cache, **self._constructor_kwargs)
             self.save_tile_cache_if_needed(overwrite=self._tile_cache_was_ignored)
-        elif self._distributed_is_initialized() and self._distributed_world_size() > 1:
-            rank = self._distributed_rank()
-            if rank == 0:
+            self._is_prepared = True
+            return
+
+        rank = self._distributed_rank()  # get_rank is the global, not local, rank
+        status = [None]
+        if rank == 0:
+            try:
                 with self._exclusive_tile_cache_lock():
                     tile_cache = self.load_tile_cache_if_needed()
-                    if tile_cache is not None:
-                        self._prepare_streaming_model(stream_network, tile_cache, **kwargs)
-                    else:
-                        self._prepare_streaming_model(stream_network, tile_cache=None, **kwargs)
+                    self._prepare_streaming_model(source, tile_cache, **self._constructor_kwargs)
+                    if tile_cache is None:
                         self.save_tile_cache_if_needed(overwrite=self._tile_cache_was_ignored)
+                status[0] = {"ok": True}
+            except Exception as exc:  # communicated to peers before re-raising
+                status[0] = {"ok": False, "error": f"{type(exc).__name__}: {exc}"}
 
-            self._distributed_barrier()
+        # broadcast_object_list is also a failure-propagation handshake.  The
+        # fallback retains compatibility with lightweight mocked distributors.
+        try:
+            torch.distributed.broadcast_object_list(status, src=0)
+        except (RuntimeError, ValueError, AttributeError):
+            if rank == 0 and status[0] and not status[0]["ok"]:
+                raise RuntimeError(f"Rank 0 failed while preparing tile cache: {status[0]['error']}")
 
-            if rank != 0:
-                tile_cache = self.load_tile_cache_if_needed()
-                if tile_cache is None:
-                    raise RuntimeError(
-                        "Rank "
-                        f"{rank} could not load a compatible tile cache after waiting for rank 0. "
-                        f"Expected cache path: {self._tile_cache_location()}"
-                    )
-                self._prepare_streaming_model(stream_network, tile_cache, **kwargs)
-        else:
-            self._prepare_streaming_model(stream_network, tile_cache=None, **kwargs)
-            self.save_tile_cache_if_needed(overwrite=self._tile_cache_was_ignored)
+        if status[0] and not status[0]["ok"]:
+            raise RuntimeError(f"Rank 0 failed while preparing tile cache: {status[0]['error']}")
+        self._distributed_barrier()
+
+        if rank != 0:
+            tile_cache = self.load_tile_cache_if_needed()
+            if tile_cache is None:
+                raise RuntimeError(
+                    f"Rank {rank} could not load the tile cache written by global rank 0. "
+                    "The cache directory must be on storage shared by every rank. "
+                    f"Expected cache path: {self._tile_cache_location()}"
+                )
+            self._prepare_streaming_model(source, tile_cache, **self._constructor_kwargs)
+        self._is_prepared = True
 
     @staticmethod
     def _distributed_is_initialized() -> bool:
@@ -427,7 +481,17 @@ class StreamingModule(nn.Module):
                 print(f"writing streaming cache file to {str(write_path)}")
                 tile_cache = self.stream_network.get_tile_cache()
                 tile_cache[self.TILE_CACHE_METADATA_KEY] = copy.deepcopy(self.tile_cache_metadata)
-                torch.save(tile_cache, str(write_path))
+                # Never expose a partially-written pickle to another rank.
+                fd, temporary_name = tempfile.mkstemp(
+                    prefix=f".{write_path.name}.", dir=str(write_path.parent)
+                )
+                os.close(fd)
+                try:
+                    torch.save(tile_cache, temporary_name)
+                    os.replace(temporary_name, write_path)
+                finally:
+                    if os.path.exists(temporary_name):
+                        os.unlink(temporary_name)
 
         else:
             raise NotADirectoryError(f"Did not find {self.tile_cache_dir} or does not exist")
@@ -492,6 +556,8 @@ class StreamingModule(nn.Module):
         torch.Tensor or tuple or list or dict
             Output produced by ``self.stream_network``.
         """
+        if not self._is_prepared:
+            raise RuntimeError("StreamingModule.prepare_streaming_model() must be called before forward")
         return self.stream_network(x, mask=mask)
 
     def backward_streaming(self, image, grad, mask=None):

--- a/tests/test_streaming_module_distributed_cache.py
+++ b/tests/test_streaming_module_distributed_cache.py
@@ -239,3 +239,45 @@ def test_distributed_nonzero_rank_errors_when_cache_missing_after_barrier(monkey
         StreamingModule(nn.Identity(), 8, tile_cache_path=cache_path)
 
     assert DummyConstructor.calls == []
+
+
+def test_deferred_preparation_waits_for_process_group_and_is_idempotent(monkeypatch, tmp_path):
+    initialized = False
+    saves = []
+    barriers = []
+
+    monkeypatch.setattr(StreamingModule, "load_tile_cache_if_needed", lambda self: None)
+    monkeypatch.setattr(
+        StreamingModule,
+        "save_tile_cache_if_needed",
+        lambda self, overwrite=False: saves.append(overwrite),
+    )
+    monkeypatch.setattr(
+        StreamingModule,
+        "_distributed_is_initialized",
+        staticmethod(lambda: initialized),
+    )
+    monkeypatch.setattr(StreamingModule, "_distributed_world_size", staticmethod(lambda: 2))
+    monkeypatch.setattr(StreamingModule, "_distributed_rank", staticmethod(lambda: 0))
+    monkeypatch.setattr(
+        StreamingModule,
+        "_distributed_barrier",
+        staticmethod(lambda: barriers.append("barrier")),
+    )
+
+    wrapper = StreamingModule(
+        nn.Identity(),
+        8,
+        tile_cache_path=tmp_path / "cache",
+        defer_prepare=True,
+    )
+    assert DummyConstructor.calls == []
+    assert wrapper.tile_cache_metadata is None
+
+    initialized = True
+    wrapper.prepare_streaming_model()
+    wrapper.prepare_streaming_model()
+
+    assert [call["tile_cache"] for call in DummyConstructor.calls] == [None]
+    assert saves == [False]
+    assert barriers == ["barrier"]


### PR DESCRIPTION
### Motivation

- Constructing the streaming network and calculating/saving tile-cache metadata is expensive and must be deferred until a distributed process group (or Lightning strategy) is initialized. 
- Lightning users need a way to build modules before the framework sets up distributed state so cache generation is coordinated by global rank zero. 
- Preparation must be idempotent and safe across repeated lifecycle hooks to avoid duplicate work or deadlocks.

### Description

- Add a backward-compatible `defer_prepare: bool = False` constructor option to `StreamingModule` and retain the original `stream_network` and `StreamingConstructor` keyword arguments for later use. 
- Introduce an idempotent public `prepare_streaming_model(self) -> None` method that performs metadata probing, coordinated global-rank-zero cache generation under an exclusive lock, status broadcast/failure propagation, a post-publication barrier, and CPU-mapped cache loads on nonzero ranks. 
- Make cache publication atomic by writing to a temporary file and then `os.replace`-ing it into place, and guard forward calls to require preparation. 
- Update `LightningStreamingModule` to keep the `StreamingModule` wrapper, prevent access to the converted network before preparation, and call `prepare_streaming_model()` during Lightning `setup()` so preparation runs after the strategy/process group is available. 
- Improve robustness of distributed handshake by broadcasting a status object via `torch.distributed.broadcast_object_list` with sensible fallbacks and clear errors if nonzero ranks cannot load the shared cache. 
- Add lifecycle-focused tests covering deferred construction, delayed process-group initialization, and idempotent repeated preparation in `tests/test_streaming_module_distributed_cache.py`.

### Testing

- Ran `pytest -q tests/test_streaming_module_distributed_cache.py` which passed (`7 passed, 1 warning`).
- Verified `python -m compileall -q lightstream/modules/streaming.py lightstream/modules/lightningstreaming.py` completed without syntax errors. 
- Ran repository checks with `git diff --check` which reported no issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a666376ae4083308d341c1ed4a80b77)