### PR TITLE
Add LayerScale and StreamingLayerScale (streaming-aware learnable multiplier)

### DIFF
--- a/lightstream/core/constructor.py
+++ b/lightstream/core/constructor.py
@@ -18,6 +18,7 @@ from copy import deepcopy
 from lightstream.core.scnn.scnn import StreamingCNN
 from lightstream.core.reducer import BaseReducer
 from lightstream.core.scnn.streaminglayernorm import ChannelLayerNorm
+from lightstream.core.scnn.streaminglayerscale import LayerScale
 from typing import Any, Callable, Optional
 
 
@@ -86,6 +87,7 @@ class StreamingConstructor:
             torch.nn.MaxPool3d,
             torch.nn.Upsample,
             ChannelLayerNorm,
+            LayerScale,
             BaseReducer,
         ]
 

--- a/lightstream/core/scnn/__init__.py
+++ b/lightstream/core/scnn/__init__.py
@@ -7,5 +7,6 @@ modules from here instead of from implementation modules such as
 """
 
 from lightstream.core.scnn.streaminglayernorm import ChannelLayerNorm, StreamingChannelLayerNorm
+from lightstream.core.scnn.streaminglayerscale import LayerScale, StreamingLayerScale
 
-__all__ = ["ChannelLayerNorm", "StreamingChannelLayerNorm"]
+__all__ = ["ChannelLayerNorm", "StreamingChannelLayerNorm", "LayerScale", "StreamingLayerScale"]

--- a/lightstream/core/scnn/scnn.py
+++ b/lightstream/core/scnn/scnn.py
@@ -31,6 +31,7 @@ from lightstream.core.scnn.streaminglayernorm import (
     ChannelLayerNorm,
     StreamingChannelLayerNorm,
 )
+from lightstream.core.scnn.streaminglayerscale import LayerScale, StreamingLayerScale
 from lightstream.core.reducer import BaseReducer, BaseStreamingGlobalReducer
 
 
@@ -43,12 +44,13 @@ BACKWARD_STREAMING_MODULE_TYPES = (
     StreamingConv2d,
     StreamingUpsample2d,
     StreamingChannelLayerNorm,
+    StreamingLayerScale,
 )
 
 
 def _is_pointwise_channel_norm(module):
     """Return True for channel-only normalization layers that preserve spatial support."""
-    return isinstance(module, (ChannelLayerNorm, StreamingChannelLayerNorm))
+    return isinstance(module, (ChannelLayerNorm, StreamingChannelLayerNorm, LayerScale, StreamingLayerScale))
 
 
 def _is_backward_streaming_module(module):
@@ -763,6 +765,18 @@ class StreamingCNN(torch.nn.Module):
                     mod.upsample_backward_input_lost = None
                 self._module_stats[mod] = self._module_stats[module]
                 del self._module_stats[module]
+        elif isinstance(module, LayerScale):
+            mod = StreamingLayerScale.from_layer_scale(module)
+            if module in self._module_stats:
+                stats = self._module_stats[module]
+                if "grad_lost" in stats:
+                    mod.grad_lost = stats["grad_lost"]
+                if "output_stride" in stats:
+                    mod.output_stride = stats["output_stride"]
+                self._module_stats[mod] = stats
+                del self._module_stats[module]
+            del module
+            return mod
         elif isinstance(module, ChannelLayerNorm):
             mod = StreamingChannelLayerNorm.from_channel_layer_norm(module)
             if module in self._module_stats:
@@ -815,6 +829,16 @@ class StreamingCNN(torch.nn.Module):
                     stats["scale_factor_hw"] = (
                         (float(sf[-2]), float(sf[-1])) if isinstance(sf, tuple) else (float(sf), float(sf))
                     )
+                self._module_stats[mod] = stats
+            else:
+                self._module_stats[mod] = self._module_stats[module]
+                del self._module_stats[module]
+        elif isinstance(module, StreamingLayerScale):
+            mod = module.to_layer_scale()
+            if module not in self._module_stats:
+                stats = {}
+                stats["grad_lost"] = module.grad_lost
+                stats["output_stride"] = module.output_stride
                 self._module_stats[mod] = stats
             else:
                 self._module_stats[mod] = self._module_stats[module]

--- a/lightstream/core/scnn/streaminglayerscale.py
+++ b/lightstream/core/scnn/streaminglayerscale.py
@@ -1,0 +1,214 @@
+from __future__ import annotations
+
+from collections.abc import Iterable
+import torch
+import torch.nn as nn
+from torch.amp import custom_bwd, custom_fwd
+
+from lightstream.core.scnn.utils import Box, H_DIM, Lost, W_DIM, _new_value_indices
+
+
+def _normalize_scale_shape(shape: int | Iterable[int] | torch.Size) -> torch.Size:
+    if isinstance(shape, torch.Size):
+        values = tuple(shape)
+    elif isinstance(shape, int):
+        values = (shape,)
+    elif isinstance(shape, Iterable):
+        values = tuple(shape)
+    else:
+        raise TypeError(
+            "LayerScale shape must be an int, tuple/list of ints, or torch.Size; "
+            f"got {type(shape).__name__}."
+        )
+
+    if not all(isinstance(dim, int) for dim in values):
+        raise TypeError(f"LayerScale shape must contain only ints, got {values!r}.")
+    if any(dim < 0 for dim in values):
+        raise ValueError(
+            f"LayerScale shape dimensions must be non-negative, got {values!r}."
+        )
+    return torch.Size(values)
+
+
+def _broadcast_error(
+    module_name: str, x: torch.Tensor, scale: torch.Tensor
+) -> ValueError:
+    return ValueError(
+        f"{module_name} scale with shape {tuple(scale.shape)} cannot broadcast to input shape {tuple(x.shape)}. "
+        "Choose a scale shape compatible with PyTorch broadcasting, for example (1,), (C,), or (1, C, 1, 1)."
+    )
+
+
+class LayerScale(nn.Module):
+    """Learnable multiplicative scale with PyTorch broadcasting semantics."""
+
+    def __init__(
+        self, shape: int | Iterable[int] | torch.Size, init_value: float = 0.0
+    ):
+        super().__init__()
+        self.shape = _normalize_scale_shape(shape)
+        self.init_value = init_value
+        self.scale = nn.Parameter(torch.full(self.shape, init_value))
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        try:
+            return x * self.scale
+        except RuntimeError as error:
+            raise _broadcast_error(type(self).__name__, x, self.scale) from error
+
+
+class StreamingLayerScaleF(torch.autograd.Function):
+    @staticmethod
+    @custom_fwd(
+        device_type="cuda",
+        cast_inputs=torch.bfloat16 if torch.cuda.is_bf16_supported() else torch.float16,
+    )
+    def forward(ctx, inpt, scale, grad_lost, seen_indices, output_stride, input_loc):
+        ctx.grad_lost = grad_lost
+        ctx.seen_indices = seen_indices
+        ctx.output_stride = output_stride
+        ctx.input_loc = input_loc
+        ctx.save_for_backward(inpt, scale)
+        return inpt * scale
+
+    @staticmethod
+    @custom_bwd(device_type="cuda")
+    def backward(ctx, grad_output):
+        inpt, scale = ctx.saved_tensors
+
+        grad_in = (
+            grad_output * scale.to(dtype=grad_output.dtype)
+            if ctx.needs_input_grad[0]
+            else None
+        )
+        grad_scale = None
+
+        if ctx.needs_input_grad[1]:
+            if grad_output.ndim < 4:
+                grad_scale = (
+                    (grad_output * inpt).sum_to_size(scale.shape).to(dtype=scale.dtype)
+                )
+                return grad_in, grad_scale, None, None, None, None
+
+            input_loc = ctx.input_loc
+            sides = input_loc.sides if input_loc is not None else None
+            grad_lost = ctx.grad_lost
+            seen_indices = ctx.seen_indices
+
+            lost_top = grad_lost.top if not (sides is not None and sides.top) else 0
+            lost_bottom = (
+                grad_lost.bottom if not (sides is not None and sides.bottom) else 0
+            )
+            lost_left = grad_lost.left if not (sides is not None and sides.left) else 0
+            lost_right = (
+                grad_lost.right if not (sides is not None and sides.right) else 0
+            )
+
+            valid_grad = grad_output[
+                :,
+                :,
+                lost_top : grad_output.shape[H_DIM] - lost_bottom,
+                lost_left : grad_output.shape[W_DIM] - lost_right,
+            ]
+
+            if input_loc is None:
+                data_loc = Box(lost_top, 0, lost_left, 0, sides)
+            else:
+                output_stride = ctx.output_stride
+                stride_h = (
+                    int(output_stride[1].item())
+                    if isinstance(output_stride, torch.Tensor)
+                    else int(output_stride[1])
+                )
+                stride_w = (
+                    int(output_stride[2].item())
+                    if isinstance(output_stride, torch.Tensor)
+                    else int(output_stride[2])
+                )
+                data_loc_y = int(input_loc.y // stride_h) + lost_top
+                data_loc_x = int(input_loc.x // stride_w) + lost_left
+                data_loc = Box(data_loc_y, 0, data_loc_x, 0, input_loc.sides)
+
+            new_output_box, updated_total_indices = _new_value_indices(
+                valid_grad.shape, data_loc, seen_indices
+            )
+            seen_indices.y = updated_total_indices.y
+            seen_indices.height = updated_total_indices.height
+            seen_indices.x = updated_total_indices.x
+            seen_indices.width = updated_total_indices.width
+            seen_indices.sides = updated_total_indices.sides
+
+            if new_output_box.height > 0 and new_output_box.width > 0:
+                y0 = lost_top + new_output_box.y
+                y1 = y0 + new_output_box.height
+                x0 = lost_left + new_output_box.x
+                x1 = x0 + new_output_box.width
+                relevant_grad = grad_output[:, :, y0:y1, x0:x1]
+                relevant_input = inpt[:, :, y0:y1, x0:x1]
+                grad_scale = (
+                    (relevant_grad * relevant_input)
+                    .sum_to_size(scale.shape)
+                    .to(dtype=scale.dtype)
+                )
+            else:
+                grad_scale = torch.zeros_like(scale)
+
+        return grad_in, grad_scale, None, None, None, None
+
+
+streaming_layer_scale = StreamingLayerScaleF.apply
+
+
+class StreamingLayerScale(nn.Module):
+    """Streaming variant of :class:`LayerScale` with compatible ``scale`` state dict keys."""
+
+    def __init__(
+        self, shape: int | Iterable[int] | torch.Size, init_value: float = 0.0
+    ):
+        super().__init__()
+        self.shape = _normalize_scale_shape(shape)
+        self.init_value = init_value
+        self.scale = nn.Parameter(torch.full(self.shape, init_value))
+        self.grad_lost = Lost(0, 0, 0, 0)
+        self.output_stride = torch.tensor([1, 1, 1])
+        self.reset()
+
+    def reset(self):
+        self.seen_indices = Box(0, 0, 0, 0, None)
+        self.input_loc = Box(0, 0, 0, 0, None)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        try:
+            return streaming_layer_scale(
+                x,
+                self.scale,
+                self.grad_lost,
+                self.seen_indices,
+                self.output_stride,
+                self.input_loc,
+            )
+        except RuntimeError as error:
+            raise _broadcast_error(type(self).__name__, x, self.scale) from error
+
+    @classmethod
+    def from_layer_scale(cls, module: LayerScale) -> "StreamingLayerScale":
+        if not isinstance(module, LayerScale):
+            raise TypeError(
+                f"StreamingLayerScale.from_layer_scale expected LayerScale, got {type(module).__name__}."
+            )
+        mod = cls(module.scale.shape, module.init_value)
+        mod = mod.to(
+            device=module.scale.device, dtype=module.scale.dtype, non_blocking=True
+        )
+        mod.scale.requires_grad = module.scale.requires_grad
+        mod.scale.data.copy_(module.scale.data)
+        return mod
+
+    def to_layer_scale(self) -> LayerScale:
+        mod = LayerScale(self.scale.shape, self.init_value)
+        mod = mod.to(
+            device=self.scale.device, dtype=self.scale.dtype, non_blocking=True
+        )
+        mod.scale.requires_grad = self.scale.requires_grad
+        mod.scale.data.copy_(self.scale.data)
+        return mod

--- a/tests/test_streaminglayerscale.py
+++ b/tests/test_streaminglayerscale.py
@@ -1,0 +1,115 @@
+import sys
+import types
+
+import pytest
+import torch
+
+from lightstream.core.scnn import LayerScale, StreamingLayerScale
+from lightstream.core.scnn.streaminglayerscale import LayerScale as ImportedLayerScale
+
+
+def test_layer_scale_broadcasts_supported_shapes():
+    x = torch.randn(2, 3, 5, 7)
+    for shape in (1, (1,), torch.Size([3, 1, 1]), (1, 3, 1, 1)):
+        module = LayerScale(shape, init_value=2.0)
+        torch.testing.assert_close(module(x), x * module.scale)
+
+
+def test_layer_scale_defaults_to_identity_at_initialization_multiplier_zero():
+    module = LayerScale((1, 4, 1, 1))
+    assert torch.count_nonzero(module.scale) == 0
+    torch.testing.assert_close(module(torch.randn(2, 4, 3, 3)), torch.zeros(2, 4, 3, 3))
+
+
+def test_layer_scale_rejects_unbroadcastable_shape_with_clear_message():
+    module = LayerScale((2,))
+    with pytest.raises(ValueError, match="cannot broadcast to input shape"):
+        module(torch.randn(1, 3, 4, 5))
+
+
+def test_streaming_layer_scale_round_trip_preserves_state_dict_metadata():
+    module = LayerScale((1, 3, 1, 1), init_value=0.25).to(dtype=torch.float64)
+    module.scale.requires_grad = False
+    module.scale.data.copy_(torch.arange(3, dtype=torch.float64).view(1, 3, 1, 1))
+
+    streaming = StreamingLayerScale.from_layer_scale(module)
+    assert list(streaming.state_dict()) == ["scale"]
+    assert streaming.scale.dtype == module.scale.dtype
+    assert streaming.scale.device == module.scale.device
+    assert streaming.scale.requires_grad is False
+    torch.testing.assert_close(streaming.scale, module.scale)
+
+    restored = streaming.to_layer_scale()
+    assert list(restored.state_dict()) == ["scale"]
+    assert restored.scale.dtype == module.scale.dtype
+    assert restored.scale.requires_grad is False
+    torch.testing.assert_close(restored.scale, module.scale)
+
+
+def test_streaming_layer_scale_public_export():
+    assert ImportedLayerScale is LayerScale
+    assert StreamingLayerScale.__name__ == "StreamingLayerScale"
+
+
+def test_constructor_keeps_layer_scale_streamable(monkeypatch):
+    monkeypatch.setitem(sys.modules, "numpy", types.ModuleType("numpy"))
+    from lightstream.core.constructor import StreamingConstructor
+
+    constructor = StreamingConstructor(
+        torch.nn.Sequential(LayerScale((1, 3, 1, 1))), tile_size=8, verbose=False
+    )
+    assert LayerScale in constructor.keep_modules
+
+
+class SmallLayerScaleNet(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.upstream = torch.nn.Conv2d(3, 4, kernel_size=3, padding=1)
+        self.scale = LayerScale((1, 4, 1, 1), init_value=0.5)
+        self.downstream = torch.nn.Conv2d(4, 2, kernel_size=3, padding=1)
+
+    def forward(self, x):
+        return self.downstream(torch.relu(self.scale(self.upstream(x))))
+
+
+def test_scnn_layer_scale_forward_backward_parity(monkeypatch):
+    monkeypatch.setitem(sys.modules, "numpy", types.ModuleType("numpy"))
+    from lightstream.core.scnn.scnn import StreamingCNN
+
+    torch.manual_seed(404)
+    model = SmallLayerScaleNet().eval()
+    reference = SmallLayerScaleNet().eval()
+    reference.load_state_dict(model.state_dict())
+
+    image = torch.randn(1, 3, 13, 11)
+    upstream_grad = torch.randn(1, 2, 13, 11)
+
+    ref_image = image.detach().clone().requires_grad_(True)
+    ref_output = reference(ref_image)
+    torch.autograd.backward(ref_output, upstream_grad)
+
+    scnn = StreamingCNN(
+        model,
+        tile_shape=(1, 3, 8, 8),
+        verbose=False,
+        deterministic=True,
+        copy_to_gpu=False,
+        statistics_on_cpu=False,
+        normalize_on_gpu=False,
+    )
+    assert isinstance(scnn.stream_module.scale, StreamingLayerScale)
+
+    stream_output = scnn.forward(image.detach().clone())
+    torch.testing.assert_close(stream_output, ref_output.detach(), atol=1e-5, rtol=1e-4)
+
+    scnn.backward(image.detach().clone(), upstream_grad.detach().clone())
+
+    reference_grads = {name: param.grad for name, param in reference.named_parameters()}
+    streaming_grads = {
+        name: param.grad for name, param in scnn.stream_module.named_parameters()
+    }
+    assert streaming_grads.keys() == reference_grads.keys()
+    for name in reference_grads:
+        torch.testing.assert_close(
+            streaming_grads[name], reference_grads[name], atol=1e-5, rtol=1e-4
+        )


### PR DESCRIPTION
### Motivation

- Provide a lightweight, broadcastable learnable multiplier layer (`LayerScale`) used by ConvNeXt/HFRM-style patterns with identity-at-init support via `init_value=0.0`.
- Provide a streaming-compatible variant (`StreamingLayerScale`) that preserves the same `scale` parameter name and avoids double-counting parameter gradients when tiled training replays overlapping tiles.

### Description

- Add `lightstream/core/scnn/streaminglayerscale.py` implementing `LayerScale` and `StreamingLayerScale` and a custom autograd `StreamingLayerScaleF` that deduplicates tiled gradient accumulation using `seen_indices`/valid-region logic and computes `grad_scale = sum(valid_grad * valid_input)` reduced to `scale.shape`.
- Export `LayerScale` and `StreamingLayerScale` from `lightstream/core/scnn/__init__.py` and add `LayerScale` to the constructor keep-list in `lightstream/core/constructor.py` for streaming conversion compatibility.
- Integrate conversions into `StreamingCNN` in `lightstream/core/scnn/scnn.py` so `LayerScale` -> `StreamingLayerScale` during streaming setup and the reverse during reset, and add `StreamingLayerScale` to backward-streaming module tracking.
- Add unit tests `tests/test_streaminglayerscale.py` covering broadcasting behavior, default initialization, clear broadcast error messages, state-dict round-trip conversions, public exports, constructor keep-list, and streaming forward/backward parity with overlapping tiles.

### Testing

- Ran targeted unit tests: `pytest -q tests/test_streaminglayerscale.py tests/test_streaminglayernorm.py`, all tests passed (33 passed) with one NumPy-missing warning from torch internals.
- Compiled modified modules with `python -m py_compile ...` to ensure syntax correctness; compilation succeeded for the new and modified files.
- Full test run `pytest -q` could not complete in this environment due to `ModuleNotFoundError: No module named 'numpy'` during collection, which is an environment dependency and not a code failure.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7260cf05e88330ad9a6cbae4618d45)