### PR TITLE
Add LayerScale streaming tests and docs

### DIFF
--- a/docs/modules/scnn.md
+++ b/docs/modules/scnn.md
@@ -1,11 +1,69 @@
 # Streaming CNN layers
 
 `lightstream.core.scnn` is the documented public module for streaming CNN layer
-building blocks. Import channel layer normalization from this package instead of
-private implementation modules:
+building blocks. Import channel layer normalization and layer scale helpers from
+this package instead of private implementation modules:
 
 ```python
-from lightstream.core.scnn import ChannelLayerNorm, StreamingChannelLayerNorm
+from lightstream.core.scnn import ChannelLayerNorm, LayerScale, StreamingChannelLayerNorm
 ```
+
+## LayerScale for discoverable learned scaling
+
+Use `LayerScale` when model code needs a learned multiplicative scale that the
+streaming converter can discover and replace with `StreamingLayerScale`. For
+example, replace a raw parameter such as this:
+
+```python
+class Block(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.gamma = torch.nn.Parameter(torch.zeros(1))
+
+    def forward(self, x):
+        return x * self.gamma
+```
+
+with a module-based scale:
+
+```python
+from lightstream.core.scnn import LayerScale
+
+class Block(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.gamma_scale = LayerScale(shape=1, init_value=0.0)
+
+    def forward(self, x):
+        return self.gamma_scale(x)
+```
+
+`LayerScale` is also useful in residual branches where the learnable `gamma`
+starts at zero:
+
+```python
+from lightstream.core.scnn import LayerScale
+
+class ResidualBlock(torch.nn.Module):
+    def __init__(self, branch):
+        super().__init__()
+        self.branch = branch
+        self.gamma_scale = LayerScale(shape=1, init_value=0.0)
+
+    def forward(self, residual):
+        branch = self.branch(residual)
+        out = residual + self.gamma_scale(branch)
+        return out
+```
+
+Supported scale shapes follow PyTorch broadcasting semantics. Common choices
+include scalar `(1,)`, channel-wise `(1, C, 1, 1)`, or any shape broadcastable to
+the input tensor.
+
+Raw `nn.Parameter` multiplications inside arbitrary `forward` code are not
+represented as child modules, so the streaming converter cannot discover or
+replace them automatically. `LayerScale` makes the operation explicit in the
+module tree, allowing `StreamingCNN` conversion to replace it with
+`StreamingLayerScale` while preserving the `scale` state-dict key.
 
 ::: lightstream.core.scnn

--- a/tests/test_streaminglayerscale.py
+++ b/tests/test_streaminglayerscale.py
@@ -4,8 +4,26 @@ import types
 import pytest
 import torch
 
+from lightstream.core.reducer import MeanReducer, StreamingMeanReducer
 from lightstream.core.scnn import LayerScale, StreamingLayerScale
 from lightstream.core.scnn.streaminglayerscale import LayerScale as ImportedLayerScale
+
+
+def test_layer_scale_scalar_shape_forward_matches_raw_multiplication():
+    x = torch.randn(2, 3, 5, 7)
+    module = LayerScale(shape=1, init_value=1.75)
+
+    assert tuple(module.scale.shape) == (1,)
+    torch.testing.assert_close(module(x), x * module.scale)
+
+
+def test_layer_scale_channel_shape_broadcasts_across_spatial_dimensions():
+    x = torch.randn(2, 3, 5, 7)
+    module = LayerScale(shape=(1, 3, 1, 1), init_value=1.0)
+    module.scale.data.copy_(torch.tensor([[[[0.5]], [[1.5]], [[2.5]]]]))
+
+    expected = x * torch.tensor([0.5, 1.5, 2.5]).view(1, 3, 1, 1)
+    torch.testing.assert_close(module(x), expected)
 
 
 def test_layer_scale_broadcasts_supported_shapes():
@@ -113,3 +131,60 @@ def test_scnn_layer_scale_forward_backward_parity(monkeypatch):
         torch.testing.assert_close(
             streaming_grads[name], reference_grads[name], atol=1e-5, rtol=1e-4
         )
+
+
+class SmallLayerScaleReducerNet(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.features = torch.nn.Sequential(
+            torch.nn.Conv2d(3, 4, kernel_size=3, padding=1),
+            LayerScale((1, 4, 1, 1), init_value=0.5),
+            torch.nn.ReLU(),
+        )
+        self.head = torch.nn.Sequential(
+            torch.nn.Conv2d(4, 2, kernel_size=1, bias=False),
+            MeanReducer(),
+        )
+
+    def forward(self, x):
+        return self.head(self.features(x))
+
+
+def test_scnn_layer_scale_reducer_head_forward_backward_scale_gradient_parity():
+    from lightstream.core.scnn.scnn import StreamingCNN
+
+    torch.manual_seed(405)
+    model = SmallLayerScaleReducerNet().eval()
+    reference = SmallLayerScaleReducerNet().eval()
+    reference.load_state_dict(model.state_dict())
+
+    image = torch.randn(1, 3, 13, 11)
+
+    ref_image = image.detach().clone().requires_grad_(True)
+    ref_output = reference(ref_image)
+    upstream_grad = torch.randn_like(ref_output)
+    torch.autograd.backward(ref_output, upstream_grad)
+
+    scnn = StreamingCNN(
+        model,
+        tile_shape=(1, 3, 8, 8),
+        verbose=False,
+        deterministic=True,
+        copy_to_gpu=False,
+        statistics_on_cpu=False,
+        normalize_on_gpu=False,
+    )
+    assert isinstance(scnn.stream_module.features[1], StreamingLayerScale)
+    assert isinstance(scnn.stream_module.head[1], StreamingMeanReducer)
+
+    stream_output = scnn.forward(image.detach().clone())
+    torch.testing.assert_close(stream_output, ref_output.detach(), atol=1e-5, rtol=1e-4)
+
+    scnn.backward(image.detach().clone(), upstream_grad.detach().clone())
+
+    torch.testing.assert_close(
+        scnn.stream_module.features[1].scale.grad,
+        reference.features[1].scale.grad,
+        atol=1e-5,
+        rtol=1e-4,
+    )


### PR DESCRIPTION
### Motivation
- Ensure `LayerScale` broadcasting, conversion to streaming form, and forward/backward parity are covered by unit tests for robustness of streaming conversion and gradient handling.
- Document the public import path and recommended usage patterns so users replace raw `nn.Parameter` multiplications with a discoverable `LayerScale` module that `StreamingCNN` can convert.

### Description
- Added focused tests to `tests/test_streaminglayerscale.py` including scalar `shape=1` forward behavior and channel-wise broadcast behavior `(1, C, 1, 1)`, plus existing coverage improvements for `StreamingLayerScale` conversion and round-trip state preservation.  
- Added a small model test (`SmallLayerScaleReducerNet`) that combines convolution, `LayerScale`, and a `MeanReducer` to verify `StreamingCNN` replaces `LayerScale` with `StreamingLayerScale` and `MeanReducer` with `StreamingMeanReducer`, and to assert forward parity and `scale` gradient parity against non-streaming autograd.  
- Updated `docs/modules/scnn.md` to show import usage (`from lightstream.core.scnn import LayerScale`), replacing raw `nn.Parameter(torch.zeros(1))` with `LayerScale(shape=1, init_value=0.0)`, a residual/gamma example `out = residual + gamma_scale(branch)`, a list of supported broadcast shapes (scalar `(1,)`, channel `(1, C, 1, 1)`, or any broadcastable shape), and a note that raw `nn.Parameter` multiplications are not discoverable by the streaming converter while `LayerScale` is.

### Testing
- Ran `pytest -q tests/test_streaminglayerscale.py`, which passed (`10 passed`) with one warning about missing `numpy` initialization inside PyTorch.  
- Attempted to run `pytest -q tests/test_scnn.py tests/test_streaminglayerscale.py`, but test collection failed due to `ModuleNotFoundError: No module named 'numpy'` in this environment.  
- All added tests in `tests/test_streaminglayerscale.py` passed in the environment after the change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7272bac1788330a15ea3e7d4cc1c0b)