### PR TITLE
Track dilation in streaming statistics

### DIFF
--- a/lightstream/core/scnn/scnn.py
+++ b/lightstream/core/scnn/scnn.py
@@ -2077,16 +2077,19 @@ class StreamingCNN(torch.nn.Module):
             stride = torch.tensor([1, 1, 1])
             kernel_size = torch.tensor([1, 1, 1])
             padding = torch.tensor([0, 0, 0])
+            dilation = torch.tensor([1, 1, 1])
         elif not is_upsample:
-            stride, kernel_size, padding = (
+            stride, kernel_size, padding, dilation = (
                 _triple(module.stride),
                 _triple(module.kernel_size),
                 _triple(module.padding),
+                _triple(getattr(module, "dilation", 1)),
             )
         else:
             stride = torch.tensor([1, 1, 1])
             kernel_size = torch.tensor([1, 1, 1])
             padding = torch.tensor([0, 0, 0])
+            dilation = torch.tensor([1, 1, 1])
 
         if not torch.is_grad_enabled():  # type:ignore
             # Convert strided convolutions/pooling to average pool
@@ -2135,6 +2138,7 @@ class StreamingCNN(torch.nn.Module):
                 "stride": stride if not is_upsample else torch.tensor([1, 1, 1]),
                 "kernel_size": kernel_size,
                 "padding": padding,
+                "dilation": dilation,
                 "module": module,
             }
             if is_upsample:

--- a/tests/test_scnn.py
+++ b/tests/test_scnn.py
@@ -27,6 +27,48 @@ from lightstream.core.reducer import (
 )
 
 
+def test_forward_statistics_store_and_preserve_dilated_conv2d_dilation():
+    scnn = StreamingCNN.__new__(StreamingCNN)
+    scnn.eps = 1e-5
+    scnn.dtype = torch.float32
+    scnn.device = torch.device("cpu")
+    scnn._saved_tensors = {}
+    scnn._module_stats = {}
+    scnn._print_verbose = lambda *args, **kwargs: None
+
+    module = nn.Conv2d(3, 4, kernel_size=3, padding=(2, 3), dilation=(2, 3), bias=False)
+    scnn.stream_module = nn.Sequential(module)
+    inpt = torch.ones(1, 3, 16, 16)
+
+    with torch.no_grad():
+        output = module(inpt)
+        scnn._forward_gather_statistics_hook(module, (inpt,), output)
+
+    module_stats = scnn._module_stats[module]
+    assert module_stats["dilation"] == (1, 2, 3)
+
+    scnn.output_stride = torch.tensor([1, 1, 1])
+    scnn.tile_output_lost = Lost(0, 0, 0, 0)
+    scnn._tile_output_lost = [scnn.tile_output_lost]
+    scnn.tile_gradient_lost = Lost(0, 0, 0, 0)
+    scnn._tile_output_shape = torch.Size([1, 4, 16, 16])
+    scnn._tile_output_shapes = [scnn._tile_output_shape]
+    scnn._output_stride_per_output = [scnn.output_stride]
+    scnn._output_spec = ("tensor", None)
+
+    state = scnn.get_tile_cache()
+    restored = StreamingCNN.__new__(StreamingCNN)
+    restored.stream_module = scnn.stream_module
+    restored._module_stats = {}
+    restored.disable = lambda: None
+    restored.enable = lambda: None
+
+    restored.load_tile_cache(state)
+
+    assert restored._module_stats[module]["dilation"] == (1, 2, 3)
+
+
+
 @pytest.mark.parametrize(
     "reducer_cls",
     [


### PR DESCRIPTION
### Motivation

- Ensure streaming per-module statistics include the convolution `dilation` so downstream streaming logic can account for dilated kernels and pooling.

### Description

- Compute `dilation` for modules with `getattr(module, "dilation", 1)` and convert it via the existing `_triple(...)` convention used for `stride`, `kernel_size`, and `padding` in `_forward_gather_statistics_hook`.
- Record identity dilation as `torch.tensor([1, 1, 1])` for pointwise and upsample modules to match how stride/kernel/padding are handled for those cases.
- Add the key `"dilation": dilation` to the `module_stats` dictionary for convolution/pooling/stat-tracked modules so the value is saved with the other per-module stats.
- Add a unit test `test_forward_statistics_store_and_preserve_dilated_conv2d_dilation` that builds a dilated `nn.Conv2d`, runs the forward statistics hook, asserts the stored `dilation` value, serializes via `get_tile_cache()` and restores via `load_tile_cache()` and asserts the `dilation` survives the round trip.

### Testing

- `python -m py_compile lightstream/core/scnn/scnn.py tests/test_scnn.py` succeeded.
- `pytest -q tests/test_scnn.py::test_forward_statistics_store_and_preserve_dilated_conv2d_dilation` failed during collection with `ModuleNotFoundError: No module named 'numpy'`, so the new test could not be executed in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7349e371d88330a28ca2b0588417fd)