### PR TITLE
Account for dilation in backward overlap stats

### DIFF
--- a/lightstream/core/scnn/scnn.py
+++ b/lightstream/core/scnn/scnn.py
@@ -2231,16 +2231,23 @@ class StreamingCNN(torch.nn.Module):
             stride = torch.tensor([1, 1, 1])
             kernel_size = torch.tensor([1, 1, 1])
             _padding = torch.tensor([0, 0, 0])
+            dilation = torch.tensor([1, 1, 1])
         elif not is_upsample:
-            stride, kernel_size, _padding = (
+            stride, kernel_size, _padding, dilation = (
                 _triple(module.stride),
                 _triple(module.kernel_size),
                 _triple(module.padding),
+                _triple(getattr(module, "dilation", 1)),
             )
         else:
             stride = torch.tensor([1, 1, 1])
             kernel_size = torch.tensor([1, 1, 1])
             _padding = torch.tensor([0, 0, 0])
+            dilation = torch.tensor([1, 1, 1])
+        dilation_h, dilation_w = dilation[1], dilation[2]
+        kernel_h, kernel_w = kernel_size[1], kernel_size[2]
+        effective_kernel_h = dilation_h * (kernel_h - 1) + 1
+        effective_kernel_w = dilation_w * (kernel_w - 1) + 1
         if grad_in[0] is not None:
             # We sum over the channels to deal with networks that do different operations
             # on groups of channels. Channel-only normalization and layer scaling are pointwise in space,
@@ -2313,18 +2320,19 @@ class StreamingCNN(torch.nn.Module):
 
             valid_grad = f_grad > (1 - self.eps) * f_grad.max()
 
-            # When kernel_size > stride we have some _overlap_ of gradients,
-            # this overlap makes extra positions in the input gradient invalid.
+            # When the effective kernel is larger than the stride we have some
+            # _overlap_ of gradients, this overlap makes extra positions in the
+            # input gradient invalid. Dilation increases the effective receptive
+            # field, so use the effective kernel rather than the raw kernel size.
             # Pointwise spatial-preserving channel modules have no additional spatial loss.
             if (not is_upsample and not is_pointwise_module) and (
-                (stride[0] > 1 and kernel_size[0] > stride[0])
-                or (stride[1] > 1 and kernel_size[1] > stride[1])
-                or (stride[2] > 1 and kernel_size[2] > stride[2])
+                (stride[1] > 1 and effective_kernel_h > stride[1])
+                or (stride[2] > 1 and effective_kernel_w > stride[2])
             ):
                 valid_lost = self._non_max_border_amount(f_grad)
                 valid_grad.fill_(0)
-                overlap_rows = kernel_size[1] - stride[1]
-                overlap_cols = kernel_size[2] - stride[2]
+                overlap_rows = effective_kernel_h - stride[1]
+                overlap_cols = effective_kernel_w - stride[2]
                 valid_grad[
                     valid_lost.top + overlap_rows : valid_grad.shape[0] - valid_lost.bottom - overlap_rows,
                     valid_lost.left + overlap_cols : valid_grad.shape[1] - valid_lost.right - overlap_cols,

--- a/tests/test_scnn.py
+++ b/tests/test_scnn.py
@@ -67,6 +67,36 @@ def test_forward_statistics_store_and_preserve_dilated_conv2d_dilation():
 
     assert restored._module_stats[module]["dilation"] == (1, 2, 3)
 
+def _conv2d_backward_valid_lost_for_dilation(dilation):
+    scnn = StreamingCNN.__new__(StreamingCNN)
+    scnn.eps = 1e-5
+    scnn.dtype = torch.float32
+    scnn.device = torch.device("cpu")
+    scnn._saved_tensors = {}
+    scnn._module_stats = {}
+    scnn._print_verbose = lambda *args, **kwargs: None
+
+    module = nn.Conv2d(1, 1, kernel_size=2, stride=2, dilation=dilation, bias=False)
+    module.weight.data.fill_(1)
+    inpt = torch.ones(1, 1, 8, 8, requires_grad=True)
+    output = module(inpt)
+    scnn._module_stats[module] = {}
+
+    output.sum().backward()
+    scnn._backward_gather_statistics_hook(module, (inpt.grad,), (torch.ones_like(output),))
+
+    return scnn._module_stats[module]["backward_valid_lost"]
+
+
+def test_backward_statistics_use_dilated_effective_kernel_for_overlap():
+    dilation_1_lost = _conv2d_backward_valid_lost_for_dilation(1)
+    dilation_2_lost = _conv2d_backward_valid_lost_for_dilation(2)
+
+    assert dilation_1_lost == Lost(0, 0, 0, 0)
+    assert dilation_2_lost.top > dilation_1_lost.top
+    assert dilation_2_lost.left > dilation_1_lost.left
+    assert dilation_2_lost.bottom > dilation_1_lost.bottom
+    assert dilation_2_lost.right > dilation_1_lost.right
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
### Motivation

- Ensure backward overlap detection accounts for convolution `dilation` so the computed backward valid region reflects the effective receptive field. 
- Make backward statistics (e.g. `backward_valid_lost`) grow when effective kernel size (with dilation) exceeds the stride.

### Description

- In `_backward_gather_statistics_hook` compute `dilation` and derive `effective_kernel_h` and `effective_kernel_w` via `dilation_h * (kernel_h - 1) + 1` and `dilation_w * (kernel_w - 1) + 1` in `lightstream/core/scnn/scnn.py`.
- Replace the overlap condition from raw `kernel_size > stride` to compare `effective_kernel_* > stride` and compute `overlap_rows`/`overlap_cols` using the effective kernel (`effective_kernel_h - stride[1]` and `effective_kernel_w - stride[2]`).
- Add a regression test in `tests/test_scnn.py` that compares `backward_valid_lost` for dilation `1` vs dilation `2` to assert the dilated receptive field increases the reported lost area.

### Testing

- Ran `python -m pytest tests/test_scnn.py -q`, which failed during test collection due to a missing dependency (`ModuleNotFoundError: No module named 'numpy'`).
- Local static checks (`git diff --check`) and commits were performed successfully (changes committed as `Account for dilation in backward overlap stats`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a734c1279d88330980de4263c84dfdb)