### PR TITLE
Expose LocalRectification internals to streaming statistics with StatisticsProbe

### DIFF
--- a/lightstream/core/constructor.py
+++ b/lightstream/core/constructor.py
@@ -20,6 +20,7 @@ from lightstream.core.scnn.scnn import StreamingCNN
 from lightstream.core.reducer import BaseReducer
 from lightstream.core.scnn.streaminglayernorm import ChannelLayerNorm
 from lightstream.core.scnn.streaminglayerscale import LayerScale
+from lightstream.core.scnn.statisticsprobe import StatisticsProbe
 from typing import Any, Callable, Optional
 
 
@@ -89,6 +90,7 @@ class StreamingConstructor:
             torch.nn.Upsample,
             ChannelLayerNorm,
             LayerScale,
+            StatisticsProbe,
             BaseReducer,
         ]
 

--- a/lightstream/core/scnn/scnn.py
+++ b/lightstream/core/scnn/scnn.py
@@ -32,6 +32,7 @@ from lightstream.core.scnn.streaminglayernorm import (
     StreamingChannelLayerNorm,
 )
 from lightstream.core.scnn.streaminglayerscale import LayerScale, StreamingLayerScale
+from lightstream.core.scnn.statisticsprobe import StatisticsProbe
 from lightstream.core.reducer import BaseReducer, BaseStreamingGlobalReducer
 
 
@@ -50,7 +51,16 @@ BACKWARD_STREAMING_MODULE_TYPES = (
 
 def _is_spatial_preserving_pointwise_module(module):
     """Return True for pointwise channel modules that preserve spatial support."""
-    return isinstance(module, (ChannelLayerNorm, StreamingChannelLayerNorm, LayerScale, StreamingLayerScale))
+    return isinstance(
+        module,
+        (
+            ChannelLayerNorm,
+            StreamingChannelLayerNorm,
+            LayerScale,
+            StreamingLayerScale,
+            StatisticsProbe,
+        ),
+    )
 
 
 def _is_backward_streaming_module(module):

--- a/lightstream/core/scnn/statisticsprobe.py
+++ b/lightstream/core/scnn/statisticsprobe.py
@@ -1,0 +1,11 @@
+import torch
+
+
+class StatisticsProbe(torch.nn.Identity):
+    """Expose an otherwise module-free tensor to streaming statistics hooks.
+
+    The probe is an identity during ordinary execution.  StreamingCNN recognizes
+    it as a spatially preserving pointwise module while it gathers tile support,
+    allowing support on both sides of Python arithmetic to remain visible.
+    """
+

--- a/lightstream/models/sshr/model.py
+++ b/lightstream/models/sshr/model.py
@@ -12,7 +12,7 @@ from lightstream.models.segment.resnet import make_resnet_backbone
 from lightstream.core.reducer import NGWPReducer
 from torchinfo import summary
 
-from lightstream.core.scnn.streaminglayerscale import LayerScale
+from lightstream.core.scnn.statisticsprobe import StatisticsProbe
 
 
 class LocalRectification(nn.Module):
@@ -46,6 +46,14 @@ class LocalRectification(nn.Module):
 
         self.gamma = 0.0 # LayerScale(shape=1, init_value=0.0)
 
+        # Local arithmetic has no module boundary of its own.  These identities
+        # make every operand and result visible while streaming tile statistics
+        # are gathered, without changing ordinary model execution.
+        self.feature_shallow_probe = StatisticsProbe()
+        self.weights_probe = StatisticsProbe()
+        self.weighted_features_probe = StatisticsProbe()
+        self.output_probe = StatisticsProbe()
+
     def forward(self, feature_shallow: Tensor, feature_deep: Tensor) -> Tensor:
         """
 
@@ -59,9 +67,11 @@ class LocalRectification(nn.Module):
 
         """
 
-        weights = self.rec_block(feature_deep)
-        weighted_features = feature_shallow * weights
-        return feature_shallow + 1.0 * weighted_features
+        feature_shallow = self.feature_shallow_probe(feature_shallow)
+        weights = self.weights_probe(self.rec_block(feature_deep))
+        weighted_features = self.weighted_features_probe(feature_shallow * weights)
+        output = feature_shallow + weighted_features
+        return self.output_probe(output)
 
 
 class SSHRDecoder(nn.Module):

--- a/tests/test_statisticsprobe.py
+++ b/tests/test_statisticsprobe.py
@@ -1,0 +1,52 @@
+import operator
+
+import pytest
+import torch
+
+from lightstream.core.scnn.statisticsprobe import StatisticsProbe
+
+
+def _valid(tensor: torch.Tensor) -> torch.Tensor:
+    # Streaming statistics use the maximum positive probe value to identify
+    # positions to which every required branch contributed.
+    return tensor == tensor.max()
+
+
+@pytest.mark.parametrize("operation", [operator.mul, operator.add])
+@pytest.mark.parametrize("reversed_operands", [False, True])
+def test_probe_arithmetic_support_and_branch_gradients(operation, reversed_operands):
+    """Arithmetic support is its operands' intersection in statistics probes."""
+    shallow = torch.zeros(1, 1, 6, 7)
+    shallow[:, :, 1:6, 1:6] = 2.0
+    weights = torch.zeros_like(shallow)
+    weights[:, :, 0:5, 2:7] = 3.0
+    shallow.requires_grad_()
+    weights.requires_grad_()
+
+    shallow_seen = StatisticsProbe()(shallow)
+    weights_seen = StatisticsProbe()(weights)
+    operands = (weights_seen, shallow_seen) if reversed_operands else (shallow_seen, weights_seen)
+    weighted_features = StatisticsProbe()(operation(*operands))
+    output = StatisticsProbe()(weighted_features)
+
+    expected_valid = _valid(shallow_seen) & _valid(weights_seen)
+    assert torch.equal(_valid(weighted_features), expected_valid)
+    assert torch.equal(_valid(output), expected_valid)
+
+    # Positive, nonuniform upstream gradients make both branch derivatives
+    # observable and prevent cancellation or a uniform reduction hiding one.
+    upstream = torch.arange(1, output.numel() + 1, dtype=output.dtype).reshape_as(output)
+    output.backward(upstream)
+    if operation is operator.mul:
+        assert torch.equal(shallow.grad, upstream * weights.detach())
+        assert torch.equal(weights.grad, upstream * shallow.detach())
+    else:
+        assert torch.equal(shallow.grad, upstream)
+        assert torch.equal(weights.grad, upstream)
+
+
+def test_statistics_probe_is_an_identity_in_ordinary_execution():
+    value = torch.randn(2, 3, 4, 5, requires_grad=True)
+    observed = StatisticsProbe()(value)
+
+    assert observed is value


### PR DESCRIPTION
### Motivation

- Make internal tensors in `LocalRectification.forward` visible to the streaming statistics machinery so arithmetic support and branch contributions can be diagnosed without changing ordinary execution semantics.

### Description

- Add `StatisticsProbe` (`lightstream/core/scnn/statisticsprobe.py`), a no-op `torch.nn.Identity` that streaming hooks treat as a spatially preserving pointwise module. 
- Register `StatisticsProbe` as a spatially preserving pointwise module in `_is_spatial_preserving_pointwise_module` (`lightstream/core/scnn/scnn.py`) and retain it during streaming-model preparation via `StreamingConstructor.keep_modules` (`lightstream/core/constructor.py`).
- Instrument `LocalRectification.forward` (`lightstream/models/sshr/model.py`) with probes for `feature_shallow`, `weights`, `weighted_features`, and the returned `output`, wrapping the arithmetic so streaming statistics can observe operands and results while keeping behavior identical for ordinary execution.
- Add `tests/test_statisticsprobe.py` which checks that `valid(weighted_features) == valid(output) == valid(feature_shallow) ∩ valid(weights)` for both `*` and `+` and for both operand orders, and also verifies upstream gradient patterns so missing branch contributions cannot be hidden by cancellation or uniform reductions.

### Testing

- Ran `pytest -q tests/test_statisticsprobe.py`; all tests passed (5 passed) with one unrelated NumPy-related warning from the environment.
- Ran `python -m compileall` on the modified files; compilation succeeded for the new/changed modules.
- Attempted to run the broader `tests/test_scnn.py` suite but collection failed in this environment due to a missing external dependency (`numpy`) unrelated to the changes, preventing full-suite execution here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7c69c06cf083308e82d6c5040b8502)