### PR TITLE
Collect nearest spatial predecessors and validate effective stride/phase

### DIFF
--- a/lightstream/core/scnn/scnn.py
+++ b/lightstream/core/scnn/scnn.py
@@ -431,10 +431,9 @@ class StreamingCNN(torch.nn.Module):
             gradients.append(gradient)
 
             p_stats = self._prev_stats(out)
-            if p_stats:
-                output_stride = p_stats["output_stride"] * torch.tensor(p_stats["stride"])
-            else:
-                output_stride = torch.tensor([1, 1, 1])
+            output_stride, _ = self._compatible_predecessor_coordinates(
+                p_stats, context=f"output {idx}"
+            )
 
             self._output_stride_per_output.append(output_stride)
 
@@ -2202,14 +2201,9 @@ class StreamingCNN(torch.nn.Module):
             module_stats = self._module_stats[module]
 
             p_stats = self._prev_stats(output)
-            if p_stats:
-                prev_output_stride = (
-                    p_stats["output_stride"] * p_stats["stride"].clone().detach()
-                    if isinstance(p_stats["stride"], torch.Tensor)
-                    else p_stats["output_stride"] * torch.tensor(p_stats["stride"])
-                )
-            else:
-                prev_output_stride = torch.tensor([1, 1, 1])
+            prev_output_stride, prev_output_phase = self._compatible_predecessor_coordinates(
+                p_stats, context=f"input to {module!r}"
+            )
 
             if is_upsample:
                 pre_upsample_output_stride = prev_output_stride.clone().detach()
@@ -2228,6 +2222,15 @@ class StreamingCNN(torch.nn.Module):
             output_stride = output_stride.clone().detach()
             output_stride[0] = 1
             module_stats["output_stride"] = output_stride
+            # The phase identifies the spatial lattice independently of the
+            # autograd operation used to join branches. Pointwise operations
+            # and upsampling preserve its origin; convolution/pooling shift it
+            # by their left/top padding in predecessor coordinates.
+            output_phase = prev_output_phase.clone()
+            if not is_upsample and not is_pointwise_module:
+                output_phase[1] -= int(padding[1]) * int(prev_output_stride[1])
+                output_phase[2] -= int(padding[2]) * int(prev_output_stride[2])
+            module_stats["output_phase"] = output_phase
             if is_upsample:
                 module_stats["post_upsample_output_stride"] = output_stride
             self._stats_per_grad_fn[output.grad_fn] = module_stats
@@ -2472,9 +2475,12 @@ class StreamingCNN(torch.nn.Module):
         return grad_in
 
     def _prev_stats(self, grad_fn):
-        """DAG traversal, finds the first grad_fn that is in self._stats_per_grad_fn
+        """Collect every nearest statistics-bearing spatial predecessor.
 
-        Finds the first grad_fn that is in self._stats_per_grad_fn, which is needed for output stride calculations
+        Traversal stops independently on each path when it reaches recorded
+        module statistics. Autograd graphs are DAGs, so both visited-node and
+        result deduplication are necessary. Parameter/scalar paths naturally
+        terminate without contributing spatial coordinates.
 
         Parameters
         ----------
@@ -2484,20 +2490,62 @@ class StreamingCNN(torch.nn.Module):
         if hasattr(grad_fn, "grad_fn"):
             grad_fn = grad_fn.grad_fn
 
-        prev_stats = None
+        pending = [grad_fn]
+        visited = set()
+        found = []
+        found_ids = set()
+        while pending:
+            node = pending.pop()
+            if node is None or id(node) in visited:
+                continue
+            visited.add(id(node))
+            stats = self._stats_per_grad_fn.get(node)
+            if stats is not None:
+                if id(stats) not in found_ids:
+                    found.append(stats)
+                    found_ids.add(id(stats))
+                continue
+            pending.extend(
+                child for child, _ in getattr(node, "next_functions", ()) if child is not None
+            )
+        return found
 
-        if grad_fn in self._stats_per_grad_fn:
-            prev_stats = self._stats_per_grad_fn[grad_fn]
-            return prev_stats
-        elif hasattr(grad_fn, "next_functions") and len(grad_fn.next_functions) > 0:
-            children = [x[0] for x in grad_fn.next_functions]
+    @staticmethod
+    def _compatible_predecessor_coordinates(predecessors, context):
+        """Return the common effective stride and phase for spatial branches."""
+        if not predecessors:
+            origin = torch.tensor([0, 0, 0], dtype=torch.long)
+            return torch.tensor([1, 1, 1], dtype=torch.long), origin
 
-            for x in children:
-                prev_stats = self._prev_stats(x)
-                if prev_stats is not None:
-                    break
-            return prev_stats
-        return prev_stats
+        coordinates = []
+        for stats in predecessors:
+            output_stride = torch.as_tensor(stats["output_stride"], dtype=torch.long)
+            stride = torch.as_tensor(stats.get("stride", (1, 1, 1)), dtype=torch.long)
+            effective_stride = output_stride * stride
+            phase = torch.as_tensor(
+                stats.get("output_phase", (0, 0, 0)), dtype=torch.long
+            )
+            # Phases differing by a whole stride describe the same lattice.
+            phase = torch.remainder(phase, effective_stride)
+            coordinates.append((effective_stride, phase))
+
+        expected_stride, expected_phase = coordinates[0]
+        incompatible = [
+            (stride.tolist(), phase.tolist())
+            for stride, phase in coordinates[1:]
+            if not torch.equal(stride[1:], expected_stride[1:])
+            or not torch.equal(phase[1:], expected_phase[1:])
+        ]
+        if incompatible:
+            all_coordinates = [
+                (stride.tolist(), phase.tolist()) for stride, phase in coordinates
+            ]
+            raise ValueError(
+                f"Incompatible spatial predecessor coordinates for {context}: "
+                f"effective stride and phase values are {all_coordinates}. "
+                "All spatial branches must use the same sampling lattice."
+            )
+        return expected_stride, expected_phase
 
     def get_tile_cache(self):
         named_stats = {"net_stats": {}}

--- a/tests/test_scnn.py
+++ b/tests/test_scnn.py
@@ -27,6 +27,57 @@ from lightstream.core.reducer import (
 )
 
 
+def _predecessor_stats(stride, phase=(0, 0, 0)):
+    return {
+        "output_stride": torch.tensor(stride),
+        "stride": torch.tensor([1, 1, 1]),
+        "output_phase": torch.tensor(phase),
+    }
+
+
+def test_prev_stats_collects_all_nearest_spatial_predecessors_once():
+    scnn = StreamingCNN.__new__(StreamingCNN)
+    source = torch.ones(1, requires_grad=True)
+    left = source * 2
+    right = source * 3
+    left_stats = _predecessor_stats([1, 2, 2])
+    right_stats = _predecessor_stats([1, 2, 2])
+    scnn._stats_per_grad_fn = {
+        left.grad_fn: left_stats,
+        right.grad_fn: right_stats,
+    }
+
+    # Reusing left exercises result deduplication, while the trainable scalar
+    # exercises a non-spatial parameter branch.
+    scalar = torch.nn.Parameter(torch.tensor(2.0))
+    output = (left + right + left) * scalar
+    predecessors = scnn._prev_stats(output)
+
+    assert {id(stats) for stats in predecessors} == {id(left_stats), id(right_stats)}
+    stride, phase = scnn._compatible_predecessor_coordinates(predecessors, "test output")
+    assert stride.tolist() == [1, 2, 2]
+    assert phase.tolist() == [0, 0, 0]
+
+
+@pytest.mark.parametrize(
+    ("right_stride", "right_phase"),
+    [([1, 4, 2], [0, 0, 0]), ([1, 2, 2], [0, 1, 0])],
+)
+def test_predecessor_coordinates_reject_incompatible_spatial_branches(
+    right_stride, right_phase
+):
+    predecessors = [
+        _predecessor_stats([1, 2, 2]),
+        _predecessor_stats(right_stride, right_phase),
+    ]
+
+    with pytest.raises(
+        ValueError,
+        match="Incompatible spatial predecessor coordinates.*effective stride and phase",
+    ):
+        StreamingCNN._compatible_predecessor_coordinates(predecessors, "test merge")
+
+
 def test_forward_statistics_store_and_preserve_dilated_conv2d_dilation():
     scnn = StreamingCNN.__new__(StreamingCNN)
     scnn.eps = 1e-5


### PR DESCRIPTION
### Motivation

- Replace a fragile first-match autograd traversal that missed merged spatial branches with a robust collector that discovers every nearest statistics-bearing predecessor.  
- Ensure spatially-merged branches are compatible before using their coordinates for output/gradient tiling decisions.  

### Description

- Replace `StreamingCNN._prev_stats` to perform an iterative DAG traversal that tracks visited autograd nodes, collects every nearest predecessor, and deduplicates shared results so parameter/scalar-only branches do not contribute spatial coordinates.  
- Add `StreamingCNN._compatible_predecessor_coordinates` to compute each predecessor's effective stride and normalized phase, require spatial predecessors to share the same sampling lattice, and raise a descriptive `ValueError` on incompatibility.  
- Use the new collector/validator at output-stride sites so `output_stride` and predecessor `phase` are derived from all nearest predecessors and propagate an `output_phase` through `module_stats` instead of relying on private autograd class names.  
- Ignore scalar/non-spatial parameter branches by design; do not reference private PyTorch backward node class names (e.g. `AddBackward0`/`MulBackward0`).  
- Add unit tests exercising multi-branch collection, deduplication, scalar-parameter branches, compatible coordinate resolution, and rejection of incompatible stride/phase merges in `tests/test_scnn.py`.

### Testing

- Ran `python -m py_compile` on `lightstream/core/scnn/scnn.py` and `tests/test_scnn.py`, which succeeded.  
- Ran repository checks (`git diff --check`) and basic static checks which reported no issues.  
- Added unit tests in `tests/test_scnn.py` covering the collector and coordinate validation, but invoking `pytest` in this environment failed during collection because `numpy` is not installed.  
- Attempted to install `numpy` and re-run `pytest`, but the environment could not reach the package index, so full test execution could not be completed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7c7582df1c8330b9c0ed2e1d22a934)