### PR TITLE
Normalize predecessor phases using spatial strides only

### DIFF
--- a/lightstream/core/scnn/scnn.py
+++ b/lightstream/core/scnn/scnn.py
@@ -2518,23 +2518,39 @@ class StreamingCNN(torch.nn.Module):
             return torch.tensor([1, 1, 1], dtype=torch.long), origin
 
         coordinates = []
+        spatial_indices = (H_DIM - 1, W_DIM - 1)
         for stats in predecessors:
             output_stride = torch.as_tensor(stats["output_stride"], dtype=torch.long)
             stride = torch.as_tensor(stats.get("stride", (1, 1, 1)), dtype=torch.long)
             effective_stride = output_stride * stride
             phase = torch.as_tensor(
                 stats.get("output_phase", (0, 0, 0)), dtype=torch.long
-            )
+            ).clone()
+            spatial_stride = effective_stride[list(spatial_indices)]
+            if torch.any(spatial_stride <= 0):
+                raise ValueError(
+                    f"Invalid spatial predecessor coordinates for {context}: "
+                    f"effective height/width stride must be strictly positive, got "
+                    f"{effective_stride.tolist()}."
+                )
             # Phases differing by a whole stride describe the same lattice.
-            phase = torch.remainder(phase, effective_stride)
+            # The leading entry is a legacy, non-spatial coordinate and may be
+            # zero (for example, strides expanded from a Conv2d tuple).
+            phase[list(spatial_indices)] = torch.remainder(
+                phase[list(spatial_indices)], spatial_stride
+            )
             coordinates.append((effective_stride, phase))
 
         expected_stride, expected_phase = coordinates[0]
         incompatible = [
             (stride.tolist(), phase.tolist())
             for stride, phase in coordinates[1:]
-            if not torch.equal(stride[1:], expected_stride[1:])
-            or not torch.equal(phase[1:], expected_phase[1:])
+            if not torch.equal(
+                stride[list(spatial_indices)], expected_stride[list(spatial_indices)]
+            )
+            or not torch.equal(
+                phase[list(spatial_indices)], expected_phase[list(spatial_indices)]
+            )
         ]
         if incompatible:
             all_coordinates = [

--- a/tests/test_scnn.py
+++ b/tests/test_scnn.py
@@ -78,6 +78,44 @@ def test_predecessor_coordinates_reject_incompatible_spatial_branches(
         StreamingCNN._compatible_predecessor_coordinates(predecessors, "test merge")
 
 
+def test_predecessor_coordinates_ignore_legacy_non_spatial_stride():
+    predecessors = [
+        _predecessor_stats([0, 4, 4], phase=(7, -4, 12)),
+        _predecessor_stats([1, 4, 4], phase=(9, 0, 0)),
+    ]
+
+    stride, phase = StreamingCNN._compatible_predecessor_coordinates(
+        predecessors, "legacy coordinate records"
+    )
+
+    assert stride.tolist() == [0, 4, 4]
+    assert phase.tolist() == [7, 0, 0]
+
+
+def test_resnet_initial_conv_to_max_pool_coordinates_allow_zero_legacy_stride():
+    # Conv2d/MaxPool2d strides are expanded from (H, W) to (0, H, W).
+    # The initial ResNet convolution produces spatial stride two, and its
+    # max-pool predecessor record therefore has effective stride (0, 4, 4).
+    conv_stats = _predecessor_stats([1, 2, 2], phase=(0, -3, -3))
+    conv_stats["stride"] = torch.tensor([0, 2, 2])
+    pool_equivalent = _predecessor_stats([1, 4, 4], phase=(1, 1, 1))
+
+    stride, phase = StreamingCNN._compatible_predecessor_coordinates(
+        [conv_stats, pool_equivalent], "ResNet conv1 to maxpool"
+    )
+
+    assert stride.tolist() == [0, 4, 4]
+    assert phase.tolist() == [0, 1, 1]
+
+
+@pytest.mark.parametrize("stride", ([1, 0, 4], [1, 4, 0], [1, -1, 4]))
+def test_predecessor_coordinates_require_positive_spatial_stride(stride):
+    with pytest.raises(ValueError, match="height/width stride must be strictly positive"):
+        StreamingCNN._compatible_predecessor_coordinates(
+            [_predecessor_stats(stride)], "invalid spatial stride"
+        )
+
+
 def test_forward_statistics_store_and_preserve_dilated_conv2d_dilation():
     scnn = StreamingCNN.__new__(StreamingCNN)
     scnn.eps = 1e-5


### PR DESCRIPTION
### Motivation
- Prevent division-by-zero and incorrect normalization by ensuring only the spatial height/width components are used when reducing predecessor `output_phase` via `torch.remainder`.
- Preserve the legacy leading (non-spatial) component in the stride/phase representation so older records (e.g. Conv2d-expanded tuples) remain supported.

### Description
- Updated `StreamingCNN._compatible_predecessor_coordinates` to compute `spatial_indices = (H_DIM - 1, W_DIM - 1)` and to apply `torch.remainder` only to the H/W components of `output_phase` while preserving the leading legacy coordinate. 
- Added a strict check that both effective spatial strides (`effective_stride[H,W]`) are strictly positive and raise a `ValueError` with a descriptive message if not.
- Restricted compatibility comparisons to only spatial stride and phase components (height/width) when deciding if predecessor coordinates are compatible.
- Added regression tests in `tests/test_scnn.py` that exercise mixed `(0,4,4)`/`(1,4,4)` records, the ResNet initial conv->maxpool chain, and invalid/zero/negative spatial stride cases.

### Testing
- Ran `python -m py_compile lightstream/core/scnn/scnn.py tests/test_scnn.py` which succeeded.
- Ran `git diff --check` which reported no issues for the diff and changes were committed.
- Attempted `pytest -q tests/test_scnn.py -k 'predecessor_coordinates or prev_stats'` but test collection failed due to a missing `numpy` dependency and installing `numpy` via `python -m pip install numpy` was blocked in the environment (network/proxy), so the new tests were not executed under `pytest` here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7c78b780c48330a3c4466a09071b9f)