### PR TITLE
Fix spatial predecessor traversal and coordinate validation in StreamingCNN

### DIFF
--- a/lightstream/core/scnn/scnn.py
+++ b/lightstream/core/scnn/scnn.py
@@ -2477,10 +2477,12 @@ class StreamingCNN(torch.nn.Module):
     def _prev_stats(self, grad_fn):
         """Collect every nearest statistics-bearing spatial predecessor.
 
-        Traversal stops independently on each path when it reaches recorded
-        module statistics. Autograd graphs are DAGs, so both visited-node and
-        result deduplication are necessary. Parameter/scalar paths naturally
-        terminate without contributing spatial coordinates.
+        Traversal is breadth-first and stops after the first graph depth that
+        contains recorded module statistics. This prevents an uninstrumented
+        skip/parameter path from contributing stale coordinates from much
+        earlier in the graph after a nearer spatial producer has been found.
+        All records at that nearest depth are retained so merges between
+        equally near spatial branches can still be validated.
 
         Parameters
         ----------
@@ -2492,23 +2494,29 @@ class StreamingCNN(torch.nn.Module):
 
         pending = [grad_fn]
         visited = set()
-        found = []
-        found_ids = set()
         while pending:
-            node = pending.pop()
-            if node is None or id(node) in visited:
-                continue
-            visited.add(id(node))
-            stats = self._stats_per_grad_fn.get(node)
-            if stats is not None:
-                if id(stats) not in found_ids:
-                    found.append(stats)
-                    found_ids.add(id(stats))
-                continue
-            pending.extend(
-                child for child, _ in getattr(node, "next_functions", ()) if child is not None
-            )
-        return found
+            next_pending = []
+            found = []
+            found_ids = set()
+            for node in pending:
+                if node is None or id(node) in visited:
+                    continue
+                visited.add(id(node))
+                stats = self._stats_per_grad_fn.get(node)
+                if stats is not None:
+                    if id(stats) not in found_ids:
+                        found.append(stats)
+                        found_ids.add(id(stats))
+                    continue
+                next_pending.extend(
+                    child
+                    for child, _ in getattr(node, "next_functions", ())
+                    if child is not None
+                )
+            if found:
+                return found
+            pending = next_pending
+        return []
 
     @staticmethod
     def _compatible_predecessor_coordinates(predecessors, context):
@@ -2518,23 +2526,39 @@ class StreamingCNN(torch.nn.Module):
             return torch.tensor([1, 1, 1], dtype=torch.long), origin
 
         coordinates = []
+        spatial_indices = (H_DIM - 1, W_DIM - 1)
         for stats in predecessors:
             output_stride = torch.as_tensor(stats["output_stride"], dtype=torch.long)
             stride = torch.as_tensor(stats.get("stride", (1, 1, 1)), dtype=torch.long)
             effective_stride = output_stride * stride
             phase = torch.as_tensor(
                 stats.get("output_phase", (0, 0, 0)), dtype=torch.long
-            )
+            ).clone()
+            spatial_stride = effective_stride[list(spatial_indices)]
+            if torch.any(spatial_stride <= 0):
+                raise ValueError(
+                    f"Invalid spatial predecessor coordinates for {context}: "
+                    f"effective height/width stride must be strictly positive, got "
+                    f"{effective_stride.tolist()}."
+                )
             # Phases differing by a whole stride describe the same lattice.
-            phase = torch.remainder(phase, effective_stride)
+            # The leading entry is a legacy, non-spatial coordinate and may be
+            # zero (for example, strides expanded from a Conv2d tuple).
+            phase[list(spatial_indices)] = torch.remainder(
+                phase[list(spatial_indices)], spatial_stride
+            )
             coordinates.append((effective_stride, phase))
 
         expected_stride, expected_phase = coordinates[0]
         incompatible = [
             (stride.tolist(), phase.tolist())
             for stride, phase in coordinates[1:]
-            if not torch.equal(stride[1:], expected_stride[1:])
-            or not torch.equal(phase[1:], expected_phase[1:])
+            if not torch.equal(
+                stride[list(spatial_indices)], expected_stride[list(spatial_indices)]
+            )
+            or not torch.equal(
+                phase[list(spatial_indices)], expected_phase[list(spatial_indices)]
+            )
         ]
         if incompatible:
             all_coordinates = [

--- a/tests/test_scnn.py
+++ b/tests/test_scnn.py
@@ -59,6 +59,25 @@ def test_prev_stats_collects_all_nearest_spatial_predecessors_once():
     assert phase.tolist() == [0, 0, 0]
 
 
+def test_prev_stats_does_not_mix_near_coordinates_with_deeper_skip_path():
+    scnn = StreamingCNN.__new__(StreamingCNN)
+    source = torch.ones(1, requires_grad=True)
+    deep = source * 2
+    near = deep * 3
+    near_stats = _predecessor_stats([1, 4, 4], phase=(0, 3, 3))
+    stale_stats = _predecessor_stats([0, 1, 1])
+    scnn._stats_per_grad_fn = {
+        near.grad_fn: near_stats,
+        deep.grad_fn: stale_stats,
+    }
+
+    # The direct branch reaches `near` one level before the skip branch can
+    # walk back to `deep`; only the globally nearest statistics are relevant.
+    output = near + deep.square()
+
+    assert scnn._prev_stats(output) == [near_stats]
+
+
 @pytest.mark.parametrize(
     ("right_stride", "right_phase"),
     [([1, 4, 2], [0, 0, 0]), ([1, 2, 2], [0, 1, 0])],
@@ -76,6 +95,44 @@ def test_predecessor_coordinates_reject_incompatible_spatial_branches(
         match="Incompatible spatial predecessor coordinates.*effective stride and phase",
     ):
         StreamingCNN._compatible_predecessor_coordinates(predecessors, "test merge")
+
+
+def test_predecessor_coordinates_ignore_legacy_non_spatial_stride():
+    predecessors = [
+        _predecessor_stats([0, 4, 4], phase=(7, -4, 12)),
+        _predecessor_stats([1, 4, 4], phase=(9, 0, 0)),
+    ]
+
+    stride, phase = StreamingCNN._compatible_predecessor_coordinates(
+        predecessors, "legacy coordinate records"
+    )
+
+    assert stride.tolist() == [0, 4, 4]
+    assert phase.tolist() == [7, 0, 0]
+
+
+def test_resnet_initial_conv_to_max_pool_coordinates_allow_zero_legacy_stride():
+    # Conv2d/MaxPool2d strides are expanded from (H, W) to (0, H, W).
+    # The initial ResNet convolution produces spatial stride two, and its
+    # max-pool predecessor record therefore has effective stride (0, 4, 4).
+    conv_stats = _predecessor_stats([1, 2, 2], phase=(0, -3, -3))
+    conv_stats["stride"] = torch.tensor([0, 2, 2])
+    pool_equivalent = _predecessor_stats([1, 4, 4], phase=(1, 1, 1))
+
+    stride, phase = StreamingCNN._compatible_predecessor_coordinates(
+        [conv_stats, pool_equivalent], "ResNet conv1 to maxpool"
+    )
+
+    assert stride.tolist() == [0, 4, 4]
+    assert phase.tolist() == [0, 1, 1]
+
+
+@pytest.mark.parametrize("stride", ([1, 0, 4], [1, 4, 0], [1, -1, 4]))
+def test_predecessor_coordinates_require_positive_spatial_stride(stride):
+    with pytest.raises(ValueError, match="height/width stride must be strictly positive"):
+        StreamingCNN._compatible_predecessor_coordinates(
+            [_predecessor_stats(stride)], "invalid spatial stride"
+        )
 
 
 def test_forward_statistics_store_and_preserve_dilated_conv2d_dilation():


### PR DESCRIPTION
### Motivation

- Prevent mixing stale spatial coordinates from deeper skip/parameter paths with nearer spatial producers when discovering predecessor statistics. 
- Correct handling of legacy non-spatial stride entries and ensure spatial stride/phase validation is robust for 2D branches. 

### Description

- Change `_prev_stats` to perform a breadth-first traversal that collects statistics only from the nearest graph depth containing recorded module stats and return those records once found. 
- Keep result deduplication while preventing deeper skip/parameter paths from contributing stale coordinates. 
- Update `_compatible_predecessor_coordinates` to perform phase modulo only on spatial dimensions (preserving the legacy leading non-spatial entry), to compare compatibility only on spatial dims, and to raise a `ValueError` when any spatial stride component is non-positive. 
- Add unit tests to cover the new traversal semantics, legacy non-spatial stride handling, ResNet conv->maxpool scenario, and rejection of non-positive spatial stride values. 

### Testing

- Ran the updated test file with `pytest -q tests/test_scnn.py`. 
- All tests in `tests/test_scnn.py` passed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7c78b780c48330a3c4466a09071b9f)