### PR TITLE
Add StreamingMerge boundary and integrate into streaming statistics

### DIFF
--- a/lightstream/core/constructor.py
+++ b/lightstream/core/constructor.py
@@ -21,6 +21,7 @@ from lightstream.core.reducer import BaseReducer
 from lightstream.core.scnn.streaminglayernorm import ChannelLayerNorm
 from lightstream.core.scnn.streaminglayerscale import LayerScale
 from lightstream.core.scnn.statisticsprobe import StatisticsProbe
+from lightstream.core.scnn.streamingmerge import StreamingMerge
 from typing import Any, Callable, Optional
 
 
@@ -91,6 +92,7 @@ class StreamingConstructor:
             ChannelLayerNorm,
             LayerScale,
             StatisticsProbe,
+            StreamingMerge,
             BaseReducer,
         ]
 

--- a/lightstream/core/scnn/__init__.py
+++ b/lightstream/core/scnn/__init__.py
@@ -9,5 +9,6 @@ as ``lightstream.core.scnn.streaminglayernorm`` or
 
 from lightstream.core.scnn.streaminglayernorm import ChannelLayerNorm, StreamingChannelLayerNorm
 from lightstream.core.scnn.streaminglayerscale import LayerScale, StreamingLayerScale
+from lightstream.core.scnn.streamingmerge import StreamingMerge
 
-__all__ = ["ChannelLayerNorm", "StreamingChannelLayerNorm", "LayerScale", "StreamingLayerScale"]
+__all__ = ["ChannelLayerNorm", "StreamingChannelLayerNorm", "LayerScale", "StreamingLayerScale", "StreamingMerge"]

--- a/lightstream/core/scnn/scnn.py
+++ b/lightstream/core/scnn/scnn.py
@@ -33,6 +33,7 @@ from lightstream.core.scnn.streaminglayernorm import (
 )
 from lightstream.core.scnn.streaminglayerscale import LayerScale, StreamingLayerScale
 from lightstream.core.scnn.statisticsprobe import StatisticsProbe
+from lightstream.core.scnn.streamingmerge import StreamingMerge
 from lightstream.core.reducer import BaseReducer, BaseStreamingGlobalReducer
 
 
@@ -59,6 +60,7 @@ def _is_spatial_preserving_pointwise_module(module):
             LayerScale,
             StreamingLayerScale,
             StatisticsProbe,
+            StreamingMerge,
         ),
     )
 
@@ -2083,6 +2085,7 @@ class StreamingCNN(torch.nn.Module):
     def _forward_gather_statistics_hook(self, module, inpt, output):
         is_upsample = isinstance(module, torch.nn.Upsample)
         is_pointwise_module = _is_spatial_preserving_pointwise_module(module)
+        is_merge = isinstance(module, StreamingMerge)
         if is_pointwise_module:
             stride = torch.tensor([1, 1, 1])
             kernel_size = torch.tensor([1, 1, 1])
@@ -2132,7 +2135,11 @@ class StreamingCNN(torch.nn.Module):
             # constant setup tensors can make the actual output all zeros, so
             # derive validity from the input.
 
-            lost = self._non_max_border_amount(inpt[0] if is_pointwise_module else output)
+            # A merge's valid support is the intersection encoded by its actual
+            # numerical result.  Other pointwise boundaries remain value
+            # independent and inherit support from their sole input.
+            validity_source = output if is_merge or not is_pointwise_module else inpt[0]
+            lost = self._non_max_border_amount(validity_source)
 
             # Make output between 0-1 again, so the values do not explode
             output.fill_(0)
@@ -2161,6 +2168,31 @@ class StreamingCNN(torch.nn.Module):
             self._module_stats[module] = module_stats
         else:
             module_stats = self._module_stats[module]
+
+            if is_merge:
+                if inpt[0].shape[-2:] != inpt[1].shape[-2:]:
+                    raise ValueError(
+                        "StreamingMerge inputs must have compatible spatial shapes; "
+                        f"got {tuple(inpt[0].shape[-2:])} and {tuple(inpt[1].shape[-2:])}"
+                    )
+                input_stats = [self._prev_stats(value) for value in inpt]
+                coordinates = []
+                for stats in input_stats:
+                    if stats is None:
+                        coordinates.append(((1, 1, 1), Lost(0, 0, 0, 0)))
+                    else:
+                        effective_stride = stats["output_stride"] * torch.as_tensor(stats["stride"])
+                        coordinates.append(
+                            (
+                                tuple(int(value) for value in effective_stride),
+                                stats["lost"],
+                            )
+                        )
+                if coordinates[0] != coordinates[1]:
+                    raise ValueError(
+                        "StreamingMerge inputs must have compatible spatial coordinates; "
+                        f"got {coordinates[0]} and {coordinates[1]}"
+                    )
 
             p_stats = self._prev_stats(output)
             if p_stats:

--- a/lightstream/core/scnn/streamingmerge.py
+++ b/lightstream/core/scnn/streamingmerge.py
@@ -1,0 +1,28 @@
+import torch
+
+
+class StreamingMerge(torch.nn.Module):
+    """A module boundary for spatially aligned elementwise merges.
+
+    Only the two operations used by streaming statistics are supported.  The
+    forward expressions are deliberately kept literal so ordinary eager
+    execution has precisely PyTorch's add/multiply semantics.
+    """
+
+    MODES = ("add", "multiply")
+
+    def __init__(self, mode: str) -> None:
+        super().__init__()
+        if mode not in self.MODES:
+            raise ValueError(f"mode must be one of {self.MODES}, got {mode!r}")
+        self.mode = mode
+
+    def forward(self, a: torch.Tensor, b: torch.Tensor) -> torch.Tensor:
+        if a.shape[-2:] != b.shape[-2:]:
+            raise ValueError(
+                "StreamingMerge inputs must have compatible spatial shapes; "
+                f"got {tuple(a.shape[-2:])} and {tuple(b.shape[-2:])}"
+            )
+        if self.mode == "add":
+            return a + b
+        return a * b

--- a/lightstream/models/sshr/model.py
+++ b/lightstream/models/sshr/model.py
@@ -12,7 +12,7 @@ from lightstream.models.segment.resnet import make_resnet_backbone
 from lightstream.core.reducer import NGWPReducer
 from torchinfo import summary
 
-from lightstream.core.scnn.statisticsprobe import StatisticsProbe
+from lightstream.core.scnn.streamingmerge import StreamingMerge
 
 
 class LocalRectification(nn.Module):
@@ -46,13 +46,8 @@ class LocalRectification(nn.Module):
 
         self.gamma = 0.0 # LayerScale(shape=1, init_value=0.0)
 
-        # Local arithmetic has no module boundary of its own.  These identities
-        # make every operand and result visible while streaming tile statistics
-        # are gathered, without changing ordinary model execution.
-        self.feature_shallow_probe = StatisticsProbe()
-        self.weights_probe = StatisticsProbe()
-        self.weighted_features_probe = StatisticsProbe()
-        self.output_probe = StatisticsProbe()
+        self.multiply_merge = StreamingMerge("multiply")
+        self.add_merge = StreamingMerge("add")
 
     def forward(self, feature_shallow: Tensor, feature_deep: Tensor) -> Tensor:
         """
@@ -67,11 +62,9 @@ class LocalRectification(nn.Module):
 
         """
 
-        feature_shallow = self.feature_shallow_probe(feature_shallow)
-        weights = self.weights_probe(self.rec_block(feature_deep))
-        weighted_features = self.weighted_features_probe(feature_shallow * weights)
-        output = feature_shallow + weighted_features
-        return self.output_probe(output)
+        weights = self.rec_block(feature_deep)
+        weighted_features = self.multiply_merge(feature_shallow, weights)
+        return self.add_merge(feature_shallow, weighted_features)
 
 
 class SSHRDecoder(nn.Module):

--- a/tests/test_streamingmerge.py
+++ b/tests/test_streamingmerge.py
@@ -1,0 +1,32 @@
+import pytest
+import torch
+
+from lightstream.core.constructor import StreamingConstructor
+from lightstream.core.scnn.streamingmerge import StreamingMerge
+
+
+@pytest.mark.parametrize(
+    ("mode", "expected"),
+    [("add", torch.add), ("multiply", torch.mul)],
+)
+def test_streaming_merge_has_exact_eager_semantics(mode, expected):
+    a = torch.randn(2, 3, 4, 5, requires_grad=True)
+    b = torch.randn(2, 3, 4, 5, requires_grad=True)
+
+    assert torch.equal(StreamingMerge(mode)(a, b), expected(a, b))
+
+
+def test_streaming_merge_rejects_unknown_mode():
+    with pytest.raises(ValueError, match="mode must be one of"):
+        StreamingMerge("subtract")
+
+
+def test_streaming_merge_requires_matching_spatial_shapes():
+    with pytest.raises(ValueError, match="compatible spatial shapes"):
+        StreamingMerge("add")(torch.ones(1, 2, 3, 4), torch.ones(1, 2, 4, 4))
+
+
+def test_streaming_constructor_preserves_merge_boundaries():
+    constructor = StreamingConstructor(torch.nn.Linear(2, 2), tile_size=4)
+
+    assert StreamingMerge in constructor.keep_modules


### PR DESCRIPTION
### Motivation
- Make local arithmetic operations explicit module boundaries so streaming statistics can reason about multi-input merges rather than treating them as invisible Python ops.
- Ensure merge validity is derived from the actual numeric result (intersection support) and enforce spatial/coordinate compatibility between operands.
- Use explicit merge modules only around the two eager operations in `LocalRectification.forward` while keeping traversal, tile stepping, and convolution backward behaviour unchanged.

### Description
- Add `lightstream/core/scnn/streamingmerge.py` defining `StreamingMerge` with explicit `"add"` and `"multiply"` modes whose forward returns exactly `a + b` and `a * b`, and that validates matching spatial shapes.
- Register `StreamingMerge` as a spatially-preserving pointwise boundary by exporting it from `lightstream/core/scnn/__init__.py` and adding it to `StreamingConstructor.keep_modules` in `lightstream/core/constructor.py` so merge boundaries are preserved during streaming conversion.
- Update `lightstream/core/scnn/scnn.py` to treat `StreamingMerge` in `_forward_gather_statistics_hook`, derive validity from the merge's numeric `output` for statistics, and check that input operands have compatible spatial coordinates/effective strides before recording stats.
- Replace the inline multiply/add in `lightstream/models/sshr/model.py:LocalRectification.forward` with `StreamingMerge("multiply")` and `StreamingMerge("add")` instances so the two eager arithmetic ops become explicit streaming boundaries.
- Add unit tests in `tests/test_streamingmerge.py` that assert exact eager semantics, invalid-mode rejection, spatial-shape validation, and that the constructor preserves merge boundaries.

### Testing
- `python -m py_compile` on modified files succeeded without syntax errors.
- A small runtime smoke check (`python - <<'PY' ...`) verified `StreamingMerge('add')` and `StreamingMerge('multiply')` produce results identical to native PyTorch `+` and `*`.
- `pytest` was attempted for `tests/test_streamingmerge.py`, `tests/test_statisticsprobe.py`, and `tests/test_scnn.py`, but collection failed due to a missing test environment dependency (`numpy`) and dependency installation was blocked by network/PyPI access in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7c842b7e688330b714f28358e013e6)