### PR TITLE
Add opt-in SSHR gradient diagnostics

### DIFF
--- a/lightstream/core/scnn/scnn.py
+++ b/lightstream/core/scnn/scnn.py
@@ -141,6 +141,7 @@ class StreamingCNN(torch.nn.Module):
         mean=None,
         std=None,
         state_dict=None,
+        debug_gradient_statistics=False,
     ):
         """
         Parameters:
@@ -152,6 +153,8 @@ class StreamingCNN(torch.nn.Module):
             deterministic (bool): whether to use the deterministic algorithms for cudnn
             saliency (bool): will gather the gradients of the input image (saliency map)
             eps (float): epsilon error to compare floating values
+            debug_gradient_statistics (bool): temporarily log synthetic and intermediate
+                gradient statistics without changing gradients (default is False)
         """
         super().__init__()
         global H_DIM, W_DIM
@@ -167,6 +170,10 @@ class StreamingCNN(torch.nn.Module):
         self.gather_input_gradient = saliency
         self.copy_to_gpu = copy_to_gpu
         self.statistics_on_cpu = statistics_on_cpu
+        self.debug_gradient_statistics = debug_gradient_statistics
+        # Models with targeted diagnostic hooks (for example SSHR) opt in by
+        # inspecting this attribute during their forward pass.
+        setattr(self.stream_module, "debug_gradient_statistics", debug_gradient_statistics)
 
         if mean is not None and not isinstance(mean, torch.Tensor):
             mean = torch.Tensor(mean)[:, None, None]
@@ -427,6 +434,27 @@ class StreamingCNN(torch.nn.Module):
                 lost.left : out.shape[W_DIM] - lost.right,
             ] = 1
             gradients.append(gradient)
+
+            if self.debug_gradient_statistics:
+                finite = torch.isfinite(gradient)
+                finite_values = gradient[finite]
+                finite_min = finite_values.min().item() if finite_values.numel() else None
+                finite_max = finite_values.max().item() if finite_values.numel() else None
+                logger.warning(
+                    "synthetic upstream gradient[%d]: shape=%s nan=%d inf=%d "
+                    "finite_min=%s finite_max=%s",
+                    idx,
+                    tuple(gradient.shape),
+                    torch.isnan(gradient).sum().item(),
+                    torch.isinf(gradient).sum().item(),
+                    finite_min,
+                    finite_max,
+                )
+                debug_recorder = getattr(
+                    self.stream_module, "_record_supplied_gradient_statistics", None
+                )
+                if debug_recorder is not None:
+                    debug_recorder(idx, gradient)
 
             p_stats = self._prev_stats(out)
             if p_stats:

--- a/lightstream/models/sshr/model.py
+++ b/lightstream/models/sshr/model.py
@@ -2,16 +2,21 @@
 https://github.com/Nexuslkl/Swin_MIL/blob/main/models/swin_mil.py
 
 """
+import logging
+from typing import List
+
 import torch
 import torch.nn as nn
 from torch import Tensor
-from typing import List
 from torchinfo import summary
 
 from lightstream.core.reducer import NGWPReducer
 from lightstream.models.segment.resnet import make_resnet_backbone
 from lightstream.core.scnn.streamingmerge import StreamingMerge
 from lightstream.core.scnn.streaminglayerscale import LayerScale
+
+
+logger = logging.getLogger(__name__)
 
 
 class LocalRectification(nn.Module):
@@ -178,6 +183,59 @@ class SSHR(nn.Module):
         self.segmentation_head = FuseHead(apply_sigmoid=False)
         self.upsample_blocks = self._init_upsample_blocks(self.feature_strides)
         self._init_reducers(reducer_accumulator_dtype)
+        # Set by StreamingCNN. This diagnostic is deliberately disabled by
+        # default so ordinary training does not retain or inspect gradients.
+        self.debug_gradient_statistics = False
+        self._gradient_debug_previous_finite = True
+        self._gradient_debug_source_reported = False
+
+    def _record_supplied_gradient_statistics(self, index: int, gradient: Tensor) -> None:
+        """Seed transition tracking with the gradient supplied to backward."""
+        if not self.debug_gradient_statistics:
+            return
+        finite = bool(torch.isfinite(gradient).all().item())
+        if not finite and not self._gradient_debug_source_reported:
+            logger.warning(
+                "first finite-to-non-finite gradient transition: supplied upstream gradient[%d]",
+                index,
+            )
+            self._gradient_debug_source_reported = True
+        self._gradient_debug_previous_finite = (
+            self._gradient_debug_previous_finite and finite
+        )
+
+    def _attach_gradient_debug_hook(self, tensor: Tensor, name: str, source: str) -> None:
+        if not self.debug_gradient_statistics or not tensor.requires_grad:
+            return
+
+        def report(gradient: Tensor) -> Tensor:
+            finite = torch.isfinite(gradient)
+            finite_values = gradient[finite]
+            finite_min = finite_values.min().item() if finite_values.numel() else None
+            finite_max = finite_values.max().item() if finite_values.numel() else None
+            is_finite = bool(finite.all().item())
+            logger.warning(
+                "%s gradient: shape=%s nan=%d inf=%d finite_min=%s finite_max=%s",
+                name,
+                tuple(gradient.shape),
+                torch.isnan(gradient).sum().item(),
+                torch.isinf(gradient).sum().item(),
+                finite_min,
+                finite_max,
+            )
+            if (
+                self._gradient_debug_previous_finite
+                and not is_finite
+                and not self._gradient_debug_source_reported
+            ):
+                logger.warning(
+                    "first finite-to-non-finite gradient transition: %s", source
+                )
+                self._gradient_debug_source_reported = True
+            self._gradient_debug_previous_finite = is_finite
+            return gradient
+
+        tensor.register_hook(report)
 
     def _init_upsample_blocks(self, scale_factors: list[float]):
         blocks = nn.ModuleList()
@@ -196,6 +254,9 @@ class SSHR(nn.Module):
 
 
     def forward(self, x, mask=None):
+        if self.debug_gradient_statistics:
+            self._gradient_debug_previous_finite = True
+            self._gradient_debug_source_reported = False
         features = self.encoder(x)
         logits = self.decoder(features)
 
@@ -207,11 +268,21 @@ class SSHR(nn.Module):
 
         # Only enlarge what is needed for spatial fusion
         probs_up = [self.upsample_blocks[i](p) for i, p in enumerate(probs)]
+        for index, probability in enumerate(probs_up):
+            self._attach_gradient_debug_hook(
+                probability, f"probs_up[{index}]", "fusion"
+            )
 
         p_fused = self.segmentation_head(*probs_up, fuse_weights=self.fuse_weights)
+        self._attach_gradient_debug_hook(p_fused, "p_fused", "Tensor.logit")
         logit_fused = p_fused.logit(eps=1e-6)
+        self._attach_gradient_debug_hook(logit_fused, "logit_fused", "NGWPReducer")
 
-        reduced_outputs += (self.reducers[-1](logit_fused, p_fused, mask=mask),)
+        reduced_fused = self.reducers[-1](logit_fused, p_fused, mask=mask)
+        self._attach_gradient_debug_hook(
+            reduced_fused, "reduced_fused", "supplied upstream gradient"
+        )
+        reduced_outputs += (reduced_fused,)
 
         return reduced_outputs
 


### PR DESCRIPTION
### Motivation

- Provide a temporary diagnostic mode to help identify the origin of non-finite gradients during streaming backward passes by logging and validating synthetic and intermediate gradients.

### Description

- Add an opt-in `debug_gradient_statistics` flag to `StreamingCNN` and propagate it to the streamed model for targeted diagnostics without changing normal training behavior.  
- Validate and log each synthetic gradient built in `_gather_backward_statistics`, reporting shape, NaN count, infinity count, and finite-only min/max, and forward this data to the streamed module when present.  
- Add non-mutating gradient hooks in `SSHR` that attach to every `probs_up`, `p_fused`, `logit_fused`, and `reduced_fused` tensor and emit the same statistics when gradients flow.  
- Track the first finite-to-non-finite transition and attempt to attribute it to one of: the supplied upstream gradient, `NGWPReducer`, `Tensor.logit`, or fusion; leave the instrumentation disabled by default and only enable it when `debug_gradient_statistics` is set.

### Testing

- ✅ `git diff --check` (no whitespace or diff check errors).  
- ✅ `python -m compileall -q lightstream/core/scnn/scnn.py lightstream/models/sshr/model.py` (both files compile).  
- ⚠️ `pytest -q tests/test_scnn.py` (collection failed because the test environment is missing `numpy`, preventing test collection).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7cfb6ecfc08330a4979bbeb7828e9e)