### PR TITLE
Add optional gradient-debugging hooks to streaming pipeline (debug_gradient_statistics)

### DIFF
--- a/lightstream/core/constructor.py
+++ b/lightstream/core/constructor.py
@@ -42,6 +42,7 @@ class StreamingConstructor:
         add_keep_modules: Optional[list[nn.Module]] = None,
         before_streaming_init_callbacks: Optional[list[Callable[..., Any]]] = None,
         after_streaming_init_callbacks: Optional[list[Callable[..., Any]]] = None,
+        debug_gradient_statistics: bool = False,
     ):
         """Initialize a streaming model constructor.
 
@@ -74,6 +75,7 @@ class StreamingConstructor:
         self.mean = mean
         self.std = std
         self.tile_cache = tile_cache
+        self.debug_gradient_statistics = debug_gradient_statistics
 
         self.before_streaming_init_callbacks = before_streaming_init_callbacks or []
         self.after_streaming_init_callbacks = after_streaming_init_callbacks or []
@@ -178,6 +180,7 @@ class StreamingConstructor:
             mean=self.mean,
             std=self.std,
             state_dict=self.tile_cache,
+            debug_gradient_statistics=self.debug_gradient_statistics,
         )
 
     def save_parameters(self) -> dict:

--- a/lightstream/core/scnn/scnn.py
+++ b/lightstream/core/scnn/scnn.py
@@ -141,6 +141,7 @@ class StreamingCNN(torch.nn.Module):
         mean=None,
         std=None,
         state_dict=None,
+        debug_gradient_statistics=False,
     ):
         """
         Parameters:
@@ -152,6 +153,8 @@ class StreamingCNN(torch.nn.Module):
             deterministic (bool): whether to use the deterministic algorithms for cudnn
             saliency (bool): will gather the gradients of the input image (saliency map)
             eps (float): epsilon error to compare floating values
+            debug_gradient_statistics (bool): temporarily log synthetic and intermediate
+                gradient statistics without changing gradients (default is False)
         """
         super().__init__()
         global H_DIM, W_DIM
@@ -167,6 +170,13 @@ class StreamingCNN(torch.nn.Module):
         self.gather_input_gradient = saliency
         self.copy_to_gpu = copy_to_gpu
         self.statistics_on_cpu = statistics_on_cpu
+        self.debug_gradient_statistics = debug_gradient_statistics
+        # Models with targeted diagnostic hooks (for example SSHR) opt in by
+        # declaring this attribute. Walk descendants as the model may be
+        # wrapped in a Sequential container by StreamingSSHR.
+        for module in self.stream_module.modules():
+            if hasattr(module, "debug_gradient_statistics"):
+                module.debug_gradient_statistics = debug_gradient_statistics
 
         if mean is not None and not isinstance(mean, torch.Tensor):
             mean = torch.Tensor(mean)[:, None, None]
@@ -427,6 +437,28 @@ class StreamingCNN(torch.nn.Module):
                 lost.left : out.shape[W_DIM] - lost.right,
             ] = 1
             gradients.append(gradient)
+
+            if self.debug_gradient_statistics:
+                finite = torch.isfinite(gradient)
+                finite_values = gradient[finite]
+                finite_min = finite_values.min().item() if finite_values.numel() else None
+                finite_max = finite_values.max().item() if finite_values.numel() else None
+                logger.warning(
+                    "synthetic upstream gradient[%d]: shape=%s nan=%d inf=%d "
+                    "finite_min=%s finite_max=%s",
+                    idx,
+                    tuple(gradient.shape),
+                    torch.isnan(gradient).sum().item(),
+                    torch.isinf(gradient).sum().item(),
+                    finite_min,
+                    finite_max,
+                )
+                for module in self.stream_module.modules():
+                    debug_recorder = getattr(
+                        module, "_record_supplied_gradient_statistics", None
+                    )
+                    if debug_recorder is not None:
+                        debug_recorder(idx, gradient)
 
             p_stats = self._prev_stats(out)
             if p_stats:

--- a/lightstream/models/sshr/model.py
+++ b/lightstream/models/sshr/model.py
@@ -2,16 +2,21 @@
 https://github.com/Nexuslkl/Swin_MIL/blob/main/models/swin_mil.py
 
 """
+import logging
+from typing import List
+
 import torch
 import torch.nn as nn
 from torch import Tensor
-from typing import List
 from torchinfo import summary
 
 from lightstream.core.reducer import NGWPReducer
 from lightstream.models.segment.resnet import make_resnet_backbone
 from lightstream.core.scnn.streamingmerge import StreamingMerge
 from lightstream.core.scnn.streaminglayerscale import LayerScale
+
+
+logger = logging.getLogger(__name__)
 
 
 class LocalRectification(nn.Module):
@@ -178,6 +183,76 @@ class SSHR(nn.Module):
         self.segmentation_head = FuseHead(apply_sigmoid=False)
         self.upsample_blocks = self._init_upsample_blocks(self.feature_strides)
         self._init_reducers(reducer_accumulator_dtype)
+        # Set by StreamingCNN. This diagnostic is deliberately disabled by
+        # default so ordinary training does not retain or inspect gradients.
+        self.debug_gradient_statistics = False
+        self._gradient_debug_previous_finite = True
+        self._gradient_debug_source_reported = False
+
+    def _record_supplied_gradient_statistics(self, index: int, gradient: Tensor) -> None:
+        """Seed transition tracking with the gradient supplied to backward."""
+        if not self.debug_gradient_statistics:
+            return
+        finite = bool(torch.isfinite(gradient).all().item())
+        if not finite and not self._gradient_debug_source_reported:
+            logger.warning(
+                "first finite-to-non-finite gradient transition: supplied upstream gradient[%d]",
+                index,
+            )
+            self._gradient_debug_source_reported = True
+        self._gradient_debug_previous_finite = (
+            self._gradient_debug_previous_finite and finite
+        )
+
+    def _attach_gradient_debug_hook(
+        self, value: Tensor | tuple | list, name: str, source: str
+    ) -> None:
+        """Attach the diagnostic hook to every tensor in a reducer payload.
+
+        Reducers return tensors during normal execution, but return tuples of
+        tensors while ``StreamingCNN`` gathers tile statistics in passthrough
+        mode. Supporting both forms keeps the debug-only setup path from
+        changing the reducer contract.
+        """
+        if not self.debug_gradient_statistics:
+            return
+
+        if isinstance(value, (tuple, list)):
+            for index, item in enumerate(value):
+                self._attach_gradient_debug_hook(item, f"{name}[{index}]", source)
+            return
+
+        if not isinstance(value, Tensor) or not value.requires_grad:
+            return
+
+        def report(gradient: Tensor) -> Tensor:
+            finite = torch.isfinite(gradient)
+            finite_values = gradient[finite]
+            finite_min = finite_values.min().item() if finite_values.numel() else None
+            finite_max = finite_values.max().item() if finite_values.numel() else None
+            is_finite = bool(finite.all().item())
+            logger.warning(
+                "%s gradient: shape=%s nan=%d inf=%d finite_min=%s finite_max=%s",
+                name,
+                tuple(gradient.shape),
+                torch.isnan(gradient).sum().item(),
+                torch.isinf(gradient).sum().item(),
+                finite_min,
+                finite_max,
+            )
+            if (
+                self._gradient_debug_previous_finite
+                and not is_finite
+                and not self._gradient_debug_source_reported
+            ):
+                logger.warning(
+                    "first finite-to-non-finite gradient transition: %s", source
+                )
+                self._gradient_debug_source_reported = True
+            self._gradient_debug_previous_finite = is_finite
+            return gradient
+
+        value.register_hook(report)
 
     def _init_upsample_blocks(self, scale_factors: list[float]):
         blocks = nn.ModuleList()
@@ -196,6 +271,9 @@ class SSHR(nn.Module):
 
 
     def forward(self, x, mask=None):
+        if self.debug_gradient_statistics:
+            self._gradient_debug_previous_finite = True
+            self._gradient_debug_source_reported = False
         features = self.encoder(x)
         logits = self.decoder(features)
 
@@ -207,11 +285,21 @@ class SSHR(nn.Module):
 
         # Only enlarge what is needed for spatial fusion
         probs_up = [self.upsample_blocks[i](p) for i, p in enumerate(probs)]
+        for index, probability in enumerate(probs_up):
+            self._attach_gradient_debug_hook(
+                probability, f"probs_up[{index}]", "fusion"
+            )
 
         p_fused = self.segmentation_head(*probs_up, fuse_weights=self.fuse_weights)
+        self._attach_gradient_debug_hook(p_fused, "p_fused", "Tensor.logit")
         logit_fused = p_fused.logit(eps=1e-6)
+        self._attach_gradient_debug_hook(logit_fused, "logit_fused", "NGWPReducer")
 
-        reduced_outputs += (self.reducers[-1](logit_fused, p_fused, mask=mask),)
+        reduced_fused = self.reducers[-1](logit_fused, p_fused, mask=mask)
+        self._attach_gradient_debug_hook(
+            reduced_fused, "reduced_fused", "supplied upstream gradient"
+        )
+        reduced_outputs += (reduced_fused,)
 
         return reduced_outputs
 

--- a/lightstream/models/sshr/streamingsshr.py
+++ b/lightstream/models/sshr/streamingsshr.py
@@ -27,6 +27,7 @@ class StreamingSSHR(StreamingModule):
         std: list | None = None,
         tile_cache_path=None,
         reducer_accumulator_dtype: torch.dtype | None = None,
+        debug_gradient_statistics: bool = False,
     ):
         model_choices = self.get_model_choices()
 
@@ -70,6 +71,7 @@ class StreamingSSHR(StreamingModule):
             mean=mean,
             std=std,
             add_keep_modules=[nn.BatchNorm2d],
+            debug_gradient_statistics=debug_gradient_statistics,
         )
 
     @staticmethod


### PR DESCRIPTION
### Motivation

- Provide an opt-in diagnostic path to inspect synthetic and intermediate gradients during streaming backward passes to help track finite-to-non-finite transitions and locate gradient sources across reducers.

### Description

- Introduces an opt-in `debug_gradient_statistics` flag propagated from `StreamingSSHR` -> `StreamingConstructor` -> `StreamingCNN` and exposed on modules that opt into diagnostics by declaring `debug_gradient_statistics`.
- Logs synthetic upstream gradient statistics in `StreamingCNN._gather_backward_statistics` and calls per-module recorders when present via `module._record_supplied_gradient_statistics`.
- Adds diagnostic support in the SSHR model by importing a logger, adding `debug_gradient_statistics` state, and implementing `_record_supplied_gradient_statistics` and `_attach_gradient_debug_hook` to register hooks on tensors returned from reducers and intermediate probability/logit tensors.
- Minor formatting/newline fix in `streamingsshr.py` and ensures modules can receive the `debug_gradient_statistics` attribute during `StreamingCNN` initialization.

### Testing

- No automated tests were added or executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7cfb6ecfc08330a4979bbeb7828e9e)